### PR TITLE
ci: add llvm-cov and codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,53 @@ jobs:
       - run: cargo test --workspace
 
   # ---------------------------------------------------------------------------
+  # Coverage — line coverage report with cargo-llvm-cov
+  # ---------------------------------------------------------------------------
+  coverage:
+    name: Coverage (llvm-cov)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+      - name: Generate LCOV report
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Generate HTML report
+        run: cargo llvm-cov --workspace --html
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+          verbose: true
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            lcov.info
+            target/llvm-cov/html/
+
+  # ---------------------------------------------------------------------------
   # Integration tests — run ignored tests against real Docker Compose services
   # ---------------------------------------------------------------------------
   integration:
@@ -163,7 +210,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [clippy, test]
+    needs: [clippy, test, coverage]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- add a dedicated `coverage` CI job using cargo-llvm-cov
- generate both `lcov.info` and HTML coverage output
- upload `lcov.info` to Codecov so PRs show coverage directly
- keep coverage artifacts (`lcov.info` and HTML report) in Actions
- gate the `build` job on `coverage` completion

## Scope
This PR includes only `.github/workflows/ci.yml` coverage workflow changes.
