### PR TITLE
ci: add llvm-cov and codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,11 @@ jobs:
       - name: Generate HTML report
         run: cargo llvm-cov --workspace --html
       - name: Upload coverage to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
       - name: Upload coverage artifacts


### PR DESCRIPTION
## Summary
- add a dedicated `coverage` CI job using cargo-llvm-cov
- generate both `lcov.info` and HTML coverage output
- upload `lcov.info` to Codecov so PRs show coverage directly
- keep coverage artifacts (`lcov.info` and HTML report) in Actions
- gate the `build` job on `coverage` completion

## Scope
This PR includes only `.github/workflows/ci.yml` coverage workflow changes.
