### PR TITLE
feat(api): implement cluster-wide global stats

### DIFF
--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -2359,6 +2359,9 @@ pub trait TraceRepository: Send + Sync {
     /// Get storage statistics for a tenant.
     async fn get_stats(&self, tenant_id: TenantId) -> Result<StorageStats>;
 
+    /// Get aggregate statistics across all tenants (cluster-wide).
+    async fn get_global_stats(&self) -> Result<StorageStats>;
+
     /// Health check for the trace repository.
     async fn health_check(&self) -> Result<()>;
 }

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -635,6 +635,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/v1/stats", get(llmtrace_proxy::api::get_stats))
         .route(
+            "/api/v1/stats/global",
+            get(llmtrace_proxy::api::get_global_stats),
+        )
+        .route(
             "/api/v1/security/findings",
             get(llmtrace_proxy::api::list_security_findings),
         )

--- a/crates/llmtrace-storage/src/memory.rs
+++ b/crates/llmtrace-storage/src/memory.rs
@@ -280,6 +280,26 @@ impl TraceRepository for InMemoryTraceRepository {
         })
     }
 
+    async fn get_global_stats(&self) -> Result<StorageStats> {
+        let traces = self.traces.read().await;
+        let standalone = self.standalone_spans.read().await;
+
+        let total_traces = traces.len() as u64;
+        let trace_span_count: usize = traces.iter().map(|t| t.spans.len()).sum();
+        let total_spans = (trace_span_count + standalone.len()) as u64;
+
+        let oldest_trace = traces.iter().map(|t| t.created_at).min();
+        let newest_trace = traces.iter().map(|t| t.created_at).max();
+
+        Ok(StorageStats {
+            total_traces,
+            total_spans,
+            storage_size_bytes: 0,
+            oldest_trace,
+            newest_trace,
+        })
+    }
+
     async fn health_check(&self) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Add get_global_stats to TraceRepository and expose it via GET /api/v1/stats/global. This ensures aggregate counts include orphan spans from deleted tenants.

## Summary

Brief description of the changes in this PR.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance improvement
- [ ] Test improvement

## Testing Done

Describe how you tested these changes.

## Checklist

- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Documentation updated (if applicable)
