### PR TITLE
fix(proxy): support '1' and 'true' for boolean env vars

### DIFF
--- a/crates/llmtrace-proxy/src/config.rs
+++ b/crates/llmtrace-proxy/src/config.rs
@@ -55,6 +55,13 @@ pub fn apply_env_overrides(config: &mut ProxyConfig) {
     if let Ok(val) = std::env::var("LLMTRACE_REDIS_URL") {
         config.storage.redis_url = Some(val);
     }
+    if let Ok(val) = std::env::var("LLMTRACE_AUTH_ENABLED") {
+        let val = val.to_lowercase();
+        config.auth.enabled = val == "1" || val == "true" || val == "yes";
+    }
+    if let Ok(val) = std::env::var("LLMTRACE_AUTH_ADMIN_KEY") {
+        config.auth.admin_key = Some(val);
+    }
 }
 
 /// Validate a [`ProxyConfig`] for common configuration errors.


### PR DESCRIPTION
Update apply_env_overrides to correctly parse truthy strings from environment variables for authentication flags.

## Summary

Brief description of the changes in this PR.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Performance improvement
- [ ] Test improvement

## Testing Done

Describe how you tested these changes.

## Checklist

- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Documentation updated (if applicable)
