### PR TITLE
chore(docs-deps): pin Pygments < 2.20 until pymdown-extensions fixes filename=None

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,11 @@
 mkdocs==1.6.1
 mkdocs-material==9.6.5
 pymdown-extensions==10.16.1
-Pygments==2.19.2
+# Pygments 2.20.0 tightens HtmlFormatter.__init__ to reject filename=None,
+# which pymdown-extensions 10.16.1 still passes at
+# pymdownx/highlight.py:179. Break surfaces as
+# "AttributeError: 'NoneType' object has no attribute 'replace'"
+# during mkdocs build. Relax the upper bound when pymdown-extensions
+# ships a release that threads a non-None filename through the
+# HtmlFormatter call. See dependabot PR #112 for the full trace.
+Pygments>=2.19.2,<2.20


### PR DESCRIPTION
## Summary

- Pins \`Pygments>=2.19.2,<2.20\` in \`requirements-docs.txt\` to suppress dependabot's weekly retry on 2.20.x
- Documents the exact call-site (\`pymdownx/highlight.py:179\`) that needs to be fixed upstream before we can relax the pin
- Sets up the conditions under which #112 can be reopened/merged

## Why

Dependabot proposed Pygments 2.20.0 in #112. CI reproducibly fails the Build site check with:

\`\`\`
File "…/pymdownx/highlight.py", line 179, in __init__
    HtmlFormatter.__init__(self, **options)
File "…/pygments/formatters/html.py", line 434, in __init__
    self.filename = html.escape(self._decodeifneeded(options.get('filename', '')))
AttributeError: 'NoneType' object has no attribute 'replace'
\`\`\`

Pygments 2.20 tightened the \`HtmlFormatter.__init__\` signature to reject \`filename=None\`. pymdown-extensions 10.15 and 10.16.1 both pass that through. The bump to 10.16.1 (landed in #111) did not fix this; the upstream fix hasn't shipped yet.

Tightening the pin stops the weekly-PR noise without blocking future Pygments upgrades.

## Test plan

- [x] \`mkdocs build\` still clean with \`Pygments==2.19.2\` (unchanged from main)
- [x] Comment in \`requirements-docs.txt\` names the exact condition for relaxing the pin
- [ ] CI: Build site green