### PR TITLE
feat(e2e): pytest harness skeleton + mock upstream + first scenario test (#93)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ benchmarks/datasets/training/training_dataset.json
 .next/
 site/
 .venv-docs/
+
+# E2E adversarial test framework — per-session subprocess logs
+tests/e2e/.logs/
+
+# Local Python venv used for running the e2e harness
+.venv-e2e/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,21 @@
+# Pytest configuration for the LLMTrace e2e adversarial test framework.
+# Repo-local so CI and clean-checkout runs don't depend on a parent
+# pyproject.toml (which a developer might have for personal setup but
+# CI runners don't).
+#
+# The harness lives under tests/e2e/. Other Rust crates have their own
+# Rust tests (cargo test); they are not pytest-discoverable.
+
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Loop E2E-L4 will diff per-scenario `/metrics` deltas; that requires
+# serial execution. The conftest.py guard rejects -n / xdist at collection
+# time, but this marker also lets us self-document specific tests as
+# "must run serially" once the suite grows.
+markers =
+    serial: scenario asserts on global counter deltas; must not run in parallel.
+    pr_gate: subset that runs in the PR-gate CI workflow (Loop E2E-L9).

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -12,3 +12,17 @@
 # Scenario validation
 jsonschema==4.23.0
 PyYAML==6.0.2
+
+# Pytest harness (Loop E2E-L3) and HTTP client used to drive the proxy
+pytest==8.3.3
+requests==2.32.3
+
+# Prometheus exposition-format parser used by the metrics-delta observer
+# (Loop E2E-L4) and for fixture parsing in tests
+prometheus-client==0.21.0
+
+# In-process FastAPI mock upstream that the proxy forwards to during
+# PR-gate runs (Loop E2E-L9). Real upstream is configured at the CI
+# level for the nightly job (Loop E2E-L10).
+fastapi==0.115.6
+uvicorn==0.32.1

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,135 @@
+# LLMTrace E2E Adversarial Test Framework
+
+> **Status:** scaffold (Loop E2E-L3 of umbrella [#91](https://github.com/epappas/llmtrace/issues/91)). Asserts proxy outcome only — metrics-delta and judge-verdict observability land in Loops E2E-L4–L6.
+
+The harness boots the LLMTrace proxy as a subprocess against an in-process FastAPI mock upstream, fires every scenario YAML under `benchmarks/attacks/` at it, and asserts the per-scenario `expected.proxy_outcome.at_*` constraints.
+
+---
+
+## Prerequisites
+
+1. **Build the proxy binary** (release recommended for CI parity, debug fine for iteration):
+
+   ```bash
+   cargo build --release -p llmtrace
+   # or: cargo build -p llmtrace
+   ```
+
+   The harness auto-discovers the binary in this order: `LLMTRACE_PROXY_BIN`
+   env var → `target/release/llmtrace-proxy` → `target/debug/llmtrace-proxy`.
+
+2. **Install the e2e Python deps** (pinned in `requirements-e2e.txt`):
+
+   ```bash
+   python3 -m pip install -r requirements-e2e.txt
+   ```
+
+3. **Validate the corpus** (optional but recommended before running tests):
+
+   ```bash
+   python3 scripts/e2e/validate_scenarios.py --verbose
+   ```
+
+---
+
+## Running the harness
+
+From the repo root:
+
+```bash
+pytest tests/e2e/ -v
+```
+
+### Filtering scenarios
+
+Both flags are **repeatable** and combine as `family AND (any of tags)`:
+
+```bash
+# Only DAN-class attacks
+pytest tests/e2e/ -v --family=prompt_injection
+
+# Only the PR-gate subset (recommended for fast local feedback)
+pytest tests/e2e/ -v --tag=pr-gate
+
+# Multiple families, multiple tags
+pytest tests/e2e/ -v \
+  --family=prompt_injection --family=jailbreak \
+  --tag=pr-gate --tag=direct-override
+```
+
+### Running a single scenario
+
+Use pytest's `-k` to match by scenario id:
+
+```bash
+pytest tests/e2e/ -v -k dan-classic-001
+```
+
+---
+
+## Outcome heuristic
+
+The first-cut classifier in `test_cascade.py::classify_proxy_outcome` maps the proxy response to one of `allow | warn | block`:
+
+| Response | Outcome |
+|---|---|
+| HTTP `>= 400` with body `{"error": {"type": "proxy_*", ...}}` | `block` |
+| HTTP `200` + `x-llmtrace-flagged: true` response header | `warn` |
+| Any other HTTP `200` | `allow` |
+
+This will be replaced by the L6 expectation DSL once metrics deltas (L4) and judge verdicts (L5) are wired up.
+
+---
+
+## Inspecting logs
+
+Both subprocesses (`llmtrace-proxy` and `mock_upstream`) capture stdout and stderr to `tests/e2e/.logs/`:
+
+```
+tests/e2e/.logs/proxy.log
+tests/e2e/.logs/mock_upstream.log
+```
+
+The directory is gitignored. Each pytest session overwrites the logs.
+
+---
+
+## Serial-execution constraint
+
+The harness runs **serially** by design. Loops E2E-L4 / L5 will diff per-scenario `/metrics` snapshots; that requires no other request to be in-flight against the proxy. `pytest-xdist` (`-n auto`) is detected and rejected at collection time:
+
+```
+UsageError: tests/e2e must run serially: counter-diff observability is global.
+```
+
+If you have a real reason to parallelise, that requires per-tenant metric scoping which is out of scope until after L9.
+
+---
+
+## Layout
+
+```
+tests/e2e/
+  conftest.py              fixtures: proxy lifecycle, mock upstream, scenarios
+  test_cascade.py          first-cut parametrised test (proxy_outcome only)
+  mock_upstream.py         FastAPI canned response server
+  fixtures/
+    config-e2e.yaml        base config, judge OFF
+    config-e2e-judge.yaml  base config, cascade ON (slow tier null)
+  README.md                this file
+  .logs/                   gitignored — per-session subprocess logs
+```
+
+The scenario corpus and JSON Schema live under `benchmarks/attacks/` (see [`benchmarks/attacks/SCHEMA.md`](../../benchmarks/attacks/SCHEMA.md)).
+
+---
+
+## What this loop does NOT do (yet)
+
+- No `/metrics` deltas (Loop E2E-L4).
+- No judge verdict polling (Loop E2E-L5).
+- No `findings_include` / `findings_min_severity` checks (Loop E2E-L6).
+- No upstream-fell-for-it detector (Loop E2E-L8).
+- No CI integration (Loop E2E-L9).
+
+Each follow-up loop is a separate PR; see [`docs/TODO_E2E.md`](../../docs/TODO_E2E.md) for the full breakdown.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,355 @@
+"""Pytest fixtures for the LLMTrace e2e adversarial test framework.
+
+Owns the per-session lifecycle of two subprocesses:
+
+  1. The FastAPI mock upstream (tests/e2e/mock_upstream.py).
+  2. The LLMTrace proxy release binary, configured to forward to the
+     mock and persist traces under a temp SQLite file.
+
+Both run on free ports allocated by `socket.bind((..., 0))`. The proxy
+fixture polls `/health` until 200 or 60 s, then yields a `ProxyHandle`.
+
+Teardown is reliable: SIGTERM-then-wait for both subprocesses inside a
+`finally` block, with stdout/stderr captured to `tests/e2e/.logs/`.
+
+Loaded scenarios come from `benchmarks/attacks/**/*.yaml` and respect
+two CLI markers: `--family=` and `--tag=` (comma-separated, repeatable).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTACKS_DIR = REPO_ROOT / "benchmarks" / "attacks"
+LOGS_DIR = Path(__file__).resolve().parent / ".logs"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+MOCK_UPSTREAM_PATH = Path(__file__).resolve().parent / "mock_upstream.py"
+
+PROXY_BIN_ENV = "LLMTRACE_PROXY_BIN"
+DEFAULT_PROXY_BINARIES = (
+    REPO_ROOT / "target" / "release" / "llmtrace-proxy",
+    REPO_ROOT / "target" / "debug" / "llmtrace-proxy",
+)
+
+PROXY_HEALTH_TIMEOUT_SECS = 60
+PROXY_HEALTH_POLL_INTERVAL_SECS = 0.5
+PROXY_TEARDOWN_TIMEOUT_SECS = 10
+MOCK_HEALTH_TIMEOUT_SECS = 10
+
+
+# ---------------------------------------------------------------------------
+# CLI / collection
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--family",
+        action="append",
+        default=[],
+        help=(
+            "Restrict scenarios to one or more families (e.g. "
+            "--family=prompt_injection --family=jailbreak). Repeatable."
+        ),
+    )
+    parser.addoption(
+        "--tag",
+        action="append",
+        default=[],
+        help=(
+            "Restrict scenarios by tag (e.g. --tag=pr-gate). "
+            "Repeatable; logical OR across tags."
+        ),
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Ensure the harness runs serially.
+
+    Counter-diff observability (Loop E2E-L4) relies on serial scenario
+    execution. Detect pytest-xdist activation and fail loudly rather
+    than silently producing nonsense.
+    """
+    if config.getoption("-n", default=None) not in (None, 0, "0"):
+        raise pytest.UsageError(
+            "tests/e2e must run serially: counter-diff observability is global. "
+            "Remove -n / pytest-xdist flags."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """Return a port that is currently free on 127.0.0.1.
+
+    Closes the bound socket immediately; brief race window is acceptable
+    for serial e2e runs.
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _resolve_proxy_binary() -> Path:
+    override = os.environ.get(PROXY_BIN_ENV)
+    if override:
+        path = Path(override)
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"{PROXY_BIN_ENV}={override} does not point to a file"
+            )
+        return path
+    for candidate in DEFAULT_PROXY_BINARIES:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        "llmtrace-proxy binary not found. Build it first:\n"
+        "  cargo build --release -p llmtrace\n"
+        "or set the LLMTRACE_PROXY_BIN env var to an existing binary."
+    )
+
+
+def _wait_for_health(url: str, timeout_secs: float, label: str) -> None:
+    import requests  # local import keeps top-level import deps minimal
+
+    deadline = time.monotonic() + timeout_secs
+    last_error: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(url, timeout=2.0)
+            if resp.status_code == 200:
+                return
+            last_error = f"HTTP {resp.status_code}"
+        except requests.RequestException as e:
+            last_error = str(e)
+        time.sleep(PROXY_HEALTH_POLL_INTERVAL_SECS)
+    raise TimeoutError(
+        f"{label} did not become healthy within {timeout_secs}s "
+        f"(last error: {last_error})"
+    )
+
+
+def _terminate(process: subprocess.Popen, label: str) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=PROXY_TEARDOWN_TIMEOUT_SECS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=2)
+    if process.returncode not in (0, -15, None):
+        # -15 is SIGTERM on POSIX; treat as a clean shutdown.
+        # Loud but non-fatal — the test session has already finished.
+        print(
+            f"[e2e] {label} exited with code {process.returncode}",
+            file=sys.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mock upstream fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MockUpstreamHandle:
+    base_url: str
+    port: int
+
+
+@pytest.fixture(scope="session")
+def mock_upstream() -> Iterator[MockUpstreamHandle]:
+    LOGS_DIR.mkdir(exist_ok=True)
+    port = _free_port()
+    log_path = LOGS_DIR / "mock_upstream.log"
+
+    process = subprocess.Popen(
+        [sys.executable, str(MOCK_UPSTREAM_PATH), "--port", str(port)],
+        stdout=log_path.open("w", encoding="utf-8"),
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_for_health(
+            f"{base_url}/health", MOCK_HEALTH_TIMEOUT_SECS, "mock_upstream"
+        )
+        yield MockUpstreamHandle(base_url=base_url, port=port)
+    finally:
+        _terminate(process, "mock_upstream")
+
+
+# ---------------------------------------------------------------------------
+# Proxy fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProxyHandle:
+    base_url: str
+    health_url: str
+    metrics_url: str
+    config_path: Path
+    log_path: Path
+
+    def post_chat(
+        self,
+        prompt: str,
+        *,
+        trace_id: uuid.UUID | None = None,
+        timeout: float = 30.0,
+    ):
+        """Send a single-turn chat completion request and return the response."""
+        import requests
+
+        headers = {"content-type": "application/json"}
+        if trace_id is not None:
+            headers["x-llmtrace-trace-id"] = str(trace_id)
+        body = {
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+        }
+        return requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            data=json.dumps(body),
+            headers=headers,
+            timeout=timeout,
+        )
+
+
+@pytest.fixture(scope="session")
+def proxy_config_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Render the e2e (judge-off) config into a per-session temp file.
+
+    The base config is copied as-is; runtime networking + storage paths
+    are passed via env vars to the proxy subprocess.
+    """
+    src = FIXTURES_DIR / "config-e2e.yaml"
+    dst = tmp_path_factory.mktemp("e2e-config") / "config.yaml"
+    shutil.copyfile(src, dst)
+    return dst
+
+
+@pytest.fixture(scope="session")
+def proxy(
+    mock_upstream: MockUpstreamHandle,
+    proxy_config_path: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[ProxyHandle]:
+    LOGS_DIR.mkdir(exist_ok=True)
+    binary = _resolve_proxy_binary()
+
+    listen_port = _free_port()
+    listen_addr = f"127.0.0.1:{listen_port}"
+    db_dir = tmp_path_factory.mktemp("e2e-db")
+    db_path = db_dir / "llmtrace-e2e.db"
+    log_path = LOGS_DIR / "proxy.log"
+
+    env = os.environ.copy()
+    env["LLMTRACE_LISTEN_ADDR"] = listen_addr
+    env["LLMTRACE_UPSTREAM_URL"] = mock_upstream.base_url
+    env["LLMTRACE_STORAGE_DATABASE_PATH"] = str(db_path)
+    env["LLMTRACE_STORAGE_PROFILE"] = "lite"
+    env["RUST_LOG"] = env.get("RUST_LOG", "llmtrace_proxy=info,info")
+
+    process = subprocess.Popen(
+        [str(binary), "--config", str(proxy_config_path)],
+        stdout=log_path.open("w", encoding="utf-8"),
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+
+    base_url = f"http://{listen_addr}"
+    try:
+        _wait_for_health(
+            f"{base_url}/health", PROXY_HEALTH_TIMEOUT_SECS, "llmtrace-proxy"
+        )
+        yield ProxyHandle(
+            base_url=base_url,
+            health_url=f"{base_url}/health",
+            metrics_url=f"{base_url}/metrics",
+            config_path=proxy_config_path,
+            log_path=log_path,
+        )
+    finally:
+        _terminate(process, "llmtrace-proxy")
+
+
+# ---------------------------------------------------------------------------
+# Scenarios fixture
+# ---------------------------------------------------------------------------
+
+
+def _load_scenario(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _matches_filters(
+    scenario: dict, families: list[str], tags: list[str]
+) -> bool:
+    if families and scenario.get("family") not in families:
+        return False
+    if tags:
+        scenario_tags = set(scenario.get("tags") or [])
+        if not scenario_tags.intersection(tags):
+            return False
+    return True
+
+
+def _is_skipped(scenario: dict) -> tuple[bool, str | None]:
+    skip = scenario.get("skip")
+    if not skip:
+        return False, None
+    return True, skip.get("reason") or "no reason provided"
+
+
+def discover_scenarios(
+    families: list[str] | None = None, tags: list[str] | None = None
+) -> list[dict]:
+    """Return all scenarios under benchmarks/attacks/ matching the filters."""
+    families = families or []
+    tags = tags or []
+    scenarios: list[dict] = []
+    for path in sorted(ATTACKS_DIR.rglob("*.yaml")):
+        if not path.is_file():
+            continue
+        scenario = _load_scenario(path)
+        if not isinstance(scenario, dict):
+            continue
+        scenario["__path__"] = str(path.relative_to(REPO_ROOT))
+        if _matches_filters(scenario, families, tags):
+            scenarios.append(scenario)
+    return scenarios
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Parametrise any test that requests a `scenario` fixture."""
+    if "scenario" not in metafunc.fixturenames:
+        return
+    families = metafunc.config.getoption("--family") or []
+    tags = metafunc.config.getoption("--tag") or []
+    scenarios = discover_scenarios(families=families, tags=tags)
+    ids = [s["id"] for s in scenarios]
+    metafunc.parametrize("scenario", scenarios, ids=ids)

--- a/tests/e2e/fixtures/config-e2e-judge.yaml
+++ b/tests/e2e/fixtures/config-e2e-judge.yaml
@@ -1,0 +1,72 @@
+# LLMTrace e2e test config — judge ON (cascade, slow tier disabled).
+#
+# Same shape as config-e2e.yaml but with the LLM-as-a-Judge cascade
+# enabled in fast-tier-only mode (DeBERTa fast-judge + null slow tier),
+# matching the PR-gate matrix dimension `cascade-null-slow` from
+# Loop E2E-L9.
+#
+# The harness applies the same env-var overrides as for config-e2e.yaml
+# (LLMTRACE_LISTEN_ADDR, LLMTRACE_UPSTREAM_URL, LLMTRACE_STORAGE_DATABASE_PATH).
+
+listen_addr: "127.0.0.1:8080"
+upstream_url: "http://127.0.0.1:1"
+timeout_ms: 30000
+connection_timeout_ms: 5000
+max_connections: 100
+enable_tls: false
+enable_security_analysis: true
+enable_trace_storage: true
+enable_streaming: true
+max_request_size_bytes: 1048576
+security_analysis_timeout_ms: 5000
+trace_storage_timeout_ms: 10000
+
+storage:
+  profile: "lite"
+  database_path: "llmtrace-e2e.db"
+
+logging:
+  level: "info"
+  format: "text"
+
+auth:
+  enabled: false
+
+shutdown:
+  timeout_seconds: 5
+
+rate_limiting:
+  enabled: false
+  requests_per_second: 1000
+  burst_size: 2000
+  window_seconds: 60
+
+circuit_breaker:
+  enabled: true
+  failure_threshold: 100
+  recovery_timeout_ms: 5000
+  half_open_max_calls: 3
+
+health_check:
+  enabled: true
+  path: "/health"
+  interval_seconds: 10
+  timeout_ms: 5000
+  retries: 3
+
+# See config-e2e.yaml for rationale on enforcement mode/min_severity.
+enforcement:
+  mode: flag
+  analysis_depth: fast
+  min_severity: Low
+  min_confidence: 0.5
+  timeout_ms: 2000
+
+judge:
+  enabled: true
+  backend: cascade
+  cascade:
+    fast_backend: deberta
+    slow_backend: null
+  promotion:
+    shadow: true

--- a/tests/e2e/fixtures/config-e2e.yaml
+++ b/tests/e2e/fixtures/config-e2e.yaml
@@ -1,0 +1,72 @@
+# LLMTrace e2e test config — judge OFF.
+#
+# Used by the pytest harness in tests/e2e/. Loaded as a base; the harness
+# overrides per-session networking via environment variables:
+#
+#   LLMTRACE_LISTEN_ADDR           — bound to a free port at runtime
+#   LLMTRACE_UPSTREAM_URL          — pointed at the in-process FastAPI mock
+#   LLMTRACE_STORAGE_DATABASE_PATH — temp SQLite file for the session
+#
+# Auth is disabled so the harness does not need to bootstrap an API key.
+# Shutdown drain is short (5 s) so SIGTERM teardown completes inside the
+# harness's 10 s budget — see Loop E2E-L1 finding E2E-006.
+
+listen_addr: "127.0.0.1:8080"
+upstream_url: "http://127.0.0.1:1"
+timeout_ms: 30000
+connection_timeout_ms: 5000
+max_connections: 100
+enable_tls: false
+enable_security_analysis: true
+enable_trace_storage: true
+enable_streaming: true
+max_request_size_bytes: 1048576
+security_analysis_timeout_ms: 5000
+trace_storage_timeout_ms: 10000
+
+storage:
+  profile: "lite"
+  database_path: "llmtrace-e2e.db"
+
+logging:
+  level: "info"
+  format: "text"
+
+auth:
+  enabled: false
+
+shutdown:
+  timeout_seconds: 5
+
+rate_limiting:
+  enabled: false
+  requests_per_second: 1000
+  burst_size: 2000
+  window_seconds: 60
+
+circuit_breaker:
+  enabled: true
+  failure_threshold: 100
+  recovery_timeout_ms: 5000
+  half_open_max_calls: 3
+
+health_check:
+  enabled: true
+  path: "/health"
+  interval_seconds: 10
+  timeout_ms: 5000
+  retries: 3
+
+# Security enforcement is set to `flag` so findings surface as response
+# headers (`x-llmtrace-flagged`, `x-llmtrace-findings`). Default is `log`,
+# which detects findings but never surfaces them — the e2e harness needs
+# this signal to drive the proxy_outcome assertion.
+# min_severity is lowered from default High to Low so the harness sees
+# regex-tier signals from the example scenarios. The expectation DSL
+# (Loop E2E-L6) takes over per-scenario severity gating after L4.
+enforcement:
+  mode: flag
+  analysis_depth: fast
+  min_severity: Low
+  min_confidence: 0.5
+  timeout_ms: 2000

--- a/tests/e2e/mock_upstream.py
+++ b/tests/e2e/mock_upstream.py
@@ -1,0 +1,92 @@
+"""Canned in-process FastAPI upstream used by the e2e harness in PR-gate mode.
+
+Implements just enough of the OpenAI Chat Completions surface for the
+LLMTrace proxy to forward requests successfully and observe a 200
+response. The mock is intentionally dumb — it always returns the same
+canned assistant message regardless of the inbound prompt — because the
+PR-gate test surface only asserts on what LLMTrace decides about the
+request, not on upstream content. The real-LLM upstream lives in the
+nightly job (Loop E2E-L10).
+
+The mock is started by `tests/e2e/conftest.py::mock_upstream` as an
+in-process subprocess, so it shares no module state with the test
+runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import uuid
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+
+def _canned_chat_completion(model: str) -> dict:
+    """Return a deterministic OpenAI-shaped response."""
+    now = int(time.time())
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
+        "object": "chat.completion",
+        "created": now,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": (
+                        "This is a canned mock-upstream response used by the "
+                        "LLMTrace e2e harness. The mock does not interpret "
+                        "the inbound prompt."
+                    ),
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 32,
+            "completion_tokens": 32,
+            "total_tokens": 64,
+        },
+    }
+
+
+def build_app() -> FastAPI:
+    app = FastAPI(title="LLMTrace e2e mock upstream", version="0.1.0")
+
+    @app.get("/health")
+    async def health() -> dict:
+        return {"status": "ok"}
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request) -> JSONResponse:
+        body = await request.json()
+        model = body.get("model", "mock-model")
+        return JSONResponse(_canned_chat_completion(model))
+
+    return app
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--log-level", default="warning")
+    args = parser.parse_args(argv)
+
+    uvicorn.run(
+        build_app(),
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level,
+        access_log=False,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/test_cascade.py
+++ b/tests/e2e/test_cascade.py
@@ -1,0 +1,91 @@
+"""First-cut e2e scenario test (Loop E2E-L3 of #91).
+
+Asserts only the proxy outcome — the metrics-delta and judge-verdict
+checks live in Loops E2E-L4 / L5 / L6. This file's job is to prove the
+harness boots, fires every scenario in the corpus, and reads back a
+single binary signal (allow / warn / block) with enough fidelity to
+catch a regression in the proxy decision path.
+
+Outcome heuristic (refined in L6's expectation DSL):
+
+  * HTTP status >= 400 with a JSON body whose `error.type` starts with
+    `proxy_` → block (the proxy itself rejected the request).
+  * HTTP 200 + `x-llmtrace-flagged: true` response header → warn
+    (the proxy forwarded but flagged the request).
+  * Any other HTTP 200 → allow.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+if TYPE_CHECKING:
+    from .conftest import ProxyHandle
+
+PROXY_OUTCOME_ORDER: Final[dict[str, int]] = {"allow": 0, "warn": 1, "block": 2}
+
+
+def classify_proxy_outcome(response) -> str:
+    if response.status_code >= 400:
+        body = _safe_json(response)
+        if isinstance(body, dict):
+            err = body.get("error")
+            if isinstance(err, dict) and str(err.get("type", "")).startswith(
+                "proxy_"
+            ):
+                return "block"
+    flagged = response.headers.get("x-llmtrace-flagged")
+    if flagged and flagged.lower() == "true":
+        return "warn"
+    return "allow"
+
+
+def _safe_json(response):
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+def _expected_at_least(scenario: dict) -> str | None:
+    return (scenario.get("expected") or {}).get("proxy_outcome.at_least")
+
+
+def _expected_at_most(scenario: dict) -> str | None:
+    return (scenario.get("expected") or {}).get("proxy_outcome.at_most")
+
+
+def test_scenario(proxy: "ProxyHandle", scenario: dict) -> None:
+    skip = scenario.get("skip")
+    if skip:
+        pytest.skip(skip.get("reason") or "scenario marked skip")
+
+    trace_id = uuid.uuid4()
+    response = proxy.post_chat(prompt=scenario["prompt"], trace_id=trace_id)
+    observed = classify_proxy_outcome(response)
+    observed_rank = PROXY_OUTCOME_ORDER[observed]
+
+    at_least = _expected_at_least(scenario)
+    at_most = _expected_at_most(scenario)
+    sid = scenario["id"]
+
+    if at_least is not None:
+        floor = PROXY_OUTCOME_ORDER[at_least]
+        assert observed_rank >= floor, (
+            f"[{sid}] proxy_outcome.at_least expected >= {at_least}, "
+            f"observed {observed} (status={response.status_code}, "
+            f"flagged={response.headers.get('x-llmtrace-flagged')!r}). "
+            f"trace_id={trace_id}"
+        )
+
+    if at_most is not None:
+        ceiling = PROXY_OUTCOME_ORDER[at_most]
+        assert observed_rank <= ceiling, (
+            f"[{sid}] proxy_outcome.at_most expected <= {at_most}, "
+            f"observed {observed} (status={response.status_code}, "
+            f"flagged={response.headers.get('x-llmtrace-flagged')!r}). "
+            f"trace_id={trace_id}"
+        )


### PR DESCRIPTION
## Summary

Loop **E2E-L3** of the e2e adversarial test framework (umbrella #91, child #93).

Boots the LLMTrace proxy as a subprocess against an in-process FastAPI mock upstream, fires every scenario YAML under \`benchmarks/attacks/\` at it, and asserts the per-scenario \`expected.proxy_outcome.at_*\` constraints. Asserts proxy outcome only — metrics-delta and judge-verdict observability land in Loops E2E-L4 / L5 / L6.

> **Stacked on #115 (Loop E2E-L2).** This branch targets \`feat/issue-92-e2e-scenario-schema\` because L3 reads \`benchmarks/attacks/*.yaml\` and reuses \`requirements-e2e.txt\`. Rebase onto \`main\` after #115 merges and switch the base.

## Changes

### \`tests/e2e/conftest.py\` (NEW)

Session-scoped fixtures owning the lifecycle of two subprocesses:

- \`mock_upstream\`: free-port FastAPI subprocess, \`/health\`-gated.
- \`proxy\`: free-port \`llmtrace-proxy\` subprocess, wired to the mock via env-var overrides (\`LLMTRACE_LISTEN_ADDR\` / \`LLMTRACE_UPSTREAM_URL\` / \`LLMTRACE_STORAGE_*\`). Binary discovered via \`LLMTRACE_PROXY_BIN\` → \`target/release/\` → \`target/debug/\`.
- \`scenarios\`: walks \`benchmarks/attacks/\`, parametrises tests by scenario \`id\`. CLI filters \`--family=\` and \`--tag=\` (both repeatable).

Hard guard at collection time **rejects \`pytest-xdist\` (-n)** because Loop E2E-L4 will diff per-scenario \`/metrics\` deltas — that requires serial execution. Counter-diffing under parallel runs would silently produce nonsense.

Reliable teardown: SIGTERM-then-wait-10s in \`finally\` blocks for both subprocesses; verified with \`pgrep llmtrace-proxy/mock_upstream\` after exit (empty).

### \`tests/e2e/test_cascade.py\` (NEW)

First parametrised test. Outcome classifier maps response to \`allow\` / \`warn\` / \`block\` heuristically:

| Response | Outcome |
|---|---|
| HTTP \`>= 400\` with body \`{\"error\": {\"type\": \"proxy_*\", ...}}\` | \`block\` |
| HTTP \`200\` + \`x-llmtrace-flagged: true\` response header | \`warn\` |
| Any other HTTP \`200\` | \`allow\` |

Failure messages include scenario \`id\`, expected vs observed, status, flagged header, and trace_id — verified by deliberately tightening one xstest expectation and reading the resulting message.

### \`tests/e2e/mock_upstream.py\` (NEW)

FastAPI canned OpenAI-compatible \`/v1/chat/completions\` response. Always returns the same assistant message; PR-gate tests assert on what LLMTrace decides about the request, not on upstream content. Real-LLM upstream is the nightly job (Loop E2E-L10).

### \`tests/e2e/fixtures/config-e2e.yaml\` and \`config-e2e-judge.yaml\` (NEW)

Two base configs the harness templates per session:

- \`config-e2e.yaml\` — judge OFF.
- \`config-e2e-judge.yaml\` — judge cascade ON, slow tier null (matches the \`cascade-null-slow\` PR-gate matrix dimension from #99).

Both:

- \`shutdown.timeout_seconds: 5\` per Loop E2E-L1 finding E2E-006.
- \`auth.enabled: false\` — no API-key bootstrap needed in tests.
- \`enforcement.mode: flag\`, \`min_severity: Low\` — surfaces findings as response headers (\`x-llmtrace-flagged\`) so the harness can observe them. Default mode is \`log\`, which detects findings but never surfaces them.

### \`tests/e2e/README.md\` (NEW)

How to build the proxy, install Python deps, run the harness, filter scenarios, inspect logs, and where things live.

### \`pytest.ini\` (NEW)

Repo-local config so CI doesn't depend on a parent \`pyproject.toml\` (which a developer might have for personal setup but CI runners don't). Declares \`serial\` and \`pr_gate\` markers.

### \`requirements-e2e.txt\` (modified)

Added pinned \`pytest\`, \`requests\`, \`prometheus-client\`, \`fastapi\`, \`uvicorn\` on top of L2's \`jsonschema\` + \`PyYAML\`.

### \`.gitignore\` (modified)

\`tests/e2e/.logs/\` (per-session subprocess logs) and \`.venv-e2e/\` (local virtualenv).

## Test plan

- [x] \`pytest tests/e2e/ -v\` — **3/3 example scenarios pass in ~25s.**
  - \`dan-classic-001\` → \`warn\` (regex flagged 3 findings).
  - \`xstest-violence-question-001\` → \`allow\` (correctly NOT flagged).
  - \`base64-command-001\` → \`warn\` (regex flagged 4 findings).
- [x] \`pgrep llmtrace-proxy / mock_upstream\` after exit — **empty** (no zombie processes).
- [x] Failure-message quality verified by tightening one xstest expectation: message includes \`id\`, expected vs observed, \`status\`, \`flagged\`, \`trace_id\`.
- [x] \`pytest --collect-only\` confirms \`rootdir = /home/epappas/workspace/spacejar/llmtrace\` and \`configfile: pytest.ini\` is picked up (no parent pyproject leakage).
- [x] \`tests/e2e/.logs/proxy.log\` populated and gitignored.
- [ ] CI integration is **out of scope** — that is Loop E2E-L9 (#99).

## Notes

- The L1a trace-id header (#114) is set by the harness on every request. If #114 is not yet merged, the proxy will simply ignore the inbound header and generate its own; nothing in this loop's assertions depends on the trace-id round-trip yet (that's L4 / L5).
- The harness includes hooks for L4/L5/L8 (e.g. \`metrics_url\` on \`ProxyHandle\`, \`trace_id\` on every request) so subsequent loops only add observability, not plumbing.

## Unblocks

- Loop E2E-L4 (#94, metrics-delta observer) — \`proxy.metrics_url\` ready.
- Loop E2E-L5 (#95, judge verdict collector) — once the debug-endpoint Rust change lands.
- Loop E2E-L6 (#96, expectation DSL) — slots in by replacing the heuristic in \`test_cascade.py\`.