### PR TITLE
chore(deps): bump rustls-webpki 0.103.12 -> 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

[**RUSTSEC-2026-0104**](https://rustsec.org/advisories/RUSTSEC-2026-0104) — reachable panic in certificate revocation list parsing in \`rustls-webpki <0.103.13\`. The advisory was published after main's last successful CI run on 2026-04-21 21:55, so every currently open PR (#114, #115, #116) inherits the Security Audit failure.

\`cargo update -p rustls-webpki\` resolves to the patch release that contains the fix. No source changes; \`rustls-webpki\` is a transitive dep via the rustls / reqwest / quinn chain.

## Test plan

- [x] \`cargo audit\` — **exit 0**. Only the four pre-existing unmaintained-crate warnings remain (\`number_prefix\`, \`paste\`, \`rand\` x2). No vulnerabilities.
- [x] \`cargo build --workspace\` — clean compile.
- [ ] CI Security Audit job must go green on this PR.

## Unblocks

- #114 (E2E-L1a trace-id header)
- #115 (E2E-L2 schema + validator)
- #116 (E2E-L3 pytest harness)

After this lands on main, those three PRs will be rebased on top to pick up the bump.