### PR TITLE
feat(e2e): judge verdict collector + debug endpoint + degraded-mode (#95)

### DIFF
--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -1239,6 +1239,10 @@ pub struct ProxyConfig {
     /// clients.
     #[serde(default)]
     pub judge: JudgeConfig,
+    /// Server-level toggles. Currently only gates the e2e debug
+    /// endpoints (`/debug/judge/verdicts`) added in issue #95.
+    #[serde(default)]
+    pub server: ServerConfig,
 }
 
 impl Default for ProxyConfig {
@@ -1280,6 +1284,7 @@ impl Default for ProxyConfig {
             boundary_defense: BoundaryTokenConfig::default(),
             action_router: ActionRouterConfig::default(),
             judge: JudgeConfig::default(),
+            server: ServerConfig::default(),
         }
     }
 }
@@ -2782,6 +2787,21 @@ pub struct AuthConfig {
     pub admin_key: Option<String>,
 }
 
+/// Server-level toggles.
+///
+/// Today this only controls the e2e debug endpoint family
+/// (`/debug/judge/verdicts`). The flag is `false` by default; production
+/// proxies should never expose `/debug/*` to untrusted callers because
+/// it returns un-auth-gated verdict payloads keyed by trace_id.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerConfig {
+    /// Enable the `/debug/*` route family. Used by the e2e adversarial
+    /// test framework (issue #91 / #95) to read judge verdicts back by
+    /// trace_id. Default: `false` — debug endpoints are not registered.
+    #[serde(default)]
+    pub debug_endpoints: bool,
+}
+
 /// gRPC ingestion gateway configuration.
 ///
 /// When enabled, the proxy starts a `tonic` gRPC server on a separate
@@ -3973,6 +3993,7 @@ mod tests {
             action_router: ActionRouterConfig::default(),
             boundary_defense: BoundaryTokenConfig::default(),
             judge: JudgeConfig::default(),
+            server: ServerConfig::default(),
         };
 
         let serialized = serde_json::to_string(&config).unwrap();

--- a/crates/llmtrace-proxy/src/debug.rs
+++ b/crates/llmtrace-proxy/src/debug.rs
@@ -1,0 +1,94 @@
+//! Debug-only HTTP endpoints used by the e2e adversarial test framework
+//! (umbrella issue #91, child #95).
+//!
+//! Every route in this module is gated by `server.debug_endpoints: true`.
+//! The default is `false`, and `build_router` does not register the
+//! routes at all when the flag is off — there is no per-request opt-in
+//! and no auth bypass: if the flag is off the endpoint returns 404 from
+//! axum's not-found handler because it was never mounted.
+//!
+//! These endpoints return raw verdict payloads keyed by `trace_id` and
+//! must therefore never be reachable from production proxies.
+
+use axum::body::Body;
+use axum::extract::{Query, State};
+use axum::http::{Response, StatusCode};
+use llmtrace_core::JudgeVerdictQuery;
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::proxy::AppState;
+
+/// Query parameters for `GET /debug/judge/verdicts`.
+#[derive(Debug, Deserialize)]
+pub struct VerdictByTraceIdParams {
+    /// Required. The `trace_id` correlated with a request the e2e
+    /// harness fired earlier in the same session.
+    pub trace_id: String,
+}
+
+/// `GET /debug/judge/verdicts?trace_id=<uuid>`.
+///
+/// Returns the most recent persisted [`JudgeVerdict`] for the trace as
+/// JSON, or 404 if no verdict has been recorded yet (the judge worker
+/// runs asynchronously after the upstream response, so the harness
+/// polls this endpoint).
+///
+/// Implemented as a thin wrapper over the existing
+/// `JudgeVerdictStore::query_verdicts` trait method using the already
+/// supported `JudgeVerdictQuery { trace_id, .. }` filter — no new
+/// trait surface is required (see Loop E2E-L1 audit finding E2E-003).
+pub async fn verdict_by_trace_id_handler(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<VerdictByTraceIdParams>,
+) -> Response<Body> {
+    let trace_id = match Uuid::parse_str(params.trace_id.trim()) {
+        Ok(id) => id,
+        Err(_) => return error_json(StatusCode::BAD_REQUEST, "trace_id must be a UUID"),
+    };
+
+    let query = JudgeVerdictQuery {
+        trace_id: Some(trace_id),
+        limit: Some(1),
+        ..JudgeVerdictQuery::default()
+    };
+
+    let verdicts = match state.storage.judge_verdicts.query_verdicts(&query).await {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::warn!(%trace_id, error = %err, "verdict_by_trace_id query failed");
+            return error_json(StatusCode::INTERNAL_SERVER_ERROR, "verdict query failed");
+        }
+    };
+
+    let Some(verdict) = verdicts.into_iter().next() else {
+        return error_json(StatusCode::NOT_FOUND, "no verdict for trace_id");
+    };
+
+    let body = match serde_json::to_vec(&verdict) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::error!(%trace_id, error = %err, "verdict serialization failed");
+            return error_json(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "verdict serialization failed",
+            );
+        }
+    };
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .expect("infallible response build")
+}
+
+fn error_json(status: StatusCode, message: &str) -> Response<Body> {
+    let body = serde_json::json!({ "error": { "message": message, "type": "debug_error" } });
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("infallible response build")
+}

--- a/crates/llmtrace-proxy/src/lib.rs
+++ b/crates/llmtrace-proxy/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod config_handle;
 pub mod cost;
 pub mod cost_caps;
+pub mod debug;
 pub mod enforcement;
 pub mod feature_flags;
 pub mod feature_flags_api;

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -911,7 +911,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .allow_methods(Any)
         .allow_headers(Any);
 
-    Router::new()
+    let router = Router::new()
         // OpenAPI / Swagger UI (served by the proxy itself, not forwarded upstream).
         .merge(SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi()))
         .route("/health", get(health_handler))
@@ -1014,7 +1014,27 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/v1/traces",
             post(llmtrace_proxy::otel::ingest_traces),
+        );
+
+    // Debug routes — registered only when `server.debug_endpoints: true`.
+    // Used by the e2e adversarial test framework (#91 / #95) to read
+    // judge verdicts back by trace_id. Default is OFF; production
+    // proxies must never enable this because verdicts are returned
+    // un-auth-gated by trace_id.
+    let router = if state.config_handle.snapshot().server.debug_endpoints {
+        tracing::warn!(
+            "Debug endpoints enabled (server.debug_endpoints=true). \
+             Do not run with this flag in production."
+        );
+        router.route(
+            "/debug/judge/verdicts",
+            get(llmtrace_proxy::debug::verdict_by_trace_id_handler),
         )
+    } else {
+        router
+    };
+
+    router
         // Fallback: proxy everything else to upstream
         .fallback(any(proxy_handler))
         // Auth middleware — applied to all routes (skips /health internally)
@@ -1110,6 +1130,123 @@ mod tests {
     async fn test_build_app_state_succeeds() {
         let state = build_app_state(memory_config(), None).await;
         assert!(state.is_ok());
+    }
+
+    // ---- /debug/judge/verdicts (Loop E2E-L5 of #91) -----------------
+
+    fn debug_endpoints_config(enabled: bool) -> ProxyConfig {
+        let mut cfg = memory_config();
+        cfg.server.debug_endpoints = enabled;
+        cfg
+    }
+
+    async fn insert_test_verdict(
+        state: &Arc<llmtrace_proxy::AppState>,
+        trace_id: uuid::Uuid,
+    ) -> llmtrace_core::JudgeVerdict {
+        use chrono::Utc;
+        let verdict = llmtrace_core::JudgeVerdict {
+            id: uuid::Uuid::new_v4(),
+            trace_id,
+            tenant_id: llmtrace_core::TenantId(uuid::Uuid::new_v4()),
+            is_threat: true,
+            category: "prompt_injection".to_string(),
+            confidence: 0.92,
+            security_score: 80,
+            recommended_action: "flag".to_string(),
+            reasoning: "test verdict".to_string(),
+            mode: llmtrace_core::JudgeMode::Async,
+            model_used: "test-model".to_string(),
+            latency_ms: 12,
+            prompt_tokens: None,
+            completion_tokens: None,
+            created_at: Utc::now(),
+        };
+        state
+            .storage
+            .judge_verdicts
+            .insert_verdict(&verdict)
+            .await
+            .expect("verdict insert");
+        verdict
+    }
+
+    #[tokio::test]
+    async fn test_debug_verdicts_returns_404_when_flag_off() {
+        let state = build_app_state(debug_endpoints_config(false), None)
+            .await
+            .unwrap();
+        let _ = insert_test_verdict(&state, uuid::Uuid::new_v4()).await;
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri(format!(
+                "/debug/judge/verdicts?trace_id={}",
+                uuid::Uuid::new_v4()
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "debug route must NOT be mounted when server.debug_endpoints=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_debug_verdicts_returns_404_when_no_verdict_for_trace() {
+        let state = build_app_state(debug_endpoints_config(true), None)
+            .await
+            .unwrap();
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri(format!(
+                "/debug/judge/verdicts?trace_id={}",
+                uuid::Uuid::new_v4()
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_debug_verdicts_returns_verdict_when_present() {
+        let trace_id = uuid::Uuid::new_v4();
+        let state = build_app_state(debug_endpoints_config(true), None)
+            .await
+            .unwrap();
+        let inserted = insert_test_verdict(&state, trace_id).await;
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri(format!("/debug/judge/verdicts?trace_id={trace_id}"))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let payload: llmtrace_core::JudgeVerdict =
+            serde_json::from_slice(&body).expect("response is a JudgeVerdict");
+        assert_eq!(payload.id, inserted.id);
+        assert_eq!(payload.trace_id, trace_id);
+        assert_eq!(payload.category, "prompt_injection");
+        assert!(payload.is_threat);
+    }
+
+    #[tokio::test]
+    async fn test_debug_verdicts_rejects_non_uuid_trace_id() {
+        let state = build_app_state(debug_endpoints_config(true), None)
+            .await
+            .unwrap();
+        let app = build_router(state);
+        let req = Request::builder()
+            .uri("/debug/judge/verdicts?trace_id=not-a-uuid")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/docs/guides/e2e-testing.md
+++ b/docs/guides/e2e-testing.md
@@ -1,0 +1,215 @@
+# E2E Adversarial Testing Guide
+
+> **Status:** in development. Tracks umbrella issue [#91](https://github.com/epappas/llmtrace/issues/91). This guide covers Loops E2E-L1–L5 (proxy lifecycle + scenario schema + metrics + judge verdicts). The expectation DSL (L6), CI integration (L9/L10), and broader corpus (L7) follow.
+
+The e2e adversarial test framework exercises a **real LLMTrace proxy** against a YAML corpus of attack scenarios and asserts what the proxy decided about each one. It boots the proxy as a subprocess, fires every scenario at it, and reads back the full observability surface — HTTP status, response headers, `/metrics` deltas, and persisted judge verdicts — then evaluates each scenario's `expected:` block against what was observed.
+
+---
+
+## Quick start
+
+```bash
+# Build the proxy binary (release recommended; debug works too)
+cargo build --release -p llmtrace
+
+# Install the e2e Python deps into a venv
+python3 -m venv .venv-e2e
+.venv-e2e/bin/pip install -r requirements-e2e.txt
+
+# Run the suite
+.venv-e2e/bin/pytest tests/e2e/ -v
+
+# Run the PR-gate subset (faster; same scenarios as #99 will use)
+.venv-e2e/bin/pytest tests/e2e/ -v --tag=pr-gate
+
+# Run scenarios in one family
+.venv-e2e/bin/pytest tests/e2e/ -v --family=prompt_injection
+```
+
+The harness picks up `target/release/llmtrace-proxy` when present, then `target/debug/llmtrace-proxy`. Override with `LLMTRACE_PROXY_BIN=<path>`. The harness logs the proxy and mock-upstream stdout to `tests/e2e/.logs/` (gitignored).
+
+---
+
+## Architecture (today)
+
+```
+pytest
+  conftest.py
+    mock_upstream     ── canned FastAPI /v1/chat/completions (PR-gate only)
+    proxy             ── llmtrace-proxy subprocess, /health-gated boot
+    scenarios         ── parametrises tests against benchmarks/attacks/**/*.yaml
+
+  test_cascade.py::test_scenario(proxy, scenario)
+      ├── MetricsSnapshot.fetch(/metrics)         (before)
+      ├── proxy.post_chat(prompt, trace_id=…)     (X-LLMTrace-Trace-Id set)
+      ├── fetch_after_until_settled(…)            (poll until background task lands)
+      ├── classify_proxy_outcome(response)        (allow / warn / block)
+      ├── poll_judge_verdict(/debug/…)            (when judge_verdict expected)
+      └── assertions:
+            proxy_outcome.at_{least,most}
+            findings_include
+            judge_verdict.{is_threat, category, recommended_action.at_*}
+```
+
+Subsequent loops slot in:
+
+- **L6** — formalises the assertion logic above into an expectation DSL with per-comparator unit tests.
+- **L7** — converts ~50 labeled samples from `benchmarks/datasets/` into the corpus.
+- **L8** — adds the upstream-fell-for-it detector for live-LLM nightly runs.
+- **L9 / L10** — CI workflows (PR-gate fast subset + nightly full corpus + committed report).
+
+---
+
+## Scenario format
+
+See [`benchmarks/attacks/SCHEMA.md`](../../benchmarks/attacks/SCHEMA.md) for the field reference. The validator (`scripts/e2e/validate_scenarios.py`) runs in CI as the `e2e-validate-scenarios` job; it gates schema drift independently of the harness boot.
+
+---
+
+## Trace-id correlation
+
+Every harness request carries `X-LLMTrace-Trace-Id: <uuid>`. The proxy honours the header (PR #114, Loop E2E-L1a) and uses it as the request's `trace_id` end-to-end:
+
+- Logged with every `tracing` event for that request.
+- Propagated to security findings, persisted traces, and the persisted `JudgeVerdict.trace_id`.
+- Echoed back as the `X-LLMTrace-Trace-Id` response header on success and error paths.
+
+Because `JudgeVerdictQuery.trace_id` is already part of the verdict store trait, the harness can poll the dev-only `GET /debug/judge/verdicts?trace_id=<uuid>` endpoint to fetch a verdict back by the same id it supplied on the inbound request.
+
+If you supply no header, the proxy generates a fresh `Uuid::new_v4()` as before. The harness always supplies one.
+
+---
+
+## Debug endpoint contract
+
+> **Production-safety call-out.** The `/debug/*` route family is gated by `server.debug_endpoints: bool` (default `false`). When the flag is `false`, the route is **not registered** and returns 404 from axum's not-found handler. **Production proxies must never enable this flag** — verdicts are returned un-auth-gated by trace_id; anything that knows a trace_id can read the verdict.
+
+### `GET /debug/judge/verdicts?trace_id=<uuid>`
+
+| Status | Body | Meaning |
+|---|---|---|
+| `200` | `JudgeVerdict` JSON (matches the persisted `judge_verdicts` row schema) | Verdict found for the supplied `trace_id` |
+| `404` | `{"error": {"message": "no verdict for trace_id", "type": "debug_error"}}` | Either no verdict has landed yet (judge worker is async) or the flag is off |
+| `400` | `{"error": {"message": "trace_id must be a UUID", ...}}` | The query param is not a valid RFC 4122 UUID |
+
+Implementation: thin wrapper over `state.storage.judge_verdicts.query_verdicts(JudgeVerdictQuery { trace_id: Some(uuid), limit: Some(1), .. })`. No new trait surface; works against `InMemoryJudgeVerdictStore`, `ClickHouseJudgeVerdictStore`, and `PostgresJudgeVerdictStore`.
+
+---
+
+## Judge verdict collector lifecycle
+
+```
+harness POST /v1/chat/completions   (X-LLMTrace-Trace-Id: <uuid>)
+       │
+       │ proxy enforcement → action_router → judge_route → judge worker queue
+       │
+       │ HTTP response returns to harness
+       │
+       │ judge worker dequeues, runs DeBERTa fast tier (cascade), writes verdict
+       │ to JudgeVerdictStore (async)
+       │
+       └─► harness: poll_judge_verdict(base_url, trace_id, timeout=10s)
+             ├─ GET /debug/judge/verdicts?trace_id=…  (250 ms polling)
+             │     200 → return verdict dict
+             │     404 → keep polling
+             │     other → raise HTTPError
+             └─ timeout → return None (caller decides soft-skip vs hard-fail)
+```
+
+The verdict typically lands in 200–800 ms after the synchronous response. The poller waits up to 10 s by default.
+
+For the e2e harness to receive any verdict at all, the proxy config needs:
+
+- `judge.enabled: true`
+- `judge.backend: cascade` (or whatever backend produces verdicts)
+- `judge.persist_verdicts: true` (default)
+- `action_router.enabled: true` *and* `judge_route` in `action_router.default_actions` — without this the JudgeWorker spawns but never receives requests
+- `server.debug_endpoints: true` — without this `/debug/judge/verdicts` is not mounted
+
+The shipped `tests/e2e/fixtures/config-e2e-judge.yaml` sets all of the above and is the default the harness loads.
+
+---
+
+## Degraded-mode handling
+
+Provider/upstream flakes must not turn e2e red. The harness watches `llmtrace_judge_requests_total{status="backend_error"}` deltas and softens verdict assertions when it sees an increment:
+
+```python
+if judge_expectations is not None:
+    verdict = poll_judge_verdict(proxy.base_url, trace_id)
+    if verdict is None:
+        if judge_backend_errored(delta):
+            pytest.skip("judge tier reported backend_error; assertions softened.")
+        pytest.fail("verdict expected but never recorded.")
+```
+
+The proxy outcome and findings_include assertions stay strict — only the judge_verdict block is softened — because we want to catch LLMTrace regressions, not provider outages.
+
+---
+
+## Shadow-mode signal
+
+`shadow_would_block_count(delta, category=…, recommended_action=…)` reads the per-scenario delta of `llmtrace_judge_shadow_would_block_total`. Useful for scenarios that run with `judge.promotion.shadow: true` and want to assert "the judge *would have* blocked this" without actually changing enforcement.
+
+---
+
+## Failure-message anatomy
+
+Every assertion failure includes:
+
+- The scenario id (`[dan-classic-001]`).
+- The expected vs observed values (with the `at_least`/`at_most` semantics named explicitly).
+- The HTTP `status`, `x-llmtrace-flagged` value, and the request `trace_id`.
+- A pretty-printed dump of the **non-zero metrics delta** for the security/judge/action families, sorted deterministically:
+
+```
+non-zero metrics delta:
+  llmtrace_action_executions_total{action_type='judge_route',mode='inline',status='success'} 1
+  llmtrace_judge_verdicts_total{category='prompt_injection',is_threat='true',recommended_action='block',model='…'} 1
+  llmtrace_security_findings_total{finding_type='jailbreak',severity='Critical'} 2
+```
+
+The trace_id is recoverable from the failure message and can be replayed against the proxy log under `tests/e2e/.logs/proxy.log` for deeper investigation.
+
+---
+
+## Serial-execution constraint
+
+The harness diffs *global* Prometheus counters per scenario. That requires serial execution. `pytest-xdist` (`-n auto`) is **rejected at collection time**:
+
+```
+UsageError: tests/e2e must run serially: counter-diff observability is global.
+```
+
+Per-tenant metric scoping that would make parallel runs safe is an explicit follow-up after L9.
+
+---
+
+## Adding a scenario
+
+1. Pick a `family` from the [SCHEMA enum](../../benchmarks/attacks/SCHEMA.md#family).
+2. Create `benchmarks/attacks/<family>/<id>.yaml` matching the schema.
+3. Tag `pr-gate` if it should run on every PR (the pr-gate subset must stay fast and representative — a regression-catching scenario beats a redundant one).
+4. Run `python3 scripts/e2e/validate_scenarios.py --verbose` to check the schema.
+5. Run `pytest tests/e2e/ -v -k <id>` against a real proxy to confirm the assertions are calibrated.
+6. Open a PR. CI will run the `e2e-validate-scenarios` job + (once L9 lands) the PR-gate subset.
+
+---
+
+## Where things live
+
+| Concern | Path |
+|---|---|
+| Scenario YAMLs | `benchmarks/attacks/<family>/<id>.yaml` |
+| Scenario JSON Schema | `benchmarks/attacks/schema.json` |
+| Schema reference | `benchmarks/attacks/SCHEMA.md` |
+| Validator script | `scripts/e2e/validate_scenarios.py` |
+| Pytest harness | `tests/e2e/conftest.py` |
+| Mock upstream | `tests/e2e/mock_upstream.py` |
+| First-cut test | `tests/e2e/test_cascade.py` |
+| Metrics observer | `tests/e2e/observer.py` |
+| Observer unit tests | `tests/e2e/test_observer_unit.py` |
+| Proxy config (judge ON) | `tests/e2e/fixtures/config-e2e-judge.yaml` |
+| Proxy config (judge OFF) | `tests/e2e/fixtures/config-e2e.yaml` |
+| Proxy debug routes | `crates/llmtrace-proxy/src/debug.rs` |
+| Loop tracker | `docs/TODO_E2E.md` |

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -240,12 +240,16 @@ class ProxyHandle:
 
 @pytest.fixture(scope="session")
 def proxy_config_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Render the e2e (judge-off) config into a per-session temp file.
+    """Render the e2e (judge-on, debug-on) config into a per-session temp file.
 
     The base config is copied as-is; runtime networking + storage paths
-    are passed via env vars to the proxy subprocess.
+    are passed via env vars to the proxy subprocess. We default to the
+    cascade-null-slow judge configuration (matches the L9 PR-gate matrix
+    dimension) so verdict assertions and shadow-mode helpers are
+    exercised on every run. Loop E2E-L5 also requires
+    `server.debug_endpoints: true` for the verdict poller to work.
     """
-    src = FIXTURES_DIR / "config-e2e.yaml"
+    src = FIXTURES_DIR / "config-e2e-judge.yaml"
     dst = tmp_path_factory.mktemp("e2e-config") / "config.yaml"
     shutil.copyfile(src, dst)
     return dst

--- a/tests/e2e/fixtures/config-e2e-judge.yaml
+++ b/tests/e2e/fixtures/config-e2e-judge.yaml
@@ -62,6 +62,17 @@ enforcement:
   min_confidence: 0.5
   timeout_ms: 2000
 
+# The judge worker only spawns when action_router.enabled is true (the
+# JudgeRouteAction owns the channel that hands requests to the worker).
+# Default-actions includes `judge_route` so every finding produced by
+# the ensemble fans out to the judge tier; without this the worker
+# spawns but never receives requests.
+action_router:
+  enabled: true
+  default_actions:
+    - log
+    - judge_route
+
 judge:
   enabled: true
   backend: cascade
@@ -70,3 +81,10 @@ judge:
     slow_backend: null
   promotion:
     shadow: true
+
+# Loop E2E-L5: register the /debug/judge/verdicts endpoint so the
+# harness can poll judge verdicts back by trace_id. This is OFF by
+# default in the proxy; we enable it ONLY in the test config because
+# debug routes return verdicts un-auth-gated.
+server:
+  debug_endpoints: true

--- a/tests/e2e/fixtures/sample_metrics_after.txt
+++ b/tests/e2e/fixtures/sample_metrics_after.txt
@@ -19,3 +19,11 @@ llmtrace_judge_latency_seconds_sum{backend="deberta",mode="sync",model="x"} 0.61
 # HELP llmtrace_judge_dropped_total Judge requests dropped without a backend call, by reason
 # TYPE llmtrace_judge_dropped_total counter
 llmtrace_judge_dropped_total{reason="below_threshold"} 0.0
+# HELP llmtrace_judge_shadow_would_block_total Verdicts suppressed by shadow mode that would have been blocked
+# TYPE llmtrace_judge_shadow_would_block_total counter
+llmtrace_judge_shadow_would_block_total{category="prompt_injection",recommended_action="block"} 1.0
+llmtrace_judge_shadow_would_block_total{category="jailbreak",recommended_action="flag"} 2.0
+# HELP llmtrace_judge_requests_total Judge invocations by backend, model, mode, and status
+# TYPE llmtrace_judge_requests_total counter
+llmtrace_judge_requests_total{backend="deberta",model="x",mode="async",status="ok"} 6.0
+llmtrace_judge_requests_total{backend="deberta",model="x",mode="async",status="backend_error"} 1.0

--- a/tests/e2e/fixtures/sample_metrics_before.txt
+++ b/tests/e2e/fixtures/sample_metrics_before.txt
@@ -18,3 +18,11 @@ llmtrace_judge_latency_seconds_sum{backend="deberta",mode="sync",model="x"} 0.42
 # HELP llmtrace_judge_dropped_total Judge requests dropped without a backend call, by reason
 # TYPE llmtrace_judge_dropped_total counter
 llmtrace_judge_dropped_total{reason="below_threshold"} 0.0
+# HELP llmtrace_judge_shadow_would_block_total Verdicts suppressed by shadow mode that would have been blocked
+# TYPE llmtrace_judge_shadow_would_block_total counter
+llmtrace_judge_shadow_would_block_total{category="prompt_injection",recommended_action="block"} 0.0
+llmtrace_judge_shadow_would_block_total{category="jailbreak",recommended_action="flag"} 1.0
+# HELP llmtrace_judge_requests_total Judge invocations by backend, model, mode, and status
+# TYPE llmtrace_judge_requests_total counter
+llmtrace_judge_requests_total{backend="deberta",model="x",mode="async",status="ok"} 4.0
+llmtrace_judge_requests_total{backend="deberta",model="x",mode="async",status="backend_error"} 1.0

--- a/tests/e2e/observer.py
+++ b/tests/e2e/observer.py
@@ -176,6 +176,81 @@ def collect_finding_types(delta: MetricsSnapshot) -> set[str]:
     return out
 
 
+def poll_judge_verdict(
+    proxy_base_url: str,
+    trace_id,
+    *,
+    timeout_secs: float = 10.0,
+    poll_interval_secs: float = 0.25,
+) -> dict | None:
+    """Poll `GET /debug/judge/verdicts?trace_id=<uuid>` until verdict found.
+
+    The judge worker runs asynchronously after the upstream response
+    returns to the client, so the verdict for a request typically lands
+    in the store 10s–500ms later. The harness polls until either:
+
+      * the proxy returns 200 with a verdict body (returned as a dict),
+      * the proxy returns 404 for the entire `timeout_secs` window
+        (returned as None — caller decides whether that's a soft
+        skip-the-assertion or a hard failure),
+      * the proxy returns 4xx/5xx other than 404 (raised as
+        `requests.HTTPError` so misconfigurations surface loudly).
+
+    Returns the raw verdict dict (matches LLMTrace's JudgeVerdict
+    serialisation) or None on timeout. Requires `server.debug_endpoints:
+    true` in the proxy config — without it the endpoint returns 404
+    immediately and this helper times out.
+    """
+    url = f"{proxy_base_url.rstrip('/')}/debug/judge/verdicts"
+    deadline = time.monotonic() + timeout_secs
+    while time.monotonic() < deadline:
+        response = requests.get(url, params={"trace_id": str(trace_id)}, timeout=2.0)
+        if response.status_code == 200:
+            return response.json()
+        if response.status_code != 404:
+            response.raise_for_status()
+        time.sleep(poll_interval_secs)
+    return None
+
+
+def shadow_would_block_count(
+    delta: MetricsSnapshot,
+    *,
+    category: str | None = None,
+    recommended_action: str | None = None,
+) -> float:
+    """Sum the `llmtrace_judge_shadow_would_block_total` delta.
+
+    Returns 0.0 when the metric is absent so callers can treat
+    "no shadow-mode signal" symmetrically with "judge tier disabled".
+    The optional `category` / `recommended_action` filters narrow the
+    sum; with both `None` the result is the total across all label sets.
+    """
+    labels: dict[str, str] = {}
+    if category is not None:
+        labels["category"] = category
+    if recommended_action is not None:
+        labels["recommended_action"] = recommended_action
+    observed = delta.series(
+        "llmtrace_judge_shadow_would_block_total", labels
+    )
+    return observed if observed is not None else 0.0
+
+
+def judge_backend_errored(delta: MetricsSnapshot) -> bool:
+    """Return True iff the judge tier reported a backend error in the window.
+
+    Signals that a verdict assertion should be softened to a warning
+    (degraded mode) rather than fail the scenario. Per the #91 design
+    note: provider/upstream flakes must not turn e2e red — only
+    LLMTrace-side regressions should.
+    """
+    observed = delta.series(
+        "llmtrace_judge_requests_total", {"status": "backend_error"}
+    )
+    return observed is not None and observed > 0
+
+
 def fetch_after_until_settled(
     metrics_url: str,
     *,

--- a/tests/e2e/test_cascade.py
+++ b/tests/e2e/test_cascade.py
@@ -1,13 +1,14 @@
-"""E2E scenario test (Loops E2E-L3 + L4 of #91).
+"""E2E scenario test (Loops E2E-L3 + L4 + L5 of #91).
 
-Loop E2E-L3 added the proxy lifecycle + the binary `proxy_outcome`
-assertion. Loop E2E-L4 wires in the metrics-delta observer so the
-harness can also assert the `expected.findings_include` constraint
-from the scenario YAML — by snapshotting `/metrics` before and after
-each scenario fires and reading per-scenario counter deltas.
+L3 brought up the proxy lifecycle and the binary `proxy_outcome`
+assertion. L4 added the metrics-delta observer so the harness can
+assert the `expected.findings_include` constraint. L5 wires in the
+judge-verdict collector via the `/debug/judge/verdicts` endpoint so
+the harness can also assert `expected.judge_verdict.*` constraints
+and surface shadow-mode + degraded-mode signals.
 
-Loops E2E-L5 / L6 will add judge-verdict assertions and the full
-expectation DSL on top of these primitives.
+Loop E2E-L6 will replace the per-comparator if-blocks below with a
+formalised expectation DSL.
 
 Outcome heuristic (refined in L6's expectation DSL):
 
@@ -29,6 +30,8 @@ from tests.e2e.observer import (
     MetricsSnapshot,
     collect_finding_types,
     fetch_after_until_settled,
+    judge_backend_errored,
+    poll_judge_verdict,
     render_assertion_context,
 )
 
@@ -36,6 +39,11 @@ if TYPE_CHECKING:
     from .conftest import ProxyHandle
 
 PROXY_OUTCOME_ORDER: Final[dict[str, int]] = {"allow": 0, "warn": 1, "block": 2}
+RECOMMENDED_ACTION_ORDER: Final[dict[str, int]] = {
+    "allow": 0,
+    "flag": 1,
+    "block": 2,
+}
 
 
 def classify_proxy_outcome(response) -> str:
@@ -73,6 +81,10 @@ def _expected_findings_include(scenario: dict) -> list[str]:
     return [str(item) for item in raw]
 
 
+def _expected_judge_verdict(scenario: dict) -> dict | None:
+    return (scenario.get("expected") or {}).get("judge_verdict")
+
+
 @pytest.mark.serial
 def test_scenario(proxy: "ProxyHandle", scenario: dict) -> None:
     skip = scenario.get("skip")
@@ -84,9 +96,11 @@ def test_scenario(proxy: "ProxyHandle", scenario: dict) -> None:
     response = proxy.post_chat(prompt=scenario["prompt"], trace_id=trace_id)
     # LLMTrace records security findings in a background task that
     # outlives the synchronous response. Poll /metrics until the delta
-    # settles when we expect the scenario to produce findings;
-    # otherwise a single immediate snapshot is sufficient.
-    expect_metric_change = bool(_expected_findings_include(scenario))
+    # settles when we expect the scenario to produce findings or a
+    # judge verdict; otherwise a single immediate snapshot is enough.
+    judge_expectations = _expected_judge_verdict(scenario)
+    findings_required = _expected_findings_include(scenario)
+    expect_metric_change = bool(findings_required) or judge_expectations is not None
     after = fetch_after_until_settled(
         proxy.metrics_url, before=before, expect_metric_change=expect_metric_change
     )
@@ -100,6 +114,7 @@ def test_scenario(proxy: "ProxyHandle", scenario: dict) -> None:
     sid = scenario["id"]
 
     failure_context = render_assertion_context(delta)
+    judge_degraded = judge_backend_errored(delta)
 
     if at_least is not None:
         floor = PROXY_OUTCOME_ORDER[at_least]
@@ -121,7 +136,6 @@ def test_scenario(proxy: "ProxyHandle", scenario: dict) -> None:
             f"non-zero metrics delta:\n{failure_context}"
         )
 
-    findings_required = _expected_findings_include(scenario)
     if findings_required:
         observed_finding_types = collect_finding_types(delta)
         missing = [f for f in findings_required if f not in observed_finding_types]
@@ -130,4 +144,56 @@ def test_scenario(proxy: "ProxyHandle", scenario: dict) -> None:
             f"missing {missing} (saw {sorted(observed_finding_types) or 'none'}). "
             f"trace_id={trace_id}\n"
             f"non-zero metrics delta:\n{failure_context}"
+        )
+
+    if judge_expectations is not None:
+        verdict = poll_judge_verdict(proxy.base_url, trace_id)
+        if verdict is None:
+            if judge_degraded:
+                pytest.skip(
+                    f"[{sid}] judge tier reported backend_error; verdict "
+                    f"assertions softened. trace_id={trace_id}"
+                )
+            pytest.fail(
+                f"[{sid}] judge_verdict expected but no verdict was recorded "
+                f"after polling. trace_id={trace_id}\n"
+                f"non-zero metrics delta:\n{failure_context}"
+            )
+        _assert_judge_verdict(sid, judge_expectations, verdict, trace_id)
+
+
+def _assert_judge_verdict(
+    sid: str, expected: dict, verdict: dict, trace_id
+) -> None:
+    if "is_threat" in expected:
+        observed = bool(verdict.get("is_threat"))
+        assert observed == bool(expected["is_threat"]), (
+            f"[{sid}] judge_verdict.is_threat expected {expected['is_threat']!r}, "
+            f"observed {observed!r}. trace_id={trace_id}"
+        )
+    if "category" in expected:
+        observed = verdict.get("category")
+        assert observed == expected["category"], (
+            f"[{sid}] judge_verdict.category expected {expected['category']!r}, "
+            f"observed {observed!r}. trace_id={trace_id}"
+        )
+    floor = expected.get("recommended_action.at_least")
+    if floor is not None:
+        observed = verdict.get("recommended_action")
+        assert (
+            observed in RECOMMENDED_ACTION_ORDER
+            and RECOMMENDED_ACTION_ORDER[observed] >= RECOMMENDED_ACTION_ORDER[floor]
+        ), (
+            f"[{sid}] judge_verdict.recommended_action.at_least expected >= {floor!r}, "
+            f"observed {observed!r}. trace_id={trace_id}"
+        )
+    ceiling = expected.get("recommended_action.at_most")
+    if ceiling is not None:
+        observed = verdict.get("recommended_action")
+        assert (
+            observed in RECOMMENDED_ACTION_ORDER
+            and RECOMMENDED_ACTION_ORDER[observed] <= RECOMMENDED_ACTION_ORDER[ceiling]
+        ), (
+            f"[{sid}] judge_verdict.recommended_action.at_most expected <= {ceiling!r}, "
+            f"observed {observed!r}. trace_id={trace_id}"
         )

--- a/tests/e2e/test_observer_unit.py
+++ b/tests/e2e/test_observer_unit.py
@@ -17,7 +17,9 @@ import pytest
 from tests.e2e.observer import (
     MetricsSnapshot,
     collect_finding_types,
+    judge_backend_errored,
     render_assertion_context,
+    shadow_would_block_count,
 )
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -233,3 +235,61 @@ def test_diff_self_zeroes_counter_samples_but_keeps_gauge(
     )
     # Gauges report the latest absolute value, even on a self-diff.
     assert no_change.series("llmtrace_judge_queue_depth") == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Judge collector helpers (Loop E2E-L5)
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_would_block_count_total_across_all_labels(
+    delta: MetricsSnapshot,
+) -> None:
+    # prompt_injection/block: 1 - 0 = 1; jailbreak/flag: 2 - 1 = 1.
+    assert shadow_would_block_count(delta) == 2.0
+
+
+def test_shadow_would_block_count_filtered_by_category(
+    delta: MetricsSnapshot,
+) -> None:
+    assert shadow_would_block_count(delta, category="prompt_injection") == 1.0
+    assert shadow_would_block_count(delta, category="jailbreak") == 1.0
+
+
+def test_shadow_would_block_count_filtered_by_recommended_action(
+    delta: MetricsSnapshot,
+) -> None:
+    assert shadow_would_block_count(delta, recommended_action="block") == 1.0
+    assert shadow_would_block_count(delta, recommended_action="flag") == 1.0
+
+
+def test_shadow_would_block_count_returns_zero_when_metric_absent() -> None:
+    empty = MetricsSnapshot()
+    assert shadow_would_block_count(empty) == 0.0
+
+
+def test_judge_backend_errored_true_when_status_label_ticks(
+    delta: MetricsSnapshot,
+) -> None:
+    # before: backend_error=1, after: backend_error=1 → delta=0 → not errored.
+    # We need an actual increment to flip True. Synthesise it.
+    fixture_text = (
+        "# HELP llmtrace_judge_requests_total .\n"
+        "# TYPE llmtrace_judge_requests_total counter\n"
+        "llmtrace_judge_requests_total"
+        '{backend="deberta",model="x",mode="async",status="backend_error"} 5.0\n'
+    )
+    after_with_error = MetricsSnapshot.parse(fixture_text)
+    assert judge_backend_errored(after_with_error.diff(MetricsSnapshot())) is True
+
+
+def test_judge_backend_errored_false_when_only_ok_status_increments(
+    delta: MetricsSnapshot,
+) -> None:
+    # The fixture's backend_error counter is unchanged between before/after
+    # (1 → 1), so the delta is 0; only the ok counter advanced.
+    assert judge_backend_errored(delta) is False
+
+
+def test_judge_backend_errored_false_when_metric_absent() -> None:
+    assert judge_backend_errored(MetricsSnapshot()) is False


### PR DESCRIPTION
## Summary

Loop **E2E-L5** of the e2e adversarial test framework (umbrella #91, child #95).

Stitches the async judge verdict surface back into per-scenario assertions. The harness now declares \`expected.judge_verdict.*\` in scenario YAML and verifies it against the persisted verdict via a new debug endpoint. Provider/upstream flakes are softened to \`pytest.skip\` instead of failing red.

> **Stacked on #118 (Loop E2E-L4).** Targets \`feat/issue-94-e2e-metrics-observer\`. Rebase to main after #115/#116/#118 land.

## Rust changes

### \`crates/llmtrace-core/src/lib.rs\`

New \`ServerConfig { debug_endpoints: bool }\` (default \`false\`) on \`ProxyConfig\`. **Production proxies must not enable this** — debug routes return verdicts un-auth-gated by trace_id; anything that knows a trace_id can read the verdict.

### \`crates/llmtrace-proxy/src/debug.rs\` (NEW)

\`verdict_by_trace_id_handler\` — thin wrapper over the existing \`JudgeVerdictStore::query_verdicts(JudgeVerdictQuery { trace_id, .. })\` trait method. **No new trait surface needed** — Loop E2E-L1 audit finding E2E-003 confirmed \`JudgeVerdictQuery.trace_id\` already exists. Returns:

| Status | Body | Meaning |
|---|---|---|
| \`200\` | \`JudgeVerdict\` JSON | Verdict found |
| \`404\` | \`{\"error\": ..., \"type\": \"debug_error\"}\` | Absent OR flag off |
| \`400\` | error JSON | Non-UUID query param |

### \`crates/llmtrace-proxy/src/main.rs\`

\`build_router\` registers \`GET /debug/judge/verdicts\` only when \`server.debug_endpoints: true\`. When the flag is off the route is **not mounted at all** (404 from axum's not-found handler — there is no per-request opt-in and no auth bypass). Operator gets a loud \`WARN\` log on boot when the flag is on.

**4 new Rust integration tests** in \`main.rs::tests\`:

- 200 + verdict JSON when flag on + verdict exists.
- 404 when flag on but no verdict for trace.
- 404 when flag off (proves the route is NOT mounted).
- 400 on non-UUID trace_id.

## Python harness changes

### \`tests/e2e/observer.py\` (added)

- \`poll_judge_verdict(base_url, trace_id, timeout=10s)\` — 250 ms polling against \`/debug/judge/verdicts\`. Returns the verdict dict on 200, None on timeout, raises HTTPError on other 4xx/5xx (misconfigurations surface loudly).
- \`shadow_would_block_count(delta, category=…, recommended_action=…)\` — sums \`llmtrace_judge_shadow_would_block_total\` deltas.
- \`judge_backend_errored(delta)\` — True iff \`llmtrace_judge_requests_total{status=\"backend_error\"}\` ticked in the window.

### \`tests/e2e/test_cascade.py\` (modified)

Wires \`expected.judge_verdict.*\` into per-scenario assertions:

- \`is_threat\`, \`category\`, \`recommended_action.at_least/at_most\`.
- On verdict-not-found + \`judge_backend_errored=True\`: **pytest.skip** with explanation (degraded mode — provider/upstream flake, not LLMTrace regression).
- On verdict-not-found + no backend_error: **pytest.fail** with the full metrics-delta context attached.

### \`tests/e2e/fixtures/config-e2e-judge.yaml\` (modified)

Three flips needed for the cascade fast tier to actually write verdicts and for the harness to read them back:

- \`server.debug_endpoints: true\` — without this \`/debug/judge/verdicts\` is not mounted.
- \`action_router.enabled: true\` — without this the JudgeWorker spawns but \`JudgeRouteAction\` is not registered (channel never receives requests).
- \`action_router.default_actions: [log, judge_route]\` — adds \`judge_route\` to the default fan-out so every finding goes to the judge.

### \`tests/e2e/conftest.py\` (modified)

Default config switched from \`config-e2e.yaml\` (judge OFF) to \`config-e2e-judge.yaml\` so the cascade-null-slow PR-gate matrix dimension is exercised on every run.

### \`tests/e2e/test_observer_unit.py\` (modified) + fixtures (modified)

**7 new unit tests** covering \`shadow_would_block_count\` (filtered + unfiltered), \`judge_backend_errored\` (positive/negative/absent), and the empty-snapshot edge case. Fixtures extended with \`llmtrace_judge_shadow_would_block_total\` and \`llmtrace_judge_requests_total\` samples.

## Docs

### \`docs/guides/e2e-testing.md\` (NEW)

Full operator guide:

- Quick start (build + venv + run).
- Architecture diagram (subprocess lifecycle + assertion flow).
- Trace-id correlation explanation (depends on PR #114 / Loop E2E-L1a).
- **Debug endpoint contract** with the production-safety call-out.
- Judge collector lifecycle diagram (sync POST → async worker → verdict → poll).
- Degraded-mode handling.
- Shadow-mode signal.
- Failure-message anatomy.
- File map.

## Test plan

- [x] \`cargo test -p llmtrace --bin llmtrace-proxy\` — **11/11 ok** (4 new debug-endpoint tests + 7 pre-existing).
- [x] \`cargo clippy --workspace -- -D warnings\` — clean.
- [x] \`cargo fmt --check\` — clean.
- [x] \`pytest tests/e2e/ -v\` — **28/28 ok in ~45 s**.
  - 3 integration scenarios (dan, xstest, base64) including verdict polling on the two malicious ones.
  - 25 observer unit tests (was 18 in L4; +7 for the L5 helpers).
- [x] L1a trace-id round-trip verified end-to-end: harness sends \`X-LLMTrace-Trace-Id\`, proxy honours it, judge persists verdict under the same id, poller retrieves it. (Initial run failed because of stale \`target/release/llmtrace-proxy\` predating L1a; rebuilt and re-verified.)

## Notes / discoveries

- **\`action_router.enabled\` is the gating flag** — not just \`judge.enabled\`. The judge worker only spawns when the router has the channel receiver to hand it. Documented in the e2e-testing guide.
- **Stack rebased once during this loop** — when L1a (#114) merged, the L2→L3→L4→L5 chain (which had been branched off main pre-L1a) was rebased onto the new main so the trace-id header support actually compiled into the test binaries.

## Unblocks

- Loop E2E-L6 (#96) — formalises the per-comparator \`if\` blocks in \`test_cascade.py\` into the expectation DSL.
- Loop E2E-L8 (#98) — upstream-fell-for-it detector slots into the same per-scenario assertion path.