### PR TITLE
ops(judge): golden-set drift alerts + runbook (#66 T4)

### DIFF
--- a/deployments/helm/llmtrace/templates/prometheusrule.yaml
+++ b/deployments/helm/llmtrace/templates/prometheusrule.yaml
@@ -49,4 +49,56 @@ spec:
           annotations:
             summary: "LLMTrace critical finding rate is high"
             description: "Critical security findings exceeded 10 per minute."
+        # ---- Judge golden-set drift (#66 T4) -----------------------------
+        # Updated by GET /debug/judge/golden_set/replay; the nightly
+        # cron in CronJob `llmtrace-judge-golden-set-replay` calls it.
+        # Floors mirror crates/llmtrace-security/tests/judge_golden_set.rs::alignment_floor.
+        - alert: LLMTraceJudgeGoldenSetAlignmentDrift
+          expr: |
+            llmtrace_judge_golden_set_alignment{category="prompt_injection"} < 0.85
+            or
+            llmtrace_judge_golden_set_alignment{category="jailbreak"}        < 0.85
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "LLMTrace judge golden-set alignment dropped below floor"
+            description: |
+              Per-category alignment between the security analyzer and
+              the curated golden set has been below the 0.85 floor for
+              15 minutes. The fast detection tier is drifting; new
+              regex / ML weights or a corpus drift may be the cause.
+            runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/
+        - alert: LLMTraceJudgeGoldenSetFprDrift
+          expr: llmtrace_judge_golden_set_false_positive_rate > 0.25
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "LLMTrace judge golden-set false-positive rate exceeded ceiling"
+            description: |
+              The benign-fixture false-positive rate has been above the
+              0.25 ceiling for 15 minutes. The detector is over-flagging;
+              recent regex tightening or a new ML model is the likely
+              culprit.
+            runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/
+        - alert: LLMTraceJudgeGoldenSetReplayStale
+          expr: |
+            time()
+              - max by (category) (
+                  timestamp(llmtrace_judge_golden_set_alignment)
+                )
+              > 86400
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "LLMTrace judge golden-set replay has not run in 24h"
+            description: |
+              The /debug/judge/golden_set/replay endpoint has not
+              updated the alignment gauges in over 24 hours. Either
+              the nightly CronJob is failing, the LLMTRACE_GOLDEN_SET_PATH
+              env var is unset on the running proxy, or
+              server.debug_endpoints is OFF in production.
+            runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/
 {{- end }}

--- a/docs/runbooks/judge-golden-set-drift.md
+++ b/docs/runbooks/judge-golden-set-drift.md
@@ -1,0 +1,177 @@
+# Judge Golden-Set Drift — Operator Runbook
+
+This runbook covers the three alerts emitted by the LLMTrace Helm chart's PrometheusRule for the **judge golden-set calibration loop** (issue [#66][66]):
+
+| Alert | Triggers when | Severity |
+|---|---|---|
+| `LLMTraceJudgeGoldenSetAlignmentDrift` | per-category alignment < 0.85 for 15 min | warning |
+| `LLMTraceJudgeGoldenSetFprDrift` | per-category false-positive rate > 0.25 for 15 min | warning |
+| `LLMTraceJudgeGoldenSetReplayStale` | gauges not updated in 24h | warning |
+
+[66]: https://github.com/epappas/llmtrace/issues/66
+
+## Background
+
+The **golden set** (`crates/llmtrace-security/fixtures/judge_golden_set/`) is a small, hand-curated corpus where every entry is a known-good or known-bad example we expect the security analyzer to agree with deterministically. Drift in the fast tier (regex / DeBERTa) shows up here first, before it shows up in production findings counts or in the much-noisier full benchmark corpora.
+
+The endpoint `GET /debug/judge/golden_set/replay` (see [E2E testing guide](../guides/e2e-testing.md#get-debugjudgegoldenset-replay)) loads every fixture, runs each prompt through the configured `state.security` analyzer, and updates two Prometheus gauges:
+
+- `llmtrace_judge_golden_set_alignment{category=...}` — fraction of `is_threat=true` fixtures the analyzer flagged
+- `llmtrace_judge_golden_set_false_positive_rate{category=...}` — fraction of `is_threat=false` fixtures the analyzer flagged
+
+The PrometheusRule alerts on these gauges. The alert thresholds (`0.85`, `0.25`) mirror the per-category floor / ceiling pinned in `crates/llmtrace-security/tests/judge_golden_set.rs::alignment_floor` and `false_positive_ceiling`. Keep them in sync.
+
+---
+
+## 1. `LLMTraceJudgeGoldenSetAlignmentDrift`
+
+**Symptom**: Alignment for at least one category dropped below 0.85.
+
+**Most common causes** (in order of frequency):
+
+1. **Detector tier weakened** — a recent regex change, a new DeBERTa weight rev, or a feature-flag flip relaxed the fast tier. The golden set is now flagging fewer of the prompts it used to catch.
+2. **Corpus drift** — somebody added new fixtures the fast tier doesn't yet cover. Expected during initial corpus growth; not expected once a category is stable.
+3. **Stale gauge** — the replay endpoint hasn't run in a while and the gauge reflects an old run when the corpus was different. Confirm with `LLMTraceJudgeGoldenSetReplayStale`.
+
+### Diagnose
+
+```bash
+# Identify the failing category from the alert.
+PROXY=https://proxy.example.com   # or kubectl port-forward
+curl -s "${PROXY}/debug/judge/golden_set/replay" | jq .
+
+# The response includes per-category alignment + a list of disagreeing fixture ids:
+# {
+#   "categories": [
+#     {"category": "jailbreak", "n_threats": 8, "agreed": 6, "alignment_rate": 0.75, ...}
+#   ],
+#   "disagreement_ids": ["gs-jb-003", "gs-jb-005"]
+# }
+```
+
+Then re-run the offending fixtures locally against the analyzer to confirm:
+
+```bash
+cargo test -p llmtrace-security --test judge_golden_set -- --nocapture 2>&1 \
+  | grep "\[golden_set\]"
+# [golden_set] category=jailbreak n=8 agreed=6 rate=0.750 floor=0.850
+```
+
+Read the disagreement-ids' fixture files (`crates/llmtrace-security/fixtures/judge_golden_set/<category>/<id>.json`) — each carries a `rationale` field documenting why the prompt is in the corpus.
+
+### Mitigate
+
+- **If a recent regex / model change is the cause**: revert or refine the change. The golden-set is the calibration check the change should have passed in CI; that it didn't means the floor is too loose or the test was bypassed.
+- **If new fixtures expose a real gap**: tighten the regex / retrain the ML tier to cover the gap, then re-run the replay endpoint to clear the alert. **Do not lower the alignment floor** without a documented rationale in the PR — the floor is the contract.
+- **If the gauge is stale**: see section 3.
+
+---
+
+## 2. `LLMTraceJudgeGoldenSetFprDrift`
+
+**Symptom**: False-positive rate against benign fixtures exceeded 0.25 for 15 min.
+
+**Most common causes**:
+
+1. **Detector tier tightened** — a regex was widened or an ML threshold lowered, and the analyzer now flags benign content.
+2. **Benign-fixture corpus extended** — somebody added benign fixtures that resemble attacks (e.g. legitimate questions about security). The detector legitimately can't distinguish without more context.
+
+### Diagnose
+
+```bash
+curl -s "${PROXY}/debug/judge/golden_set/replay" | jq '.categories[] | {category, false_positive_rate, false_positives, n_benign}'
+```
+
+The disagreement-ids list includes both *missed threats* AND *false positives*; cross-reference with `is_threat=false` in the fixture JSON to find the false positives.
+
+### Mitigate
+
+- **If a regex was over-widened**: tighten or add a context-sensitive guard.
+- **If a new benign fixture is genuinely ambiguous**: that's the calibration loop's purpose. Either (a) split the fixture into clearly-benign and clearly-attack variants, (b) raise the ceiling above 0.25 with a documented PR rationale, or (c) move the fixture to the `over_defense` category where higher FPR is expected.
+
+---
+
+## 3. `LLMTraceJudgeGoldenSetReplayStale`
+
+**Symptom**: the replay endpoint has not updated the alignment gauges in over 24 hours.
+
+**Most common causes**:
+
+1. **Nightly CronJob is failing** — check Kubernetes job status.
+2. **`LLMTRACE_GOLDEN_SET_PATH` is unset** on the running proxy — the endpoint returns 503 and the gauges never update.
+3. **`server.debug_endpoints: false`** — the endpoint isn't even mounted in production. **Intentional** (debug routes return data un-auth-gated by trace_id; production must not enable them) — in that case run the replay against a staging proxy or a local instance and ship the alignment via a different metric pipeline.
+
+### Diagnose
+
+```bash
+# 1. Check CronJob status (if you ship the recommended cron).
+kubectl get cronjob -n llmtrace llmtrace-judge-golden-set-replay
+kubectl logs -n llmtrace -l job-name=llmtrace-judge-golden-set-replay --tail=100
+
+# 2. Hit the endpoint directly. A 503 tells you the env var is unset.
+curl -i "${PROXY}/debug/judge/golden_set/replay"
+
+# 3. Confirm the proxy was started with debug endpoints enabled.
+kubectl exec -n llmtrace deploy/llmtrace-proxy -- \
+  env | grep -E '^LLMTRACE_(GOLDEN_SET_PATH|DEBUG)'
+# also check the running config:
+kubectl exec -n llmtrace deploy/llmtrace-proxy -- \
+  cat /etc/llmtrace/config.yaml | grep -A2 server:
+```
+
+### Mitigate
+
+- **If the CronJob failed**: triage the job log. Common failures are network / DNS issues hitting `/debug/...` or the proxy returning 503 because of (2) below.
+- **If `LLMTRACE_GOLDEN_SET_PATH` is unset**: set it via the Helm chart values (`extraEnv`) or the deployment spec. The path must point at a directory shipped alongside the binary — the recommended layout is to bake the fixtures into a sidecar ConfigMap or a baked-in image path like `/etc/llmtrace/golden_set/`.
+- **If `server.debug_endpoints: false` in production** (the right default): silence this alert in production and run the replay loop in staging only. The drift question is *"is the analyzer drifting"* — that question doesn't need production data; the calibration corpus is the same everywhere.
+
+---
+
+## How the alerts are wired
+
+The PrometheusRule lives in the LLMTrace Helm chart at `deployments/helm/llmtrace/templates/prometheusrule.yaml` and is gated on:
+
+```yaml
+monitoring:
+  enabled: true
+  prometheusRule:
+    enabled: true
+```
+
+Alert thresholds in the Helm chart **must equal** the per-category floor / ceiling in the integration test (`crates/llmtrace-security/tests/judge_golden_set.rs`). When you change one, change the other in the same PR. The alerts have `runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/` so this page is reachable from the PagerDuty / Alertmanager UI.
+
+## Recommended cron
+
+The replay endpoint is intended to be invoked periodically (the gauges only update on call). Ship a Kubernetes CronJob alongside the Helm release:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: llmtrace-judge-golden-set-replay
+spec:
+  schedule: "*/30 * * * *"          # every 30 minutes
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: replay
+              image: curlimages/curl:8.10.1
+              args:
+                - -fsS
+                - http://llmtrace-proxy.llmtrace.svc.cluster.local/debug/judge/golden_set/replay
+          restartPolicy: OnFailure
+```
+
+The 30-minute cadence is well below the 15-min `for:` window of the drift alerts and the 24h staleness window — a single failed run stays under the threshold; two consecutive failures trip `LLMTraceJudgeGoldenSetReplayStale`.
+
+---
+
+## Related
+
+- Issue [#66 — Judge reliability patterns][66]
+- E2E framework guide: [`docs/guides/e2e-testing.md`](../guides/e2e-testing.md)
+- Integration test source: [`crates/llmtrace-security/tests/judge_golden_set.rs`](https://github.com/epappas/llmtrace/blob/main/crates/llmtrace-security/tests/judge_golden_set.rs)
+- Loader / replay implementation: [`crates/llmtrace-security/src/golden_set.rs`](https://github.com/epappas/llmtrace/blob/main/crates/llmtrace-security/src/golden_set.rs)
+- Endpoint handler: [`crates/llmtrace-proxy/src/debug.rs`](https://github.com/epappas/llmtrace/blob/main/crates/llmtrace-proxy/src/debug.rs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
       - Secrets Management: deployment/secrets-management.md
   - Operations:
       - Feature Flags: runbooks/feature-flags.md
+      - Judge Golden-Set Drift: runbooks/judge-golden-set-drift.md
       - Dashboard Features: dashboard-features.md
   - Architecture:
       - System Architecture: architecture/SYSTEM_ARCHITECTURE.md


### PR DESCRIPTION
## Summary

Closes the calibration loop started in T3a-T3c by alerting on the gauges the replay endpoint updates. Three new alerts join the existing PrometheusRule under the same chart toggle.

**Stacked on**: #133 (T3c — endpoint + gauges).

## New alerts

All in \`deployments/helm/llmtrace/templates/prometheusrule.yaml\`, gated on \`monitoring.enabled\` + \`monitoring.prometheusRule.enabled\`:

| Alert | Threshold | For | Severity |
|---|---|---|---|
| \`LLMTraceJudgeGoldenSetAlignmentDrift\` | per-category alignment < 0.85 | 15m | warning |
| \`LLMTraceJudgeGoldenSetFprDrift\` | per-category FPR > 0.25 | 15m | warning |
| \`LLMTraceJudgeGoldenSetReplayStale\` | gauges not updated in 24h | 1h | warning |

The alignment / FPR thresholds **mirror exactly** the per-category floor / ceiling pinned in \`tests/judge_golden_set.rs\` so a regression that trips CI also trips the runtime alert. All three alerts carry \`runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/\` so PagerDuty / Alertmanager links straight to the operator guide.

## Runbook

\`docs/runbooks/judge-golden-set-drift.md\`:

- Background on the golden set, the gauges it feeds, and why drift here lands before drift in production findings counts
- One section per alert: most common causes (ranked), diagnose commands (\`curl\` + \`cargo test\`), mitigation choices
- Production-safety call-out: \`debug_endpoints\` is intentionally off in production; the calibration loop runs in staging
- Recommended Kubernetes CronJob YAML (every 30 min — well inside the 15m-for and 24h-stale windows; one failed run stays under the threshold)
- Cross-links to the test source, the loader, and the endpoint so operators can trace from alert → code → fix

## Test plan

- [x] \`helm template\` renders the chart and confirms all three alerts present in the rendered PrometheusRule
- [x] \`mkdocs build --strict\` passes with the new runbook in nav (zero warnings)
- [x] \`runbook_url\` annotation on every alert links to the new doc

## What's left of #66

Everything. T1+T2 (#129) merged. T3a+T3b (#132), T3c (#133), and this PR (T4) close out the issue. Once all three are merged we can close #66.