### PR TITLE
fix(dashboard): override transitive postcss to ^8.5.10 (CI Security Audit)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -36,7 +36,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^9.0.0",
         "eslint-config-next": "^15.5.10",
-        "postcss": "^8.5.3",
+        "postcss": "^8.5.10",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.2"
       }
@@ -5635,34 +5635,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -6010,9 +5982,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -39,8 +39,11 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.5.10",
-    "postcss": "^8.5.3",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.2"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Why CI is broken on main

The Security Audit job has been failing on main since the #134 merge and again after #135 because:

\`\`\`
postcss <8.5.10
Severity: moderate
node_modules/next/node_modules/postcss
\`\`\`

Dependabot's #135 patched dashboard's **top-level** postcss devDependency to 8.5.10, but Next.js bundles its own nested postcss 8.4.31 in \`node_modules/next/node_modules/postcss\`. \`npm audit\` scans the transitive tree and keeps finding it.

\`npm audit fix --force\` would downgrade Next to 9.3.3 (breaking change). The right fix is npm's \`overrides\` field which forces *every* postcss resolution to >= 8.5.10 across the whole tree, including Next's nested copy.

## Verified locally

\`\`\`
$ cd dashboard && npm audit
found 0 vulnerabilities

$ cd crates/llmtrace-nodejs && npm audit
found 0 vulnerabilities
\`\`\`

## Test plan

- [x] Both \`npm audit\` targets clean locally
- [ ] CI Security Audit goes green on this PR
- [ ] Squash-merge → main CI Security Audit goes green

## Why this happens — and how to avoid it next time

Recording in my session memory: when a Dependabot PR for a dashboard / Node.js package merges, the next \`npm audit\` run can still fail because the transitive tree was not regenerated and a vulnerable nested copy may persist. The lockfile + \`overrides\` field is the canonical fix.