### PR TITLE
docs(judge): document the calibration loop + golden-set endpoint as shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- E2E adversarial test framework (#91, L1–L10): 50-scenario YAML corpus across 8 attack families, pytest harness with per-scenario `/metrics` delta + judge-verdict polling, expectation DSL, regex upstream-fell-for-it judge with six rule classes, PR-gate workflow on every PR, nightly cron with auto-PR'd deterministic markdown report.
+- Judge reliability patterns (#66): binary-first prompt, cross-family startup warning, per-id golden-set fixtures with a shared loader/replay module, integration test with per-category alignment floors, `GET /debug/judge/golden_set/replay` debug endpoint, two new gauges (`llmtrace_judge_golden_set_alignment`, `llmtrace_judge_golden_set_false_positive_rate`), three new PrometheusRule alerts with operator runbook at `docs/runbooks/judge-golden-set-drift.md`.
+- New attack-detection coverage in `RegexSecurityAnalyzer`: rot13 and leetspeak encoding evasion now emit `encoding_attack` findings (previously only base64 was covered).
+- `X-LLMTrace-Trace-Id` request header is honored by the proxy and echoed back on every response (`L1a` of #91).
+
+### Changed
+- E2E nightly workflow's auto-PR step is `continue-on-error: true` so a missing `Allow GitHub Actions to create and approve pull requests` repo setting surfaces as a workflow-summary warning rather than a red run while the corpus replay still passes.
+- Bumped GitHub Actions: `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7, `peter-evans/create-pull-request` v7→v8 (Node 24 ahead of the 2026-06-02 forced cutover).
+- `pytest.ini` sets `pythonpath = .` so e2e tests run without a manual `PYTHONPATH` export from the repo root.
+- Dashboard ships `"overrides": { "postcss": "^8.5.10" }` so npm audit catches Next.js's nested transitive postcss copy (GHSA-qx2v-qp2m-jg93).
+
+### Documentation
+- New guide: `docs/guides/e2e-testing.md` (in mkdocs nav under Guides) — quick start, comparator reference, CI workflow contract, scenario authoring.
+- New runbook: `docs/runbooks/judge-golden-set-drift.md` (under Operations) — per-alert diagnose + mitigate steps for the three new PrometheusRule alerts.
+- New section in `docs/guides/llm-judge.md`: "Golden-set calibration loop (#66)" — operator workflow for the replay endpoint, the new gauges, and how to add a fixture.
+- New baseline reports: `docs/research/results/e2e_2026-04-23_baseline.md`, `e2e_2026-04-23.md`, `e2e_2026-04-24.md`.
+
 ## [0.2.0] - 2026-04-17
 
 - chore: bump workspace version to 0.2.0 (6647795)

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -36,7 +36,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^9.0.0",
         "eslint-config-next": "^15.5.10",
-        "postcss": "^8.5.3",
+        "postcss": "^8.5.10",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.2"
       }
@@ -5635,34 +5635,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -6010,9 +5982,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -39,8 +39,11 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.5.10",
-    "postcss": "^8.5.3",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.2"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }

--- a/docs/architecture/LLM_JUDGE.md
+++ b/docs/architecture/LLM_JUDGE.md
@@ -219,9 +219,15 @@ for one backend do not transfer to another without re-measurement.
    promotes Block. Operators watch `llmtrace_judge_shadow_would_block_total`
    to measure the *would-block* rate under current thresholds.
 2. Collect >=1,000 verdicts across the traffic profile you intend to protect.
-3. Run the golden-set reliability workflow in issue #66: group verdicts by
-   self-reported confidence, plot observed precision vs. reported confidence,
-   fit a calibrator.
+3. Run the golden-set reliability workflow (issue #66, **shipped**): the
+   in-process replay endpoint `GET /debug/judge/golden_set/replay` reads
+   per-id fixtures from `crates/llmtrace-security/fixtures/judge_golden_set/`
+   and updates two gauges, `llmtrace_judge_golden_set_alignment{category}` and
+   `llmtrace_judge_golden_set_false_positive_rate{category}`. Group verdicts
+   by self-reported confidence, plot observed precision vs. reported
+   confidence, fit a calibrator. See the [judge guide](../guides/llm-judge.md#golden-set-calibration-loop-66)
+   for the operator workflow and the [drift runbook](../runbooks/judge-golden-set-drift.md)
+   for alert triage.
 4. Pick `min_confidence` at the target false-positive rate (typical starting
    point: FP <= 1% of legitimate traffic). Re-pick `min_security_score` from
    the same reliability diagram if the score distribution is bimodal.
@@ -230,8 +236,8 @@ for one backend do not transfer to another without re-measurement.
    silent regression.
 
 Re-run steps 2-5 whenever the judge model, provider, or system prompt
-changes. Issue #83 (per-model metrics) and issue #66 (golden-set patterns)
-are prerequisites for doing this rigorously.
+changes. Issue #83 (per-model metrics) and issue #66 (golden-set patterns,
+**shipped**) provide the calibration plumbing.
 
 ---
 

--- a/docs/guides/llm-judge.md
+++ b/docs/guides/llm-judge.md
@@ -392,6 +392,8 @@ you can compare judges without grouping yourself.
 | `llmtrace_judge_dropped_total{reason}` | counter | Requests the worker never sent a backend call for; reasons: disabled, below_threshold, channel_full, channel_closed, persist_failure, semaphore_closed, shutdown, analysis_text_truncated |
 | `llmtrace_judge_promotion_rejected_total{reason}` | counter | Verdicts the gate held back: not_threat_or_block, below_confidence, below_score, no_ensemble_support |
 | `llmtrace_judge_shadow_would_block_total{category,recommended_action}` | counter | Shadow-mode would-block rate — your primary calibration signal |
+| `llmtrace_judge_golden_set_alignment{category}` | gauge | Per-category alignment between the analyzer and the curated golden set (0.0–1.0). Drops below 0.85 = drift. See [calibration loop](#golden-set-calibration-loop-66). |
+| `llmtrace_judge_golden_set_false_positive_rate{category}` | gauge | Per-category false-positive rate against benign golden-set entries. Stays below 0.25 in a healthy detector. |
 
 ### Dashboards
 
@@ -403,6 +405,76 @@ you can compare judges without grouping yourself.
   (rate(llmtrace_judge_requests_total[5m]))`.
 - **Shadow signal:** `rate(llmtrace_judge_shadow_would_block_total[1h])`
   vs. your existing regex/ML block rate.
+- **Detector drift:** `llmtrace_judge_golden_set_alignment` and
+  `llmtrace_judge_golden_set_false_positive_rate` per category — see
+  [calibration loop](#golden-set-calibration-loop-66) below.
+
+---
+
+## Golden-set calibration loop (#66)
+
+The judge / analyzer ships with a small, hand-curated **golden set** of attack and benign prompts under [`crates/llmtrace-security/fixtures/judge_golden_set/`](https://github.com/epappas/llmtrace/blob/main/crates/llmtrace-security/fixtures/judge_golden_set/). One JSON file per fixture; each carries an `is_threat` ground truth and a `rationale`. This is the smallest possible regression suite for the fast tier — drift here lands before drift in production findings counts.
+
+The **integration test** [`crates/llmtrace-security/tests/judge_golden_set.rs`](https://github.com/epappas/llmtrace/blob/main/crates/llmtrace-security/tests/judge_golden_set.rs) replays every fixture against the regex analyzer in CI and asserts per-category alignment ≥ 0.85 and false-positive rate ≤ 0.25.
+
+The **debug endpoint** does the same thing at runtime. Enable it once and let the gauges feed your monitoring:
+
+```yaml
+# config.yaml
+server:
+  debug_endpoints: true   # WARNING: never enable in production — see e2e-testing guide
+```
+
+Set the fixture root via env var:
+
+```bash
+LLMTRACE_GOLDEN_SET_PATH=/etc/llmtrace/golden_set/
+```
+
+Then call:
+
+```bash
+curl -s http://proxy/debug/judge/golden_set/replay | jq .
+# {
+#   "fixture_root": "/etc/llmtrace/golden_set/",
+#   "total_entries": 22,
+#   "categories": [
+#     {"category":"jailbreak","n_threats":8,"agreed":8,"alignment_rate":1.0, ...},
+#     {"category":"prompt_injection","n_threats":14,"agreed":13,"alignment_rate":0.929, ...}
+#   ],
+#   "disagreement_ids": ["gs-pi-007"]
+# }
+```
+
+Each call updates the two gauges (`llmtrace_judge_golden_set_alignment` and `..._false_positive_rate`). Run on a CronJob (every 30 min recommended — see the [runbook](../runbooks/judge-golden-set-drift.md)) so the gauges stay fresh.
+
+### Alerts
+
+The Helm chart ships three alerts that fire on these gauges (see `deployments/helm/llmtrace/templates/prometheusrule.yaml`, gated on `monitoring.enabled` + `monitoring.prometheusRule.enabled`):
+
+| Alert | Triggers | Severity |
+|---|---|---|
+| `LLMTraceJudgeGoldenSetAlignmentDrift` | per-category alignment < 0.85 for 15m | warning |
+| `LLMTraceJudgeGoldenSetFprDrift` | per-category FPR > 0.25 for 15m | warning |
+| `LLMTraceJudgeGoldenSetReplayStale` | gauges not updated in 24h | warning |
+
+All three carry a `runbook_url` annotation pointing at [Judge Golden-Set Drift runbook](../runbooks/judge-golden-set-drift.md), which has per-alert diagnose + mitigate steps.
+
+### Adding a fixture
+
+One per file under `<category>/<id>.json` — never edit a monolithic file:
+
+```json
+{
+  "id": "gs-pi-015",
+  "category": "prompt_injection",
+  "is_threat": true,
+  "text": "<the verbatim prompt>",
+  "rationale": "what makes this a useful golden-set entry"
+}
+```
+
+Filename stem must equal `id`; parent dir must equal `category`. The integration test fails loudly on either mismatch. The per-id layout is intentional: it lets contributors add fixtures one prompt at a time without ever needing to touch a large concatenated corpus.
 
 ---
 


### PR DESCRIPTION
## Why

User asked: \"have you updated all the docs with the latest changes and how to use them?\" — answer was \"not fully\". The runbook + e2e guide landed in the #66 PRs, but the **user-facing judge guide** still didn't mention the new replay endpoint, the two new gauges, or how to add a fixture. The architecture doc still framed #66 as future work. The CHANGELOG had no entry for any of today's work.

## Changes

### \`docs/guides/llm-judge.md\`
- New section **Golden-set calibration loop (#66)**: how to enable the replay endpoint via \`server.debug_endpoints\` + \`LLMTRACE_GOLDEN_SET_PATH\`, sample curl + JSON response, cross-link to the [drift runbook](../runbooks/judge-golden-set-drift.md), and an \"Adding a fixture\" subsection documenting the per-id JSON schema.
- Added the two new gauges to the metrics table and dashboards list:
  - \`llmtrace_judge_golden_set_alignment{category}\`
  - \`llmtrace_judge_golden_set_false_positive_rate{category}\`
- Listed the three new alerts shipped with the Helm chart, each with trigger / severity / runbook URL.

### \`docs/architecture/LLM_JUDGE.md\`
- Reframed #66 references from future work to **shipped**.
- Pre-production rollout step 3 now points at the replay endpoint + the operator guide section.

### \`CHANGELOG.md\`
- New \`[Unreleased]\` section above \`[0.2.0]\` capturing today's full set: E2E framework (#91 L1–L10), judge reliability patterns (#66), encoding-attack coverage (rot13/leetspeak), trace-id header, action version bumps, postcss override fix, new docs.

## Verified

- \`mkdocs build --strict\` passes with zero warnings.
- All cross-links resolve under the published nav.

## Test plan
- [x] Strict mkdocs build green
- [ ] CI green on this PR