### PR TITLE
ops(e2e): wire LLMUpstreamJudge into nightly via secret-gated env (#123)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -78,8 +78,24 @@ jobs:
           # whether or not the secret is configured.
           LLMTRACE_E2E_REAL_UPSTREAM_URL: ${{ secrets.LLMTRACE_E2E_REAL_UPSTREAM_URL }}
           LLMTRACE_JUDGE_OPENAI_API_KEY: ${{ secrets.LLMTRACE_JUDGE_OPENAI_API_KEY }}
+          # LLM-backed upstream-fell-for-it judge (#123). The judge is
+          # auto-enabled when ANTHROPIC_API_KEY is configured as a repo
+          # secret; without it the harness keeps the regex baseline so
+          # the nightly never breaks on a missing secret.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LLMTRACE_E2E_UPSTREAM_JUDGE_MODEL: claude-haiku-4-5
+          LLMTRACE_E2E_UPSTREAM_JUDGE_COST_CAP_USD: "0.50"
         run: |
           mkdir -p out
+          # Defensive gate: only flip to the LLM judge when its
+          # credential is present. RegexUpstreamJudge stays the
+          # fallback so the workflow degrades gracefully.
+          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            export LLMTRACE_E2E_UPSTREAM_JUDGE=llm
+            echo "::notice title=Upstream judge::LLMUpstreamJudge (model=${LLMTRACE_E2E_UPSTREAM_JUDGE_MODEL}, cap=\$${LLMTRACE_E2E_UPSTREAM_JUDGE_COST_CAP_USD})"
+          else
+            echo "::notice title=Upstream judge::RegexUpstreamJudge (ANTHROPIC_API_KEY secret not set; LLM backend skipped)"
+          fi
           # `|| true` so the report still generates on test failures —
           # a regression IS the report's reason to exist.
           python3 -m pytest tests/e2e/test_cascade.py \


### PR DESCRIPTION
## Summary

Activates the `LLMUpstreamJudge` shipped in #139 inside the nightly workflow. Defensive — only flips to the LLM judge when `ANTHROPIC_API_KEY` is configured as a repo secret; otherwise stays on the regex baseline.

- Model: `claude-haiku-4-5` (cheapest tier; ~\$0.001/call with prompt caching)
- Per-session cap: **\$0.50** (50 scenarios * ~\$0.001 = ~\$0.05 expected; cap is the safety margin, not the budget)
- Workflow run logs include a notice annotation naming which judge is active so the choice is visible without grepping harness output

## Why secret-gated rather than required

If we hard-required `ANTHROPIC_API_KEY` and the secret weren't present, the `LLMUpstreamJudge` constructor would raise on first `select_judge()` call and crash the entire test session. The secret-gated pattern means:

- This PR can merge **before** the secret is added — the nightly stays on regex (today's behavior, zero regression).
- The moment you add `ANTHROPIC_API_KEY` to repo Secrets, the next 03:00 UTC nightly auto-picks it up.
- No two-step coordination required.

## Operator action required (one-time)

Add `ANTHROPIC_API_KEY` to repo Secrets (Settings → Secrets and variables → Actions → New repository secret). Until then the nightly notice will read:

> Upstream judge: RegexUpstreamJudge (ANTHROPIC_API_KEY secret not set; LLM backend skipped)

After the secret is set:

> Upstream judge: LLMUpstreamJudge (model=claude-haiku-4-5, cap=\$0.50)

## Test plan

- [x] YAML lint passes (`python -c \"import yaml; yaml.safe_load(...)\"`).
- [ ] CI green on this branch.
- [ ] After merge + secret addition: trigger one `workflow_dispatch` run to verify the LLM-judge code path end-to-end before tomorrow's scheduled run.

## Out of scope

- Adding a second `workflow_dispatch` input for the upstream-judge cost cap (current cap is hard-coded at \$0.50; trivial to parameterise later if needed).
- Updating the calibration corpus / prompt — separate iteration once we see real disagreement-rate numbers from the first nightly.