### PR TITLE
ops(e2e): wire LLMUpstreamJudge into nightly via Moonshot/Kimi K2.6 (#123)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -78,8 +78,32 @@ jobs:
           # whether or not the secret is configured.
           LLMTRACE_E2E_REAL_UPSTREAM_URL: ${{ secrets.LLMTRACE_E2E_REAL_UPSTREAM_URL }}
           LLMTRACE_JUDGE_OPENAI_API_KEY: ${{ secrets.LLMTRACE_JUDGE_OPENAI_API_KEY }}
+          # LLM-backed upstream-fell-for-it judge (#123). Auto-enabled
+          # when MOONSHOT_API_KEY is configured as a repo secret. Without
+          # it the harness keeps the regex baseline so the nightly never
+          # breaks on a missing secret. Calibration evidence committed
+          # at docs/research/results/upstream_judge_calibration_kimi-k2-6_2026-04-28.md
+          # — kimi-k2.6 hit 12/12 = 100% vs regex's 10/12 = 83.3% at
+          # ~$0.0016/call, so per-session cap of $0.50 is a safety margin
+          # not a budget.
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          LLMTRACE_E2E_UPSTREAM_JUDGE_BACKEND: openai
+          LLMTRACE_E2E_UPSTREAM_JUDGE_MODEL: kimi-k2.6
+          LLMTRACE_E2E_UPSTREAM_JUDGE_BASE_URL: https://api.moonshot.ai/v1
+          LLMTRACE_E2E_UPSTREAM_JUDGE_API_KEY_ENV: MOONSHOT_API_KEY
+          LLMTRACE_E2E_UPSTREAM_JUDGE_COST_CAP_USD: "0.50"
         run: |
           mkdir -p out
+          # Defensive gate: only flip to the LLM judge when its
+          # credential is present. RegexUpstreamJudge stays the
+          # fallback so the workflow degrades gracefully when no
+          # secret is configured.
+          if [ -n "${MOONSHOT_API_KEY:-}" ]; then
+            export LLMTRACE_E2E_UPSTREAM_JUDGE=llm
+            echo "::notice title=Upstream judge::LLMUpstreamJudge (backend=${LLMTRACE_E2E_UPSTREAM_JUDGE_BACKEND}, model=${LLMTRACE_E2E_UPSTREAM_JUDGE_MODEL}, cap=\$${LLMTRACE_E2E_UPSTREAM_JUDGE_COST_CAP_USD})"
+          else
+            echo "::notice title=Upstream judge::RegexUpstreamJudge (MOONSHOT_API_KEY secret not set; LLM backend skipped)"
+          fi
           # `|| true` so the report still generates on test failures —
           # a regression IS the report's reason to exist.
           python3 -m pytest tests/e2e/test_cascade.py \


### PR DESCRIPTION
## Summary

Activates the openai-compatible `LLMUpstreamJudge` backend (shipped in #144) inside the nightly workflow, pointed at `api.moonshot.ai` with `kimi-k2.6` as the model. Supersedes the closed PR #140 (Anthropic-only) since Moonshot is the operator's chosen gateway.

Defensive: only flips to the LLM judge when `MOONSHOT_API_KEY` is configured as a repo secret; otherwise stays on the regex baseline.

## Configuration

```yaml
MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
LLMTRACE_E2E_UPSTREAM_JUDGE_BACKEND: openai
LLMTRACE_E2E_UPSTREAM_JUDGE_MODEL: kimi-k2.6
LLMTRACE_E2E_UPSTREAM_JUDGE_BASE_URL: https://api.moonshot.ai/v1
LLMTRACE_E2E_UPSTREAM_JUDGE_API_KEY_ENV: MOONSHOT_API_KEY
LLMTRACE_E2E_UPSTREAM_JUDGE_COST_CAP_USD: "0.50"
```

## Why secret-gated rather than required

If we hard-required `MOONSHOT_API_KEY` and the secret weren't present, the `LLMUpstreamJudge` constructor would raise on first `select_judge()` call and crash the entire test session. The secret-gated pattern means:

- This PR can merge **before** the secret is added — the nightly stays on regex (today's behavior, zero regression).
- The moment you add `MOONSHOT_API_KEY` to repo Secrets, the next 03:00 UTC nightly auto-picks it up.
- No two-step coordination required.

## Calibration evidence (already committed)

`docs/research/results/upstream_judge_calibration_kimi-k2-6_2026-04-28.md`:

| Judge | Correct | Total | Accuracy |
|---|---:|---:|---:|
| Regex | 10 | 12 | 83.3% |
| LLM (`kimi-k2.6`) | 12 | 12 | 100.0% |

12 real Moonshot API calls, **\$0.019 total spend** (avg \$0.0016/call). Same two regex blind spots exposed as the Anthropic-haiku run on 2026-04-25. Per-session cap of \$0.50 is a safety margin, not a budget — expected nightly spend is ~\$0.08 across 50 scenarios.

## Operator action required (one-time)

Add `MOONSHOT_API_KEY` to repo Secrets (Settings → Secrets and variables → Actions → New repository secret). **Use a fresh key**, not the ephemeral one used during calibration — that one was logged in command lines and should be considered compromised.

Until the secret is set, the nightly notice will read:

> Upstream judge: RegexUpstreamJudge (MOONSHOT_API_KEY secret not set; LLM backend skipped)

After the secret is set:

> Upstream judge: LLMUpstreamJudge (backend=openai, model=kimi-k2.6, cap=\$0.50)

## Test plan

- [x] YAML lint passes (`python -c \"import yaml; yaml.safe_load(...)\"`).
- [x] Backend wiring covered by 53 unit tests in #144 (no live API in CI).
- [x] Live calibration against `kimi-k2.6` proved end-to-end: 12/12 accuracy at \$0.019.
- [ ] CI green on this branch.
- [ ] After merge + secret addition: trigger one `workflow_dispatch` run to verify the LLM-judge code path end-to-end before the next scheduled run.

## Out of scope

- Adding a second `workflow_dispatch` input for the upstream-judge cost cap (current cap is hard-coded at \$0.50; trivial to parameterise later if needed).
- Updating the calibration corpus / prompt — separate iteration once we see real disagreement-rate numbers from the first nightly.