### PR TITLE
docs(boundary): flag §7.3 integration tests as pending, link #149

### DIFF
--- a/docs/architecture/BOUNDARY_TOKEN_DEFENSE.md
+++ b/docs/architecture/BOUNDARY_TOKEN_DEFENSE.md
@@ -610,6 +610,11 @@ Each test validates a specific functional requirement.
 
 ### 7.3 Integration Tests (`tests/integration_test.rs`)
 
+> **Status: pending — tracked in [#149](https://github.com/epappas/llmtrace/issues/149).**
+> Will land bundled with IS-060 PR 1, which exercises the same proxy-handler path.
+> The unit tests in §7.1 and §7.2 are present and passing; only these
+> proxy-handler integration tests are missing.
+
 | Test | Validates | Pass Criteria |
 |------|-----------|---------------|
 | `test_boundary_defense_modifies_upstream_body` | FR-01, FR-06 | Mock upstream receives wrapped content; Content-Length matches |
@@ -647,7 +652,7 @@ The feature is considered delivered when ALL of the following are true:
 
 1. All unit tests in `boundary.rs` pass (Section 7.1)
 2. All modified unit tests in `proxy.rs` pass (Section 7.2)
-3. All integration tests pass (Section 7.3)
+3. All integration tests pass (Section 7.3) — *pending, tracked in [#149](https://github.com/epappas/llmtrace/issues/149); will land bundled with IS-060 PR 1*
 4. E2E benchmark shows no accuracy regression (Section 7.4)
 5. Shadow mode validated for minimum 24 hours with zero serialization errors
 6. At least one contract test against a live OpenAI endpoint passes (Section 7.5)


### PR DESCRIPTION
## Summary

- Flips the BOUNDARY_TOKEN_DEFENSE.md §7.3 \"Integration Tests\" section from a claim into a forward-pointer to #149.
- Updates the §7.6 \"Delivered Success Criteria\" bullet (#3) so it no longer asserts these tests pass.

The spec content (the test list, the FRs they cover, the pass criteria) is preserved as the contract. Only the delivery-status framing changes.

## Why

The IS-060 spotlighting investigation (#148) audited the boundary-token defense and confirmed that none of the §7.3 integration tests exist in \`crates/llmtrace-proxy/tests/integration_test.rs\`:

\`\`\`
$ grep -n 'boundary\\|apply_boundary' crates/llmtrace-proxy/tests/integration_test.rs
# (no matches)
\`\`\`

The §7.1 unit tests in \`boundary.rs\` are present and passing — only the proxy-handler integration coverage is missing. #149 owns writing them; bundling with IS-060 PR 1 (zone-aware ensemble fan-out) avoids two passes through the same proxy-handler surface.

## Test plan

- [x] \`git diff\` confirmed: 6 insertions, 1 deletion, no other text touched.
- [ ] CI green (docs-only change, no code paths affected).

Issue: #149
Related: #148