### PR TITLE
docs(mkdocs): wire IS-060 batch into the public nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ exclude_docs: |
   README.md
   prompts/
   TODO.md
+  TODO_E2E.md
 
 validation:
   omitted_files: warn
@@ -159,6 +160,7 @@ nav:
       - LLM Judge: architecture/LLM_JUDGE.md
       - Judge Cascade (ADR): architecture/JUDGE_CASCADE.md
       - Boundary Token Defense: architecture/BOUNDARY_TOKEN_DEFENSE.md
+      - Spotlighting Indirect Injection (Investigation): architecture/SPOTLIGHTING_INDIRECT_INJECTION.md
       - ML Long-Input Defense: architecture/ML_LONG_INPUT_DEFENSE.md
       - DMPI Average Pooling: architecture/DMPI_001_AVERAGE_POOLING.md
       - DMPI Two FC Layers: architecture/DMPI_002_TWO_FC_LAYERS.md
@@ -201,6 +203,9 @@ nav:
           - Regex FPR Calibration: research/results/fpr_calibration_regex.md
           - E2E Baseline (2026-04-23): research/results/e2e_2026-04-23_baseline.md
           - E2E Nightly Report (2026-04-23): research/results/e2e_2026-04-23.md
+          - E2E Nightly Report (2026-04-24): research/results/e2e_2026-04-24.md
+          - E2E Nightly Report (2026-04-25): research/results/e2e_2026-04-25.md
+          - E2E Nightly Report (2026-04-28): research/results/e2e_2026-04-28.md
           - Upstream Judge Calibration (2026-04-25): research/results/upstream_judge_calibration_2026-04-25.md
           - Upstream Judge Calibration — kimi-k2.6 (2026-04-28): research/results/upstream_judge_calibration_kimi-k2-6_2026-04-28.md
           - Upstream Judge Production Evidence (2026-04-28): research/results/upstream_judge_production_evidence_2026-04-28.md


### PR DESCRIPTION
## Summary

Wires the four merged IS-060-review PRs into the public mkdocs nav.

## What changed

\`mkdocs.yml\` — three nav additions + one exclusion:

| Section | Addition | From |
|---|---|---|
| Architecture | \`Spotlighting Indirect Injection (Investigation)\` → \`architecture/SPOTLIGHTING_INDIRECT_INJECTION.md\` | #148 |
| Research → Results | \`E2E Nightly Report (2026-04-24)\` | #133 (back-fill) |
| Research → Results | \`E2E Nightly Report (2026-04-25)\` | #138 (back-fill) |
| Research → Results | \`E2E Nightly Report (2026-04-28)\` | #143 (back-fill) |
| \`exclude_docs\` | \`TODO_E2E.md\` | parity with \`TODO.md\` (working/planning doc, not for the public site) |

The 2026-04-{24,25,28} backfill catches up the nav with three nightly reports the auto-PR workflow committed without touching \`mkdocs.yml\`. Going forward, the same pattern will repeat — each nightly report needs a manual nav line. Worth flagging as a follow-up: extend the auto-PR workflow to append the new \`e2e_<date>.md\` line to \`mkdocs.yml\`. Out of scope for this PR.

## Validation

\`\`\`
$ mkdocs build --strict
INFO    -  Documentation built in 8.86 seconds
$ echo \$?
0
\`\`\`

Zero \"page exists but not in nav\" warnings. Pre-existing INFO messages about anchors in unrelated guides remain (inherited; not introduced here).

## Test plan

- [x] \`mkdocs build --strict\` clean.
- [x] \`site/architecture/SPOTLIGHTING_INDIRECT_INJECTION/index.html\` renders.
- [x] \`site/research/results/e2e_2026-04-{24,25,28}/index.html\` render.
- [ ] CI green (Build site job).

Related: #148, #150, #151, #152