### PR TITLE
feat(e2e): forward upstream auth + model env to nightly proxy

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -77,6 +77,12 @@ jobs:
           # in-process mock when unset so this workflow runs unchanged
           # whether or not the secret is configured.
           LLMTRACE_E2E_REAL_UPSTREAM_URL: ${{ secrets.LLMTRACE_E2E_REAL_UPSTREAM_URL }}
+          LLMTRACE_E2E_REAL_UPSTREAM_MODEL: ${{ secrets.LLMTRACE_E2E_REAL_UPSTREAM_MODEL }}
+          # Optional auth for real-upstream runs. Prefer the raw API-key
+          # secret; use the Authorization secret only for providers that
+          # require a non-Bearer scheme or additional header parameters.
+          LLMTRACE_E2E_REAL_UPSTREAM_API_KEY: ${{ secrets.LLMTRACE_E2E_REAL_UPSTREAM_API_KEY }}
+          LLMTRACE_E2E_REAL_UPSTREAM_AUTHORIZATION: ${{ secrets.LLMTRACE_E2E_REAL_UPSTREAM_AUTHORIZATION }}
           LLMTRACE_JUDGE_OPENAI_API_KEY: ${{ secrets.LLMTRACE_JUDGE_OPENAI_API_KEY }}
           # LLM-backed upstream-fell-for-it judge (#123). Auto-enabled
           # when MOONSHOT_API_KEY is configured as a repo secret. Without

--- a/docs/guides/e2e-testing.md
+++ b/docs/guides/e2e-testing.md
@@ -79,6 +79,8 @@ The harness boots an in-process FastAPI mock upstream by default. To point the p
 
 ```bash
 export LLMTRACE_E2E_REAL_UPSTREAM_URL=https://openrouter.ai/api/v1
+export LLMTRACE_E2E_REAL_UPSTREAM_MODEL=moonshotai/kimi-k2
+export LLMTRACE_E2E_REAL_UPSTREAM_API_KEY=...
 pytest tests/e2e/test_cascade.py -v \
   --scenario-results-json=out/scenario-results.json \
   --cost-cap-usd=2.00
@@ -86,6 +88,11 @@ pytest tests/e2e/test_cascade.py -v \
 
 The cost cap reads `llmtrace_cost_usd_total` after every scenario and aborts the session via `pytest.exit` on overrun. Unset = no cap.
 
+When `LLMTRACE_E2E_REAL_UPSTREAM_URL` is set, the harness forwards an upstream auth header if either of these is set:
+
+- `LLMTRACE_E2E_REAL_UPSTREAM_API_KEY` — sent as `Authorization: Bearer <value>`.
+- `LLMTRACE_E2E_REAL_UPSTREAM_AUTHORIZATION` — sent verbatim as `Authorization: <value>` for non-standard schemes.
+- `LLMTRACE_E2E_REAL_UPSTREAM_MODEL` — optional chat-completions model name. Defaults to `mock-model` for mock-upstream compatibility.
 
 ## Architecture
 
@@ -355,6 +362,9 @@ Cron `0 3 * * *` + `workflow_dispatch`. Runs the full 50-scenario corpus, genera
 Optional secrets:
 
 - `LLMTRACE_E2E_REAL_UPSTREAM_URL` — points the proxy at a real LLM. Without it, the workflow runs against the mock (still useful for catching harness/observer regressions).
+- `LLMTRACE_E2E_REAL_UPSTREAM_MODEL` — optional provider model name for real-upstream runs.
+- `LLMTRACE_E2E_REAL_UPSTREAM_API_KEY` — optional raw provider key for real-upstream runs; forwarded as `Authorization: Bearer ...`.
+- `LLMTRACE_E2E_REAL_UPSTREAM_AUTHORIZATION` — optional full authorization header value for real-upstream runs; use only when the provider needs a non-standard auth value.
 - `LLMTRACE_JUDGE_OPENAI_API_KEY` — wires up the judge tier's slow backend.
 
 The cost-cap fixture (`--cost-cap-usd`, default `2.0` in the nightly) reads `llmtrace_cost_usd_total` after every scenario and aborts the session on overrun.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -41,6 +41,11 @@ FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 MOCK_UPSTREAM_PATH = Path(__file__).resolve().parent / "mock_upstream.py"
 
 PROXY_BIN_ENV = "LLMTRACE_PROXY_BIN"
+REAL_UPSTREAM_URL_ENV = "LLMTRACE_E2E_REAL_UPSTREAM_URL"
+REAL_UPSTREAM_MODEL_ENV = "LLMTRACE_E2E_REAL_UPSTREAM_MODEL"
+REAL_UPSTREAM_AUTHORIZATION_ENV = "LLMTRACE_E2E_REAL_UPSTREAM_AUTHORIZATION"
+REAL_UPSTREAM_API_KEY_ENV = "LLMTRACE_E2E_REAL_UPSTREAM_API_KEY"
+DEFAULT_CHAT_MODEL = "mock-model"
 DEFAULT_PROXY_BINARIES = (
     REPO_ROOT / "target" / "release" / "llmtrace-proxy",
     REPO_ROOT / "target" / "debug" / "llmtrace-proxy",
@@ -187,6 +192,30 @@ def _terminate(process: subprocess.Popen, label: str) -> None:
         )
 
 
+def _real_upstream_authorization() -> str | None:
+    """Return an Authorization header for real-upstream e2e runs, if configured."""
+    if not os.environ.get(REAL_UPSTREAM_URL_ENV):
+        return None
+
+    explicit = os.environ.get(REAL_UPSTREAM_AUTHORIZATION_ENV, "").strip()
+    if explicit:
+        return explicit
+
+    api_key = os.environ.get(REAL_UPSTREAM_API_KEY_ENV, "").strip()
+    if api_key:
+        return f"Bearer {api_key}"
+
+    return None
+
+
+def _chat_model() -> str:
+    """Return the model name for chat requests sent through the proxy."""
+    if not os.environ.get(REAL_UPSTREAM_URL_ENV):
+        return DEFAULT_CHAT_MODEL
+
+    return os.environ.get(REAL_UPSTREAM_MODEL_ENV, DEFAULT_CHAT_MODEL).strip() or DEFAULT_CHAT_MODEL
+
+
 # ---------------------------------------------------------------------------
 # Mock upstream fixture
 # ---------------------------------------------------------------------------
@@ -243,10 +272,12 @@ class ProxyHandle:
         import requests
 
         headers = {"content-type": "application/json"}
+        if auth := _real_upstream_authorization():
+            headers["authorization"] = auth
         if trace_id is not None:
             headers["x-llmtrace-trace-id"] = str(trace_id)
         body = {
-            "model": "mock-model",
+            "model": _chat_model(),
             "messages": [{"role": "user", "content": prompt}],
             "stream": False,
         }
@@ -317,7 +348,7 @@ def proxy(
     # the proxy at that real LLM (used by the nightly workflow).
     # Otherwise fall back to the in-process FastAPI mock so PR-gate
     # runs stay self-contained and free.
-    real_upstream = os.environ.get("LLMTRACE_E2E_REAL_UPSTREAM_URL")
+    real_upstream = os.environ.get(REAL_UPSTREAM_URL_ENV)
     env["LLMTRACE_UPSTREAM_URL"] = real_upstream or mock_upstream.base_url
     env["LLMTRACE_STORAGE_DATABASE_PATH"] = str(db_path)
     env["LLMTRACE_STORAGE_PROFILE"] = "lite"

--- a/tests/e2e/test_conftest_unit.py
+++ b/tests/e2e/test_conftest_unit.py
@@ -1,0 +1,45 @@
+from tests.e2e import conftest
+
+
+def test_real_upstream_authorization_disabled_without_real_upstream(monkeypatch):
+    monkeypatch.delenv(conftest.REAL_UPSTREAM_URL_ENV, raising=False)
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_API_KEY_ENV, "secret")
+
+    assert conftest._real_upstream_authorization() is None
+
+
+def test_real_upstream_authorization_uses_explicit_header(monkeypatch):
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_URL_ENV, "https://api.example.test/v1")
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_AUTHORIZATION_ENV, "Bearer explicit")
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_API_KEY_ENV, "raw-secret")
+
+    assert conftest._real_upstream_authorization() == "Bearer explicit"
+
+
+def test_real_upstream_authorization_builds_bearer_from_api_key(monkeypatch):
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_URL_ENV, "https://api.example.test/v1")
+    monkeypatch.delenv(conftest.REAL_UPSTREAM_AUTHORIZATION_ENV, raising=False)
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_API_KEY_ENV, "raw-secret")
+
+    assert conftest._real_upstream_authorization() == "Bearer raw-secret"
+
+
+def test_chat_model_uses_mock_model_without_real_upstream(monkeypatch):
+    monkeypatch.delenv(conftest.REAL_UPSTREAM_URL_ENV, raising=False)
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_MODEL_ENV, "real-model")
+
+    assert conftest._chat_model() == conftest.DEFAULT_CHAT_MODEL
+
+
+def test_chat_model_uses_real_upstream_model_when_configured(monkeypatch):
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_URL_ENV, "https://api.example.test/v1")
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_MODEL_ENV, "moonshot-v1-8k")
+
+    assert conftest._chat_model() == "moonshot-v1-8k"
+
+
+def test_chat_model_falls_back_when_real_upstream_model_is_blank(monkeypatch):
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_URL_ENV, "https://api.example.test/v1")
+    monkeypatch.setenv(conftest.REAL_UPSTREAM_MODEL_ENV, "  ")
+
+    assert conftest._chat_model() == conftest.DEFAULT_CHAT_MODEL


### PR DESCRIPTION
## Summary

- Adds three optional env vars (`LLMTRACE_E2E_REAL_UPSTREAM_API_KEY`, `LLMTRACE_E2E_REAL_UPSTREAM_AUTHORIZATION`, `LLMTRACE_E2E_REAL_UPSTREAM_MODEL`) consumed by `tests/e2e/conftest.py` so nightly real-upstream runs can target providers that need auth and a specific chat-completions model.
- Wires the same three secrets into `.github/workflows/e2e-nightly.yml`.
- Documents the new vars in `docs/guides/e2e-testing.md` (CLI section + nightly secrets list).
- Adds `tests/e2e/test_conftest_unit.py` with 6 unit tests covering `_real_upstream_authorization()` and `_chat_model()` (precedence of explicit Authorization over API key, mock fallback when real upstream unset, blank-model fallback).

When `LLMTRACE_E2E_REAL_UPSTREAM_URL` is unset, behavior is unchanged: harness keeps using the in-process FastAPI mock and the default `mock-model` for PR-gate runs.

## Test plan

- [x] `pytest tests/e2e/test_conftest_unit.py -v` — 6/6 pass locally
- [x] `pytest tests/e2e/ --collect-only` — 193 tests collected, no regression
- [ ] Nightly workflow run after merge picks up the new secrets when configured