### PR TITLE
fix(judge): JSON response mode for OpenAI-compatible upstream judge (#160)

### DIFF
--- a/tests/e2e/test_upstream_judge_unit.py
+++ b/tests/e2e/test_upstream_judge_unit.py
@@ -671,6 +671,11 @@ def test_llm_judge_openai_backend_invokes_chat_completions(monkeypatch):
     assert req["model"] == "kimi-k2.6"
     # Default for openai backend is 1024 (reasoning-model headroom)
     assert req["max_tokens"] == 1024
+    # #160 Option 1: JSON response mode constrains the model to emit
+    # valid JSON at the provider level, eliminating the prose-drift
+    # failure mode that produced ~5–10% None verdicts per nightly
+    # calibration. See docs/research/results/upstream_judge_calibration_none_investigation_2026-05-02.md
+    assert req["response_format"] == {"type": "json_object"}
     assert req["messages"][0]["role"] == "system"
     assert req["messages"][1]["role"] == "user"
     assert "ATTACK PROMPT:" in req["messages"][1]["content"]

--- a/tests/e2e/upstream_judge.py
+++ b/tests/e2e/upstream_judge.py
@@ -763,9 +763,21 @@ def _build_openai_client(
         user: str,
         max_tokens: int,
     ) -> LLMCallResult:
+        # Constrain the model to emit a JSON object (#160 Option 1).
+        # The investigation report at
+        # docs/research/results/upstream_judge_calibration_none_investigation_2026-05-02.md
+        # identified "model returned prose instead of JSON" as the
+        # direct cause of `_parse_llm_verdict()` returning None on
+        # ~5–10% of calibration cases per night. JSON response mode
+        # forces valid JSON at the provider level, eliminating that
+        # failure mode without a retry layer. Supported by Moonshot,
+        # OpenAI, OpenRouter passthrough, and most OpenAI-compatible
+        # gateways. Providers that ignore the field still receive a
+        # well-formed request.
         response = client.chat.completions.create(
             model=model,
             max_tokens=max_tokens,
+            response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},


### PR DESCRIPTION
## Why

Implements **Option 1** from the investigation report at \`docs/research/results/upstream_judge_calibration_none_investigation_2026-05-02.md\`. Both escalation triggers from that report have now fired since #177 landed:

| Trigger | Status |
|---|---|
| \`None\` recurs on the same case | ✅ \`developer-mode\` (05-02 + 05-03), \`roleplay-compliance\` (04-30 + 05-07) |
| \`None\` rises above 1 row per run | ✅ 05-02 had 2 None judgements (\`developer-mode\` + \`benign-mentioning-dan\`) |

Across 6 nights since the investigation, **4 of 12 corpus cases (33%)** have hit None at least once. Per-case per-night fail rate is ~5–10%.

## What

Single change in \`tests/e2e/upstream_judge.py::_build_openai_client\`: pass \`response_format={\"type\": \"json_object\"}\` on the \`chat.completions.create\` call. Constrains the model to emit valid JSON at the **provider level**, eliminating the prose-drift failure mode that #177 identified as the direct cause.

## Why this option (vs the alternatives in #177)

1. **JSON response mode** ← this PR. Cleanest. Eliminates the failure mode at the source.
2. Add a retry-with-repair-prompt layer — stacks on top of (1) if needed, redundant when (1) works.
3. Bump \`max_output_tokens\` — the investigation found this isn't the root cause (sidecars showed prose, not truncated JSON).

## Provider compatibility

Moonshot/Kimi (current judge), OpenAI, and OpenRouter passthrough all support \`response_format\`. Providers that ignore the field still receive a well-formed request and behave as before. Anthropic backend is untouched (no prose-drift on the Messages API path).

## Test plan

- [x] \`pytest tests/e2e/test_upstream_judge_unit.py -q\` — **56/56 pass**.
- [x] Updated \`test_llm_judge_openai_backend_invokes_chat_completions\` to assert \`response_format\` is forwarded.
- [ ] CI green on this branch.
- [ ] After merge: tomorrow's calibration nightly should show the \`None\` count drop toward 0.

## Acceptance criterion

If \`None\` rate drops to ≤ 1 row per week across the calibration corpus, close #160. If it still appears at non-trivial rates, escalate to Option 2 (retry layer).

Closes #160 (pending one nightly cycle of validation)
Refs: #177 (investigation), #156 (calibration baseline)