### PR TITLE
chore(ci): pin all GitHub Actions to full SHA per techlab-innov org policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt
       - run: cargo fmt --all --check
@@ -31,8 +31,8 @@ jobs:
     name: E2E Scenario Schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Install Python deps
@@ -44,11 +44,11 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       
       # Audit Node.js dependencies
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
       - name: NPM Audit (Dashboard)
@@ -57,9 +57,9 @@ jobs:
         run: cd crates/llmtrace-nodejs && npm audit
 
       # Audit Rust dependencies
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3  # v2
         with:
           tool: cargo-audit
       - name: Cargo Audit
@@ -70,13 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: fmt
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -94,11 +94,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: fmt
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -121,17 +121,17 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: llvm-tools-preview
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3  # v2
         with:
           tool: cargo-llvm-cov
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -232,7 +232,7 @@ jobs:
       - name: Upload coverage to Codecov
         # If CODECOV_TOKEN isn't configured, keep CI green and rely on artifacts.
         if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           files: lcov.info
           token: ${{ env.CODECOV_TOKEN }}
@@ -242,7 +242,7 @@ jobs:
         if: ${{ env.CODECOV_TOKEN == '' }}
         run: echo "Skipping Codecov upload because secrets.CODECOV_TOKEN is not set. Coverage artifacts will still be uploaded."
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: coverage-report
           path: |
@@ -257,11 +257,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -344,10 +344,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: 'npm'
@@ -525,7 +525,7 @@ jobs:
 
       - name: Upload Playwright Report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: playwright-report
           path: |
@@ -543,11 +543,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -563,7 +563,7 @@ jobs:
           RUST_LOG: warn
         run: cargo run --bin benchmarks -- --output-dir benchmarks/results --analyzer regex
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: benchmark-results
@@ -574,11 +574,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [clippy, test, coverage]
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -601,13 +601,13 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build Docker image for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: false
@@ -617,7 +617,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
         with:
           image-ref: llmtrace-proxy:scan
           format: sarif
@@ -626,7 +626,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,12 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
 
       - name: Install Python
         run: uv python install 3.12
@@ -58,11 +58,11 @@ jobs:
 
       - name: Configure Pages
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: site
 
@@ -77,4 +77,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -42,21 +42,21 @@ jobs:
     # against the mock; budget for real-LLM latency + retries.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Install Python deps
         run: python3 -m pip install -r requirements-e2e.txt
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: e2e-nightly-${{ steps.report.outputs.date }}
           path: |
@@ -193,7 +193,7 @@ jobs:
       - name: Open report PR
         id: open_pr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(e2e): nightly report ${{ steps.report.outputs.date }}"
@@ -222,7 +222,7 @@ jobs:
         if: steps.calibrate.outputs.skipped != 'true'
         id: open_calibration_pr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(e2e): calibration report ${{ steps.report.outputs.date }}"

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -46,9 +46,9 @@ jobs:
     # than raising the cap. The full corpus is nightly's job.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
@@ -60,7 +60,7 @@ jobs:
       - name: Validate scenarios
         run: python3 scripts/e2e/validate_scenarios.py
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       # protoc is required by llmtrace-proto build.rs.
       - name: Install protoc
@@ -68,7 +68,7 @@ jobs:
 
       # Cargo cache keyed on Cargo.lock per L9 spec. The release build of
       # the proxy is the dominant cost (~3 min cold, <30 s warm).
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -104,7 +104,7 @@ jobs:
       # to read first when a scenario fails.
       - name: Upload junit + proxy logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: e2e-pr-gate-artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
           mv CHANGELOG.md.tmp CHANGELOG.md
 
       - name: Upload changelog artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: changelog
           path: |
@@ -114,18 +114,18 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -151,23 +151,23 @@ jobs:
     needs: [validate, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image for scanning (amd64 only)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: false
@@ -178,7 +178,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
         with:
           image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan"
           format: sarif
@@ -187,13 +187,13 @@ jobs:
           exit-code: "1"
 
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif
 
       - name: Build and push multi-arch image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: true
@@ -217,10 +217,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Publish crates in dependency order
         env:
@@ -263,15 +263,15 @@ jobs:
             target: universal2-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist -i python3.12
@@ -279,7 +279,7 @@ jobs:
           working-directory: crates/llmtrace-python
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: wheel-${{ matrix.target }}
           path: crates/llmtrace-python/dist/*.whl
@@ -293,7 +293,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: wheel-*
           merge-multiple: true
@@ -324,7 +324,7 @@ jobs:
             artifact: llmtrace-proxy-macos-arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install protoc (Linux)
         if: runner.os == 'Linux'
@@ -335,12 +335,12 @@ jobs:
         run: brew install protobuf
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -359,7 +359,7 @@ jobs:
           chmod +x dist/${{ matrix.artifact }}
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}
@@ -373,18 +373,18 @@ jobs:
     if: always() && needs.validate.result == 'success' && needs.docker.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download changelog
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: changelog
 
       - name: Download all release assets
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: "{wheel-*,llmtrace-proxy-*}"
           merge-multiple: true
@@ -400,7 +400,7 @@ jobs:
           git push origin main
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: ${{ needs.validate.outputs.tag }}
           name: "LLMTrace ${{ needs.validate.outputs.tag }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,10 +21,10 @@ jobs:
     name: Cargo Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3  # v2
         with:
           tool: cargo-audit
       - name: Run cargo audit
@@ -34,10 +34,10 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3  # v2
         with:
           tool: cargo-deny
       - name: Run cargo deny


### PR DESCRIPTION
## Why

The migration to `techlab-innov` brought the repo under the org's strict Actions policy:

> Actions must be from a techlab-innov-owned repo, GitHub-created, or Marketplace-verified, **AND every reference must be pinned to a full 40-character commit SHA**.

Every workflow on this repo used tag refs (`@v6`, `@stable`, `@0.35.0`). Result: every workflow run since the migration fails in 2 seconds at the \"Prepare all required actions\" step.

**Concrete symptoms:**
- Yesterday's main-CI run on the dependabot-config push (run [25503648790](https://github.com/techlab-innov/llmtrace/actions/runs/25503648790)) hit `Build`/`Benchmarks` failure in 2 seconds with the message:
  > _\"all actions must be from a repository owned by techlab-innov, created by GitHub, or verified in the GitHub Marketplace. All actions must also be pinned to a full-length commit SHA.\"_
- Today's 03:00 UTC scheduled nightly **never fired** — same policy gate at the schedule trigger level.
- Every PR's CI has been silently broken since the migration.

This PR is the unblock.

## What

SHA-pin every action reference across all **6 workflow files**, preserving the version as an inline comment so Dependabot's `github-actions` ecosystem (newly active per `.github/dependabot.yml`) can maintain both the SHA and the comment together.

23 unique references resolved via `gh api repos/<owner>/<repo>/commits/<tag>`:

| Action | Tag | Full SHA |
|---|---|---|
| `actions/checkout` | v6 | de0fac2e4500dabe0009e67214ff5f5447ce83dd |
| `actions/checkout` | v4 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| `actions/setup-python` | v6 | a309ff8b426b58ec0e2a45f0f869d46889d02405 |
| `actions/setup-node` | v6 | 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e |
| `actions/cache` | v5 | 27d5ce7f107fe9357f9df03efb73ab90386fccae |
| `actions/upload-artifact` | v7 | 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a |
| `actions/download-artifact` | v8 | 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c |
| `actions/configure-pages` | v5 | 983d7736d9b0ae728b81ab479565c72886d7745b |
| `actions/deploy-pages` | v4 | d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e |
| `actions/upload-pages-artifact` | v3 | 56afc609e74202658d3ffba0e8f6dda462b719fa |
| `dtolnay/rust-toolchain` | stable | 29eef336d9b2848a0b548edc03f92a220660cdb8 |
| `aquasecurity/trivy-action` | 0.35.0 | 57a97c7e7821a5776cebc9bb87c984fa69cba8f1 |
| `codecov/codecov-action` | v5 | 75cd11691c0faa626561e295848008c8a7dddffe |
| `docker/build-push-action` | v6 | 10e90e3645eae34f1e60eeb005ba3a3d33f178e8 |
| `docker/setup-buildx-action` | v3 | 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f |
| `docker/setup-qemu-action` | v3 | c7c53464625b32c7a7e944ae62b3e17d2b600130 |
| `docker/login-action` | v3 | c94ce9fb468520275223c153574b00df6fe4bcc9 |
| `github/codeql-action/upload-sarif` | v4 | 68bde559dea0fdcac2102bfdf6230c5f70eb485e |
| `taiki-e/install-action` | v2 | cca35edeb1d01366c2843b68fc3ca441446d73d3 |
| `astral-sh/setup-uv` | v4 | 38f3f104447c67c051c4a08e39b64a148898af3a |
| `peter-evans/create-pull-request` | v8 | 5f6978faf089d4d20b00c7766989d076bb2fc7f1 |
| `PyO3/maturin-action` | v1 | e83996d129638aa358a18fbd1dfb82f0b0fb5d3b |
| `softprops/action-gh-release` | v2 | 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 |

Files touched: `ci.yml`, `docs.yml`, `e2e-nightly.yml`, `e2e-pr.yml`, `release.yml`, `security.yml`.

## Format

Each reference now reads:

```yaml
- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
```

Two-space indent before the `#` matches Dependabot's documented expectation for tag-comment pinning. Dependabot will keep both the SHA and the comment in sync on its weekly run.

## What this fixes

- Yesterday's CI failure on `main`.
- Today's missed 03:00 UTC scheduled nightly (re-triggerable via `gh workflow run e2e-nightly.yml` once this lands).
- The validation-gap-2a #161 \"one clean nightly\" gate (was blocked).
- The #160 JSON-mode validation gate (was blocked).
- The corpus-calibration PR's post-merge nightly re-trigger (was blocked).

## CI on this PR

The workflow files in this PR's HEAD are policy-compliant, so CI on this branch should run normally — that itself is the validation that the fix works.

## Out of scope

- Changing the org policy. The user (org admin) explicitly asked for SHA pinning over policy relaxation: \"let's not compromise our policies because you feel sloppy\".
- Auditing pinned SHAs against any specific release-notes / changelog. The pins are simply the current commits at the named tags.

Refs: techlab-innov org Actions policy.