### PR TITLE
fix(security): ignore RUSTSEC-2026-0097 — not vulnerable in our usage

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,15 @@ ignore = [
     # Unmaintained transitive crates (no fixed upgrade available).
     "RUSTSEC-2025-0119", # number_prefix
     "RUSTSEC-2024-0436", # paste
+    # rand 0.8 unsoundness — only triggers when a custom log::Log implementation
+    # calls rand::rng() and a TryRng method on ThreadRng from inside the logger,
+    # AND the ThreadRng reseeds (every 64 KB) while called from the logger.
+    # We verified our codebase has zero `impl log::Log` implementations
+    # (grep -rln "log::Log\|impl Log\|set_logger" crates/ returns empty), so
+    # the precondition cannot be met. The fix (rand 0.9) is a major bump with
+    # breaking API changes — Dependabot PR #197 captured the migration but
+    # the API surface needs source edits we don't currently need.
+    "RUSTSEC-2026-0097", # rand 0.8 — n/a, no custom logger; see #197
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Why

The recurring **Cargo Deny** failure (Security Audit red on 05-04, 04-27, 05-11, 05-13) is **RUSTSEC-2026-0097** — a rand 0.8 unsoundness advisory.

The unsoundness only triggers when ALL of:

1. \`log\` + \`thread_rng\` features enabled on rand
2. A custom \`log::Log\` implementation is registered
3. The custom logger calls \`rand::rng()\` / \`rand::thread_rng()\` and invokes \`TryRng\` methods on \`ThreadRng\` **from inside the logger**
4. \`ThreadRng\` reseeds (~64 KB) while called from the logger

## Verified not vulnerable

\`\`\`
$ grep -rln 'log::Log\|impl Log\|set_logger\|set_boxed_logger' crates/
(empty)
\`\`\`

Zero custom log implementations. Condition (2) is impossible. Our \`rand\` usage:
- \`canary.rs\` — canary-token generation
- \`boundary.rs\` — boundary-token nonces
- \`judge/retry.rs\` — retry jitter
- \`auth.rs\` — auth-token randomness
- \`fpr_calibration.rs\` — calibration RNG

None inside a logger.

## Why not just merge rand 0.9 (PR #197)

The Dependabot PR is a major version bump. Local CI on it is red: \`Clippy\`, \`Test\`, \`E2E PR Gate\` all fail because rand 0.9 has breaking API changes (e.g. \`thread_rng()\` → \`rng()\`, \`Rng::gen_range()\` signature, \`SliceRandom\` reorganisations). The migration is non-trivial source work for a vulnerability we're structurally immune to.

If/when we want the upgrade for ergonomic reasons, that's a separate PR.

## Test plan

- [x] cargo-deny ignore entry added to \`deny.toml\` with explanatory comment.
- [ ] CI \`Security Audit / Cargo Deny\` passes on this branch.
- [ ] After merge: tomorrow's scheduled \`Security Audit\` run goes green.
- Followup: close \`#197\` with a link to this PR's explanation.

## What this is not

- Not silencing the advisory for the wider Rust ecosystem.
- Not avoiding rand 0.9; just deferring the migration to when it's needed.