### PR TITLE
ops(e2e): enable IS-060 datamarking in shadow mode for nightly validation

### DIFF
--- a/tests/e2e/fixtures/config-e2e-judge.yaml
+++ b/tests/e2e/fixtures/config-e2e-judge.yaml
@@ -54,6 +54,25 @@ health_check:
   timeout_ms: 5000
   retries: 3
 
+# IS-060 — Boundary defense + datamarking transform.
+# Enabled in shadow mode for the first validation cycle: data zones are
+# wrapped with <llmtrace-boundary>...</llmtrace-boundary> tags AND the
+# datamarking pipeline computes the U+E000 substitution + emits metrics,
+# but shadow_mode=true means the original (unmarked) bytes still go
+# upstream. Validate one nightly cycle for zero 4xx delta and non-zero
+# byte_delta_total before flipping shadow_mode to false in a follow-up
+# ops PR. See PR #214 + docs/architecture/SPOTLIGHTING_INDIRECT_INJECTION.md.
+boundary_defense:
+  enabled: true
+  randomize_nonce: true
+  inject_system_reminder: true
+  datamarking:
+    enabled: true
+    shadow_mode: true
+    marker_strategy:
+      kind: randomized
+
+
 # See config-e2e.yaml for rationale on enforcement mode/min_severity.
 # analysis_depth=full so the pre-request enforcement decision sees BOTH
 # regex AND ML findings. With `fast` (regex only) the proxy_outcome


### PR DESCRIPTION
Stage 1 of the IS-060 PR-2 validation chain. The datamarking transform landed in PR #214 with safe defaults (\`enabled: false\`). This PR enables it in **shadow mode** in the nightly e2e fixture so the transform runs and emits metrics without modifying upstream bytes.

## Config added to \`tests/e2e/fixtures/config-e2e-judge.yaml\`

\`\`\`yaml
boundary_defense:
  enabled: true
  randomize_nonce: true
  inject_system_reminder: true
  datamarking:
    enabled: true
    shadow_mode: true
    marker_strategy:
      kind: randomized
\`\`\`

## Why shadow first

The transform changes outgoing request bytes when active. Shadow mode lets us validate the operational footprint (no 4xx delta, no encoding errors, non-zero \`byte_delta_total\`) in isolation from the behavioural-change question (does datamarking actually reduce ASR?). Two-stage rollout matches the boundary-defense precedent.

## Acceptance — post-merge

- [ ] Existing E2E PR Gate + E2E Tests green on this branch (zero regression with shadow active).
- [ ] One scheduled nightly cycle completes without 4xx-rate shift vs \`e2e_2026-05-15.json\` baseline.
- [ ] \`llmtrace_spotlighting_zones_total{shadow=\"true\"}\` > 0.
- [ ] \`llmtrace_spotlighting_byte_delta_total{shadow=\"true\"}\` > 0.
- [ ] \`llmtrace_spotlighting_failures_total\` == 0.
- [ ] No new \"spotlighting_applied\" finding-related errors in logs.

If all four hold, a follow-up ops PR flips \`shadow_mode: false\` and begins the 3-5 night ASR delta collection.

## Out of scope

- Code changes (none — pure config flip).
- Active-mode flip — separate ops PR after shadow validates.
- Workflow YAML changes — none, the fixture is read by the existing harness.

Refs: #214 (PR-2 implementation, merged), #213 (PR-3 corpus expansion, merged), docs/architecture/SPOTLIGHTING_INDIRECT_INJECTION.md §6.2 + §6.4.