### PR TITLE
ops(e2e): enable zone_detection — prerequisite for datamarking shadow validation

### DIFF
--- a/tests/e2e/fixtures/config-e2e-judge.yaml
+++ b/tests/e2e/fixtures/config-e2e-judge.yaml
@@ -54,6 +54,17 @@ health_check:
   timeout_ms: 5000
   retries: 3
 
+# IS-060 PR-1 zone detection — required for datamarking (PR-2) to have
+# Data zones to transform. Both heuristic and operator-declared zones
+# are honoured; instruction zones are skipped per the default policy
+# (data zones are the only candidates for marker substitution).
+security_analysis:
+  zone_detection:
+    enabled: true
+    mode: both
+    scan_instruction_zones: false
+
+
 # IS-060 — Boundary defense + datamarking transform.
 # Enabled in shadow mode for the first validation cycle: data zones are
 # wrapped with <llmtrace-boundary>...</llmtrace-boundary> tags AND the


### PR DESCRIPTION
Follow-up to PR #216. The first shadow-mode nightly produced zero `spotlighting_applied` findings because `security_analysis.zone_detection.enabled` defaults to `false` — without detected Data zones, datamarking has nothing to transform.

## Config added

```yaml
security_analysis:
  zone_detection:
    enabled: true
    mode: both                    # heuristic FSM + operator markers
    scan_instruction_zones: false # data zones only
```

## What this unlocks

The shadow-mode validation chain becomes meaningful: zones are detected, datamarking computes the transform on Data zones, the four `llmtrace_spotlighting_*_total` counters fire, and `spotlighting_applied` Info findings appear in the JSON sidecar.

## Test plan

- [x] YAML parses (`yaml.safe_load` clean).
- [ ] CI green on this branch.
- [ ] After merge: trigger `gh workflow run e2e-nightly.yml`. The resulting `e2e_<date>.json` should contain `spotlighting_applied` findings on indirect-injection scenarios.

Refs: #214 (PR-2 implementation), #213 (PR-3 corpus), #216 (shadow-mode prelude — incomplete without this).