### PR TITLE
ops(e2e): flip IS-060 datamarking to ACTIVE mode for ASR-delta collection

### DIFF
--- a/tests/e2e/fixtures/config-e2e-judge.yaml
+++ b/tests/e2e/fixtures/config-e2e-judge.yaml
@@ -66,20 +66,22 @@ security_analysis:
 
 
 # IS-060 — Boundary defense + datamarking transform.
-# Enabled in shadow mode for the first validation cycle: data zones are
-# wrapped with <llmtrace-boundary>...</llmtrace-boundary> tags AND the
-# datamarking pipeline computes the U+E000 substitution + emits metrics,
-# but shadow_mode=true means the original (unmarked) bytes still go
-# upstream. Validate one nightly cycle for zero 4xx delta and non-zero
-# byte_delta_total before flipping shadow_mode to false in a follow-up
-# ops PR. See PR #214 + docs/architecture/SPOTLIGHTING_INDIRECT_INJECTION.md.
+# Active mode: data zones are wrapped with <llmtrace-boundary>...
+# </llmtrace-boundary> tags AND the datamarking pipeline substitutes a
+# Unicode Private Use Area marker for whitespace in detected Data zones
+# BEFORE forwarding upstream. The system-reminder addendum tells the
+# upstream model that marked text is data, not instructions. Shadow-mode validated 2026-05-15 via workflow_dispatch run 25937040210:
+# 85/91 passed with zero errors and zero 4xx-rate shift vs prior nightly.
+# This flip activates marker substitution against the production
+# upstream (Gemini 2.0 Flash via OpenRouter); the next 3-5 scheduled
+# nightlies measure ASR delta on BIPIA scenarios vs the shadow baseline. See PR #214 + docs/architecture/SPOTLIGHTING_INDIRECT_INJECTION.md.
 boundary_defense:
   enabled: true
   randomize_nonce: true
   inject_system_reminder: true
   datamarking:
     enabled: true
-    shadow_mode: true
+    shadow_mode: false
     marker_strategy:
       kind: randomized
 


### PR DESCRIPTION
Stage 2 of the IS-060 PR-2 validation chain. Shadow mode validated 2026-05-15 (workflow_dispatch run 25937040210, 85/91 passed, 0 errors, 4xx-rate unchanged). This flip activates marker substitution against the real upstream.

## What this changes

Single line: `boundary_defense.datamarking.shadow_mode: true → false`

Comments updated to reflect the new operating mode and reference the shadow-mode validation evidence.

## Acceptance criteria — 3-5 nightly cycles post-merge

- Pass rate in 84-88/91 band (recent per-day Gemini variance band)
- `llmtrace_spotlighting_byte_delta_total` > 0
- `llmtrace_spotlighting_failures_total` == 0
- `llmtrace_spotlighting_marker_collision_total` bounded
- **upstream_fell_for_it rate on indirect_injection scenarios shifts DOWNWARD vs pre-datamarking baseline** — the headline ASR delta

Evidence will be committed to `docs/research/results/upstream_judge_datamarking_evidence_<date>.md` after 3-5 cycles.

## Risk + rollback

If the 4xx-rate spikes vs shadow-mode baseline, revert this PR — that's a one-line rollback to shadow mode while the upstream-API-side investigation happens.

Refs: #214 (PR-2 implementation), #213 (PR-3 corpus), #216 (shadow enable), #219 (zone_detection enable).