### PR TITLE
feat(deployments): config-driven Basilica tenant lifecycle

### DIFF
--- a/.github/workflows/tenant-lifecycle.yml
+++ b/.github/workflows/tenant-lifecycle.yml
@@ -1,0 +1,180 @@
+name: tenant-lifecycle
+
+on:
+  workflow_dispatch:
+    inputs:
+      tenant_id:
+        description: "DNS-safe tenant slug (^[a-z0-9][a-z0-9-]{0,29}$)"
+        required: true
+        type: string
+      action:
+        description: "Lifecycle action"
+        required: true
+        type: choice
+        options:
+          - provision
+          - update
+          - status
+          - deprovision
+      config_path:
+        description: "Path in repo to a YAML/JSON tenant config (provision/update only)"
+        required: false
+        type: string
+        default: ""
+      config_json:
+        description: "Inline JSON tenant config (provision/update only, takes precedence over config_path)"
+        required: false
+        type: string
+        default: ""
+      proxy_instance_id:
+        description: "Basilica UUID of existing proxy (required for update; optional for status/deprovision)"
+        required: false
+        type: string
+        default: ""
+      dashboard_instance_id:
+        description: "Basilica UUID of existing dashboard (required for update; optional for status/deprovision)"
+        required: false
+        type: string
+        default: ""
+      strategy:
+        description: "Update strategy (update only): recreate (URL changes) or restart (URL stable)"
+        required: false
+        type: choice
+        default: recreate
+        options:
+          - recreate
+          - restart
+
+permissions:
+  contents: read
+
+jobs:
+  lifecycle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Secrets used both for the API client and for ${VAR} substitution
+      # inside the loaded tenant config. Add per-tenant secrets here as
+      # needed — they will be resolved at deploy time.
+      BASILICA_API_TOKEN: ${{ secrets.BASILICA_API_TOKEN }}
+      LLMTRACE_UPSTREAM_URL: ${{ secrets.LLMTRACE_UPSTREAM_URL }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      LLMTRACE_AUTH_ADMIN_KEY: ${{ secrets.LLMTRACE_AUTH_ADMIN_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install basilica-sdk PyYAML
+
+      - name: Validate inputs
+        env:
+          ACTION: ${{ inputs.action }}
+          CONFIG_PATH: ${{ inputs.config_path }}
+          CONFIG_JSON: ${{ inputs.config_json }}
+          PROXY_ID: ${{ inputs.proxy_instance_id }}
+          DASHBOARD_ID: ${{ inputs.dashboard_instance_id }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASILICA_API_TOKEN:-}" ]]; then
+            echo "::error::BASILICA_API_TOKEN secret is not configured"
+            exit 2
+          fi
+          case "${ACTION}" in
+            provision)
+              if [[ -z "${CONFIG_PATH}" && -z "${CONFIG_JSON}" ]]; then
+                echo "::error::action=provision requires config_path or config_json"
+                exit 2
+              fi
+              ;;
+            update)
+              if [[ -z "${CONFIG_PATH}" && -z "${CONFIG_JSON}" ]]; then
+                echo "::error::action=update requires config_path or config_json"
+                exit 2
+              fi
+              if [[ -z "${PROXY_ID}" || -z "${DASHBOARD_ID}" ]]; then
+                echo "::error::action=update requires proxy_instance_id and dashboard_instance_id"
+                exit 2
+              fi
+              ;;
+          esac
+
+      - name: Run lifecycle action
+        id: run
+        env:
+          TENANT_ID: ${{ inputs.tenant_id }}
+          ACTION: ${{ inputs.action }}
+          CONFIG_PATH: ${{ inputs.config_path }}
+          CONFIG_JSON: ${{ inputs.config_json }}
+          PROXY_ID: ${{ inputs.proxy_instance_id }}
+          DASHBOARD_ID: ${{ inputs.dashboard_instance_id }}
+          STRATEGY: ${{ inputs.strategy }}
+        run: |
+          set -euo pipefail
+          args=("--tenant-id" "${TENANT_ID}")
+          case "${ACTION}" in
+            provision)
+              if [[ -n "${CONFIG_JSON}" ]]; then
+                args+=("--config-json" "${CONFIG_JSON}")
+              else
+                args+=("--config" "${CONFIG_PATH}")
+              fi
+              ;;
+            update)
+              args+=("--strategy" "${STRATEGY}")
+              args+=("--proxy-instance-id" "${PROXY_ID}")
+              args+=("--dashboard-instance-id" "${DASHBOARD_ID}")
+              if [[ -n "${CONFIG_JSON}" ]]; then
+                args+=("--config-json" "${CONFIG_JSON}")
+              else
+                args+=("--config" "${CONFIG_PATH}")
+              fi
+              ;;
+            status|deprovision)
+              [[ -n "${PROXY_ID}" ]] && args+=("--proxy-instance-id" "${PROXY_ID}")
+              [[ -n "${DASHBOARD_ID}" ]] && args+=("--dashboard-instance-id" "${DASHBOARD_ID}")
+              ;;
+            *)
+              echo "::error::unknown action ${ACTION}"
+              exit 2
+              ;;
+          esac
+
+          set +e
+          python3 -m deployments.basilica.cli "${ACTION}" "${args[@]}" > result.json
+          code=$?
+          set -e
+          cat result.json
+          echo "exit_code=${code}" >> "${GITHUB_OUTPUT}"
+          python3 - <<'PY' >> "${GITHUB_OUTPUT}"
+          import json, pathlib
+          data = json.loads(pathlib.Path("result.json").read_text() or "{}")
+          print(f"proxy_instance_id={data.get('proxy_instance_id') or ''}")
+          print(f"dashboard_instance_id={data.get('dashboard_instance_id') or ''}")
+          print(f"proxy_url={data.get('proxy_url') or ''}")
+          print(f"dashboard_url={data.get('dashboard_url') or ''}")
+          PY
+          if [[ "${code}" -ne 0 ]]; then
+            exit "${code}"
+          fi
+
+      - name: Write step summary
+        if: always()
+        env:
+          ACTION: ${{ inputs.action }}
+          TENANT_ID: ${{ inputs.tenant_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## tenant-lifecycle: ${ACTION} ${TENANT_ID}"
+            echo ""
+            echo '```json'
+            cat result.json 2>/dev/null || echo "{}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/deployments/basilica/__init__.py
+++ b/deployments/basilica/__init__.py
@@ -1,0 +1,1 @@
+"""LLMTrace deployment automation for the Basilica platform."""

--- a/deployments/basilica/cli.py
+++ b/deployments/basilica/cli.py
@@ -1,0 +1,261 @@
+"""CLI for tenant lifecycle on Basilica.
+
+The Basilica SDK addresses deployments by server-assigned UUID. The CLI
+mirrors that contract: `provision` returns UUIDs; subsequent commands
+(`status`, `update`, `deprovision`) require the caller to supply them.
+The caller is expected to persist the `tenant_id → (proxy_instance_id,
+dashboard_instance_id)` mapping somewhere (app DB, workflow output store).
+
+Configuration is loaded from a YAML or JSON file (or inline JSON). See
+`deployments/basilica/configs/examples/` for templates. `${VAR}` and
+`${VAR:-default}` placeholders in string values are substituted from
+process environment at load time — use this to inject secrets without
+writing them to the config file.
+
+Output is JSON to stdout. Logs to stderr. Exit codes: 0 success,
+2 usage error, 3 lifecycle error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+import pathlib
+import re
+import sys
+from typing import Any
+
+import yaml
+
+from . import lifecycle
+
+LOGGER = logging.getLogger("deployments.basilica.cli")
+
+_ENV_PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+def _substitute_env(value: Any) -> Any:
+    """Recursively substitute `${VAR}` / `${VAR:-default}` in string values."""
+    if isinstance(value, str):
+        def repl(match: re.Match[str]) -> str:
+            name, default = match.group(1), match.group(2)
+            resolved = os.environ.get(name)
+            if resolved is not None:
+                return resolved
+            if default is not None:
+                return default
+            raise KeyError(f"env var {name!r} required by config is not set")
+
+        return _ENV_PLACEHOLDER.sub(repl, value)
+    if isinstance(value, dict):
+        return {k: _substitute_env(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_substitute_env(v) for v in value]
+    return value
+
+
+def _load_config(path: str | None, inline_json: str | None) -> dict[str, Any]:
+    if path and inline_json:
+        raise SystemExit("--config and --config-json are mutually exclusive")
+    if not path and not inline_json:
+        raise SystemExit("one of --config or --config-json is required")
+    if inline_json:
+        raw = json.loads(inline_json)
+    else:
+        text = pathlib.Path(path).read_text()
+        raw = yaml.safe_load(text)
+    if not isinstance(raw, dict):
+        raise SystemExit(
+            f"config must be a mapping at the top level, got {type(raw).__name__}"
+        )
+    return _substitute_env(raw)
+
+
+def _component_from_dict(data: dict[str, Any], label: str) -> lifecycle.ComponentSpec:
+    required = {"image", "port", "cpu", "memory", "replicas", "env"}
+    missing = required - data.keys()
+    if missing:
+        raise SystemExit(
+            f"component {label!r} is missing required keys: {sorted(missing)}"
+        )
+    env = data["env"] or {}
+    if not isinstance(env, dict):
+        raise SystemExit(f"component {label!r}: 'env' must be a mapping")
+    env_strs = {str(k): str(v) for k, v in env.items()}
+    kwargs: dict[str, Any] = {
+        "image": str(data["image"]),
+        "port": int(data["port"]),
+        "cpu": str(data["cpu"]),
+        "memory": str(data["memory"]),
+        "replicas": int(data["replicas"]),
+        "env": env_strs,
+    }
+    optional = {
+        "health_check_path": str,
+        "startup_timeout_seconds": int,
+        "startup_initial_delay_seconds": int,
+        "startup_period_seconds": int,
+        "startup_failure_threshold": int,
+        "liveness_period_seconds": int,
+        "liveness_failure_threshold": int,
+        "readiness_period_seconds": int,
+        "readiness_failure_threshold": int,
+    }
+    for key, caster in optional.items():
+        if key in data:
+            kwargs[key] = caster(data[key])
+    return lifecycle.ComponentSpec(**kwargs)
+
+
+def _tenant_spec_from_config(tenant_id: str, cfg: dict[str, Any]) -> lifecycle.TenantSpec:
+    if "proxy" not in cfg or "dashboard" not in cfg:
+        raise SystemExit(
+            "config must contain top-level 'proxy' and 'dashboard' mappings"
+        )
+    proxy = _component_from_dict(cfg["proxy"], "proxy")
+    dashboard = _component_from_dict(cfg["dashboard"], "dashboard")
+    kwargs: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "proxy": proxy,
+        "dashboard": dashboard,
+    }
+    for key in (
+        "proxy_name_template",
+        "dashboard_name_template",
+        "inject_proxy_url_into_dashboard",
+        "proxy_url_env_var",
+    ):
+        if key in cfg:
+            kwargs[key] = cfg[key]
+    return lifecycle.TenantSpec(**kwargs)
+
+
+def _serialise(instances: lifecycle.TenantInstances) -> dict[str, Any]:
+    def view(info: lifecycle.InstanceInfo | None) -> dict[str, Any] | None:
+        return dataclasses.asdict(info) if info is not None else None
+
+    return {
+        "tenant_id": instances.tenant_id,
+        "proxy": view(instances.proxy),
+        "dashboard": view(instances.dashboard),
+        "proxy_instance_id": instances.proxy.instance_id if instances.proxy else None,
+        "dashboard_instance_id": instances.dashboard.instance_id if instances.dashboard else None,
+        "proxy_url": instances.proxy.url if instances.proxy else None,
+        "dashboard_url": instances.dashboard.url if instances.dashboard else None,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="deployments.basilica.cli",
+        description="LLMTrace tenant lifecycle on Basilica",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    def add_tenant(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--tenant-id", required=True)
+
+    def add_config(p: argparse.ArgumentParser) -> None:
+        g = p.add_mutually_exclusive_group(required=True)
+        g.add_argument("--config", help="Path to a YAML or JSON config file")
+        g.add_argument("--config-json", help="Inline JSON config")
+
+    def add_ids(p: argparse.ArgumentParser, required: bool) -> None:
+        p.add_argument(
+            "--proxy-instance-id",
+            required=required,
+            default=None,
+            help="Basilica UUID for the existing proxy deployment",
+        )
+        p.add_argument(
+            "--dashboard-instance-id",
+            required=required,
+            default=None,
+            help="Basilica UUID for the existing dashboard deployment",
+        )
+
+    p_prov = sub.add_parser(
+        "provision",
+        help="Create a fresh deployment pair (always creates — caller is responsible for de-duping)",
+    )
+    add_tenant(p_prov)
+    add_config(p_prov)
+
+    p_upd = sub.add_parser("update", help="Restart or recreate the pair (UUIDs required)")
+    add_tenant(p_upd)
+    add_config(p_upd)
+    add_ids(p_upd, required=True)
+    p_upd.add_argument(
+        "--strategy", default="recreate", choices=["restart", "recreate"]
+    )
+
+    p_st = sub.add_parser("status", help="Read state for given UUIDs")
+    add_tenant(p_st)
+    add_ids(p_st, required=False)
+
+    p_dep = sub.add_parser("deprovision", help="Delete given UUIDs (idempotent)")
+    add_tenant(p_dep)
+    add_ids(p_dep, required=False)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> lifecycle.TenantInstances:
+    if args.action == "provision":
+        cfg = _load_config(args.config, args.config_json)
+        spec = _tenant_spec_from_config(args.tenant_id, cfg)
+        return lifecycle.provision(spec)
+    if args.action == "update":
+        cfg = _load_config(args.config, args.config_json)
+        spec = _tenant_spec_from_config(args.tenant_id, cfg)
+        return lifecycle.update(
+            spec,
+            proxy_instance_id=args.proxy_instance_id,
+            dashboard_instance_id=args.dashboard_instance_id,
+            strategy=args.strategy,
+        )
+    if args.action == "status":
+        return lifecycle.status(
+            tenant_id=args.tenant_id,
+            proxy_instance_id=args.proxy_instance_id,
+            dashboard_instance_id=args.dashboard_instance_id,
+        )
+    if args.action == "deprovision":
+        return lifecycle.deprovision(
+            tenant_id=args.tenant_id,
+            proxy_instance_id=args.proxy_instance_id,
+            dashboard_instance_id=args.dashboard_instance_id,
+        )
+    raise SystemExit(f"unknown action {args.action!r}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    try:
+        result = _dispatch(args)
+    except (ValueError, RuntimeError, TimeoutError, KeyError) as exc:
+        LOGGER.error("lifecycle failure: %s", exc)
+        json.dump({"error": str(exc), "action": args.action}, sys.stdout)
+        sys.stdout.write("\n")
+        return 3
+    json.dump(_serialise(result), sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -1,0 +1,38 @@
+# LLMTrace tenant config — pro tier example.
+# Multi-replica proxy, persistent dashboard, debug logging, datamarking on.
+
+proxy:
+  image: "ghcr.io/techlab-innov/llmtrace-proxy:${LLMTRACE_VERSION:-latest}"
+  port: 8080
+  cpu: "4"
+  memory: 8Gi
+  replicas: 2
+  health_check_path: /health
+  startup_timeout_seconds: 600
+  env:
+    LLMTRACE_UPSTREAM_URL: "${LLMTRACE_UPSTREAM_URL}"
+    LLMTRACE_STORAGE_PROFILE: "${LLMTRACE_STORAGE_PROFILE:-sqlite}"
+    LLMTRACE_ML_ENABLED: "1"
+    LLMTRACE_ML_PRELOAD: "1"
+    LLMTRACE_ML_CACHE_DIR: /home/llmtrace/.cache/llmtrace/models
+    LLMTRACE_LOG_LEVEL: "${LLMTRACE_LOG_LEVEL:-info}"
+    LLMTRACE_LOG_FORMAT: json
+    LLMTRACE_DATAMARKING_ENABLED: "true"
+    LLMTRACE_DATAMARKING_SHADOW_MODE: "false"
+    LLMTRACE_ZONE_DETECTION_ENABLED: "true"
+    RUST_LOG: info
+    OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+    ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+
+dashboard:
+  image: "ghcr.io/techlab-innov/llmtrace-dashboard:${LLMTRACE_VERSION:-latest}"
+  port: 3000
+  cpu: "2"
+  memory: 2Gi
+  replicas: 1
+  health_check_path: /health
+  startup_timeout_seconds: 300
+  env:
+    HOSTNAME: 0.0.0.0
+    NODE_ENV: production
+    LLMTRACE_AUTH_ADMIN_KEY: "${LLMTRACE_AUTH_ADMIN_KEY:-}"

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -1,0 +1,48 @@
+# LLMTrace tenant config — starter tier example.
+#
+# Every field below is required from the caller. The `lifecycle` library has
+# no built-in defaults for runtime config — what you write here is exactly
+# what gets deployed.
+#
+# `${VAR}` and `${VAR:-default}` placeholders in string values are resolved
+# from the process environment at deploy time. Use this to keep secrets out
+# of the config file.
+
+proxy:
+  image: ghcr.io/techlab-innov/llmtrace-proxy:latest
+  port: 8080
+  cpu: "2"
+  memory: 4Gi
+  replicas: 1
+  health_check_path: /health
+  startup_timeout_seconds: 600
+  env:
+    LLMTRACE_UPSTREAM_URL: "${LLMTRACE_UPSTREAM_URL}"
+    LLMTRACE_STORAGE_PROFILE: memory
+    LLMTRACE_ML_ENABLED: "1"
+    LLMTRACE_ML_PRELOAD: "1"
+    LLMTRACE_ML_CACHE_DIR: /home/llmtrace/.cache/llmtrace/models
+    LLMTRACE_LOG_LEVEL: info
+    LLMTRACE_LOG_FORMAT: json
+    RUST_LOG: info
+    # Per-tenant upstream API key, pulled from process env at deploy time.
+    OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+
+dashboard:
+  image: ghcr.io/techlab-innov/llmtrace-dashboard:latest
+  port: 3000
+  cpu: "1"
+  memory: 1Gi
+  replicas: 1
+  health_check_path: /health
+  startup_timeout_seconds: 300
+  env:
+    HOSTNAME: 0.0.0.0
+    NODE_ENV: production
+    LLMTRACE_AUTH_ADMIN_KEY: "${LLMTRACE_AUTH_ADMIN_KEY:-}"
+
+# Optional — override if your tenant naming scheme differs.
+# proxy_name_template: "llmtrace-proxy-{tenant_id}"
+# dashboard_name_template: "llmtrace-dashboard-{tenant_id}"
+# inject_proxy_url_into_dashboard: true
+# proxy_url_env_var: LLMTRACE_PROXY_URL

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -1,0 +1,387 @@
+"""Multi-tenant lifecycle for LLMTrace on Basilica.
+
+This module is a stateless mechanism. The caller (typically an app + DB or
+the GitHub Actions workflow) owns the mapping from `tenant_id` to the
+Basilica-assigned instance UUIDs.
+
+Why caller-owned identity: Basilica's SDK only addresses deployments by
+their server-assigned UUID. The friendly name supplied at create time is
+accepted but not echoed back on read, and `get_deployment` only resolves
+UUIDs. Idempotent lookup by friendly name is not possible against this SDK.
+
+Configuration is also caller-owned: every field of `ComponentSpec` must
+come from the caller. No defaults for image, env, resources, ports.
+Probe/timeout fields have structural defaults because they describe *how
+to wait*, not *what to deploy*.
+
+Update semantics: the Basilica SDK has no patch endpoint, so
+`update(..., strategy="recreate")` deletes the old UUIDs and creates new
+ones (URLs change — Basilica URLs are UUID-keyed). `strategy="restart"`
+does a rolling restart of the existing pods (URL stable, no config change).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from basilica import (
+    BasilicaClient,
+    HealthCheckConfig,
+    ProbeConfig,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+# DNS-safe slug, ≤30 chars to leave headroom for friendly-name prefixes.
+TENANT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,29}$")
+
+POLL_INTERVAL_SECONDS = 10
+
+DEFAULT_PROXY_NAME_TEMPLATE = "llmtrace-proxy-{tenant_id}"
+DEFAULT_DASHBOARD_NAME_TEMPLATE = "llmtrace-dashboard-{tenant_id}"
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    """Full deployment spec for one component (proxy or dashboard).
+
+    Every business-meaning field is required from the caller. Probe and
+    timeout fields default because they describe wait-mechanics.
+    """
+
+    image: str
+    port: int
+    cpu: str
+    memory: str
+    replicas: int
+    env: Mapping[str, str]
+    health_check_path: str = "/health"
+    startup_timeout_seconds: int = 600
+    startup_initial_delay_seconds: int = 30
+    startup_period_seconds: int = 30
+    startup_failure_threshold: int = 15
+    liveness_period_seconds: int = 30
+    liveness_failure_threshold: int = 3
+    readiness_period_seconds: int = 10
+    readiness_failure_threshold: int = 3
+
+
+@dataclass(frozen=True)
+class TenantSpec:
+    """Full per-tenant deployment specification."""
+
+    tenant_id: str
+    proxy: ComponentSpec
+    dashboard: ComponentSpec
+    proxy_name_template: str = DEFAULT_PROXY_NAME_TEMPLATE
+    dashboard_name_template: str = DEFAULT_DASHBOARD_NAME_TEMPLATE
+    # If True, the resolved proxy URL is injected into the dashboard's env
+    # under `proxy_url_env_var` before the dashboard is created.
+    inject_proxy_url_into_dashboard: bool = True
+    proxy_url_env_var: str = "LLMTRACE_PROXY_URL"
+
+
+@dataclass(frozen=True)
+class InstanceInfo:
+    """Lifecycle-relevant view of a single Basilica deployment.
+
+    `instance_id` is the Basilica-assigned UUID — the only stable handle
+    for subsequent SDK calls. The caller is responsible for persisting it.
+    """
+
+    instance_id: str
+    state: str
+    url: str
+    ready_replicas: int
+    desired_replicas: int
+    phase: Optional[str] = None
+    message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TenantInstances:
+    """A tenant's deployment pair. Either side may be None when absent."""
+
+    tenant_id: str
+    proxy: Optional[InstanceInfo]
+    dashboard: Optional[InstanceInfo]
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    if not TENANT_ID_PATTERN.match(tenant_id):
+        raise ValueError(
+            f"tenant_id {tenant_id!r} must match {TENANT_ID_PATTERN.pattern}"
+        )
+    return tenant_id
+
+
+def make_client(api_key: Optional[str] = None) -> BasilicaClient:
+    key = api_key or os.environ.get("BASILICA_API_TOKEN")
+    if not key:
+        raise RuntimeError("BASILICA_API_TOKEN is not set")
+    return BasilicaClient(api_key=key)
+
+
+def _to_info(detail) -> InstanceInfo:
+    return InstanceInfo(
+        instance_id=detail.instance_name,
+        state=detail.state,
+        url=detail.url,
+        ready_replicas=detail.replicas.ready,
+        desired_replicas=detail.replicas.desired,
+        phase=getattr(detail, "phase", None),
+        message=getattr(detail, "message", None),
+    )
+
+
+def _build_health_check(spec: ComponentSpec) -> HealthCheckConfig:
+    return HealthCheckConfig(
+        startup=ProbeConfig(
+            path=spec.health_check_path,
+            port=spec.port,
+            initial_delay_seconds=spec.startup_initial_delay_seconds,
+            period_seconds=spec.startup_period_seconds,
+            failure_threshold=spec.startup_failure_threshold,
+        ),
+        liveness=ProbeConfig(
+            path=spec.health_check_path,
+            port=spec.port,
+            period_seconds=spec.liveness_period_seconds,
+            failure_threshold=spec.liveness_failure_threshold,
+        ),
+        readiness=ProbeConfig(
+            path=spec.health_check_path,
+            port=spec.port,
+            period_seconds=spec.readiness_period_seconds,
+            failure_threshold=spec.readiness_failure_threshold,
+        ),
+    )
+
+
+def _wait_until_ready(
+    client: BasilicaClient,
+    instance_id: str,
+    timeout_seconds: int,
+    expected_replicas: int,
+) -> InstanceInfo:
+    """Poll until `ready >= expected` and `desired >= expected`.
+
+    The post-create GET can race ahead of the Basilica operator's
+    reconciliation, briefly reporting `desired=0` even when the caller
+    requested 1+. Gating on `desired >= expected_replicas` prevents an
+    early false-positive return.
+    """
+    elapsed = 0
+    while elapsed < timeout_seconds:
+        detail = client.get_deployment(instance_id)
+        replicas = detail.replicas
+        LOGGER.info(
+            "deployment=%s state=%s phase=%s replicas=%d/%d expected=%d elapsed=%ds",
+            instance_id,
+            detail.state,
+            getattr(detail, "phase", None),
+            replicas.ready,
+            replicas.desired,
+            expected_replicas,
+            elapsed,
+        )
+        if (
+            detail.state in ("running", "Active")
+            and replicas.desired >= expected_replicas
+            and replicas.ready >= expected_replicas
+        ):
+            return _to_info(detail)
+        if detail.state in ("failed", "error", "Failed"):
+            raise RuntimeError(
+                f"deployment {instance_id} entered terminal failure: "
+                f"state={detail.state} message={detail.message or 'n/a'}"
+            )
+        time.sleep(POLL_INTERVAL_SECONDS)
+        elapsed += POLL_INTERVAL_SECONDS
+    raise TimeoutError(
+        f"deployment {instance_id} not ready after {timeout_seconds}s "
+        f"(expected_replicas={expected_replicas})"
+    )
+
+
+def _create_component(
+    client: BasilicaClient, friendly_name: str, spec: ComponentSpec
+) -> InstanceInfo:
+    LOGGER.info(
+        "creating friendly=%s image=%s cpu=%s memory=%s replicas=%d port=%d env_keys=%s",
+        friendly_name,
+        spec.image,
+        spec.cpu,
+        spec.memory,
+        spec.replicas,
+        spec.port,
+        sorted(spec.env.keys()),
+    )
+    response = client.create_deployment(
+        instance_name=friendly_name,
+        image=spec.image,
+        replicas=spec.replicas,
+        port=spec.port,
+        env=dict(spec.env),
+        cpu=spec.cpu,
+        memory=spec.memory,
+        health_check=_build_health_check(spec),
+    )
+    LOGGER.info(
+        "created friendly=%s instance_id=%s initial_state=%s",
+        friendly_name,
+        response.instance_name,
+        response.state,
+    )
+    return _wait_until_ready(
+        client,
+        response.instance_name,
+        spec.startup_timeout_seconds,
+        expected_replicas=spec.replicas,
+    )
+
+
+def _safe_get(client: BasilicaClient, instance_id: Optional[str]) -> Optional[InstanceInfo]:
+    """Read instance state by UUID. Returns None if the UUID is None or 404."""
+    if not instance_id:
+        return None
+    try:
+        return _to_info(client.get_deployment(instance_id))
+    except KeyError as exc:
+        if "Not found" in str(exc):
+            LOGGER.info("instance %s not found", instance_id)
+            return None
+        raise
+
+
+def _safe_delete(client: BasilicaClient, instance_id: Optional[str], label: str) -> bool:
+    """Delete by UUID. Returns True if deletion was attempted, False if absent."""
+    if not instance_id:
+        LOGGER.info("%s instance_id not provided — skipping delete", label)
+        return False
+    try:
+        result = client.delete_deployment(instance_id)
+        LOGGER.info("deleted %s instance_id=%s state=%s", label, instance_id, result.state)
+        return True
+    except KeyError as exc:
+        if "Not found" in str(exc):
+            LOGGER.info("%s instance_id=%s already absent", label, instance_id)
+            return False
+        raise
+
+
+def provision(
+    spec: TenantSpec, client: Optional[BasilicaClient] = None
+) -> TenantInstances:
+    """Provision a fresh proxy + dashboard pair.
+
+    This always creates new Basilica deployments. The caller MUST track
+    the returned `instance_id`s to perform any subsequent lifecycle
+    operations (status / update / deprovision) — Basilica does not expose
+    a friendly-name → UUID lookup, so the IDs cannot be rediscovered.
+
+    To make provision *idempotent at the caller*: before calling, check
+    your own DB for existing IDs; if found, call `status(...)` with those
+    IDs instead.
+    """
+    tenant_id = validate_tenant_id(spec.tenant_id)
+    client = client or make_client()
+    proxy_name = spec.proxy_name_template.format(tenant_id=tenant_id)
+    dashboard_name = spec.dashboard_name_template.format(tenant_id=tenant_id)
+
+    proxy = _create_component(client, proxy_name, spec.proxy)
+
+    dashboard_spec = spec.dashboard
+    if spec.inject_proxy_url_into_dashboard:
+        merged_env = {**dashboard_spec.env, spec.proxy_url_env_var: proxy.url}
+        dashboard_spec = dataclasses.replace(dashboard_spec, env=merged_env)
+    dashboard = _create_component(client, dashboard_name, dashboard_spec)
+
+    return TenantInstances(tenant_id=tenant_id, proxy=proxy, dashboard=dashboard)
+
+
+def update(
+    spec: TenantSpec,
+    proxy_instance_id: str,
+    dashboard_instance_id: str,
+    strategy: str = "recreate",
+    client: Optional[BasilicaClient] = None,
+) -> TenantInstances:
+    """Update the pair, addressed by caller-supplied UUIDs.
+
+    `strategy="restart"` rolls the existing pods; URLs and config stay
+    untouched. `spec` is consulted only for timeouts.
+
+    `strategy="recreate"` deletes both UUIDs and creates fresh ones from
+    `spec`. URLs change — return value carries the NEW UUIDs the caller
+    must persist.
+    """
+    tenant_id = validate_tenant_id(spec.tenant_id)
+    client = client or make_client()
+
+    if strategy == "restart":
+        LOGGER.info("restarting proxy instance_id=%s", proxy_instance_id)
+        client.restart_deployment(proxy_instance_id)
+        LOGGER.info("restarting dashboard instance_id=%s", dashboard_instance_id)
+        client.restart_deployment(dashboard_instance_id)
+        proxy = _wait_until_ready(
+            client,
+            proxy_instance_id,
+            spec.proxy.startup_timeout_seconds,
+            expected_replicas=spec.proxy.replicas,
+        )
+        dashboard = _wait_until_ready(
+            client,
+            dashboard_instance_id,
+            spec.dashboard.startup_timeout_seconds,
+            expected_replicas=spec.dashboard.replicas,
+        )
+        return TenantInstances(tenant_id=tenant_id, proxy=proxy, dashboard=dashboard)
+
+    if strategy != "recreate":
+        raise ValueError(
+            f"strategy must be 'restart' or 'recreate', got {strategy!r}"
+        )
+
+    LOGGER.info(
+        "recreating tenant=%s — deleting dashboard then proxy", tenant_id
+    )
+    _safe_delete(client, dashboard_instance_id, "dashboard")
+    _safe_delete(client, proxy_instance_id, "proxy")
+    return provision(spec, client=client)
+
+
+def deprovision(
+    tenant_id: str,
+    proxy_instance_id: Optional[str] = None,
+    dashboard_instance_id: Optional[str] = None,
+    client: Optional[BasilicaClient] = None,
+) -> TenantInstances:
+    """Delete the supplied UUIDs. Missing IDs are skipped (idempotent)."""
+    tenant_id = validate_tenant_id(tenant_id)
+    client = client or make_client()
+    _safe_delete(client, dashboard_instance_id, "dashboard")
+    _safe_delete(client, proxy_instance_id, "proxy")
+    return TenantInstances(tenant_id=tenant_id, proxy=None, dashboard=None)
+
+
+def status(
+    tenant_id: str,
+    proxy_instance_id: Optional[str] = None,
+    dashboard_instance_id: Optional[str] = None,
+    client: Optional[BasilicaClient] = None,
+) -> TenantInstances:
+    """Read state for the supplied UUIDs. Returns None for absent/missing IDs."""
+    tenant_id = validate_tenant_id(tenant_id)
+    client = client or make_client()
+    return TenantInstances(
+        tenant_id=tenant_id,
+        proxy=_safe_get(client, proxy_instance_id),
+        dashboard=_safe_get(client, dashboard_instance_id),
+    )


### PR DESCRIPTION
## Summary

Stateless multi-tenant provisioning layer for LLMTrace on Basilica, with a thin GitHub Actions surface for triggering from the product API.

- **`deployments/basilica/lifecycle.py`** — `ComponentSpec` + `TenantSpec` dataclasses driving `provision` / `update` / `deprovision` / `status`. Zero baked defaults for runtime config: image, env, resources, ports all come from the caller's config. Caller owns the `tenant_id → UUID` mapping because Basilica's SDK only addresses deployments by server-assigned UUID — friendly name on create is one-way and unrecoverable.
- **`deployments/basilica/cli.py`** — loads YAML/JSON config (or inline JSON via `--config-json`), substitutes `${VAR}` / `${VAR:-default}` from process environment so secrets stay out of files, emits JSON to stdout with exit codes 0 / 2 / 3.
- **`deployments/basilica/configs/examples/{starter,pro}.yaml`** — example tenant configs (single-replica vs multi-replica with datamarking active).
- **`.github/workflows/tenant-lifecycle.yml`** — `workflow_dispatch` trigger exposing the four lifecycle actions. App calls `POST /repos/.../actions/workflows/tenant-lifecycle.yml/dispatches` with `tenant_id`, `action`, `config_path`-or-`config_json`, and `proxy_instance_id` / `dashboard_instance_id` (when known). Workflow surfaces proxy/dashboard UUIDs and URLs as step outputs.

## Validation

Full live round-trip against a real Basilica account on 2026-05-16 (tenant `rt-919126`):

- **Provision** — proxy UUID `4fd7b93e-...` ready in ~40s, dashboard UUID `1fa4d887-...` ready in ~40s, dashboard env auto-injected with `LLMTRACE_PROXY_URL=<proxy_url>`
- **Status** — matched live state
- **HTTP round-trip** — both `https://<uuid>.deployments.basilica.ai/` returned 200 over real internet
- **Update `--strategy=recreate`** — config re-applied, URLs verified 200 again
- **Deprovision** — both deleted, `list_deployments()` returned 0
- **Idempotent re-deprovision** — returns null pair, exit 0

One **surfaced limitation** (not a library bug): `update --strategy=restart` against a freshly-provisioned deployment fails with a Basilica server-side 404 (`deployments.apps "ud-<uuid>-deployment" not found`) because the k8s Deployment CR isn't materialised yet. The library reports this cleanly via exit 3 + structured JSON error; callers should fall back to `recreate` or retry after the deployment has been running long enough for the CR to exist.

## How a tenant config is wired

```yaml
# deployments/basilica/configs/examples/starter.yaml
proxy:
  image: ghcr.io/techlab-innov/llmtrace-proxy:latest
  port: 8080
  cpu: "2"
  memory: 4Gi
  replicas: 1
  env:
    LLMTRACE_UPSTREAM_URL: "${LLMTRACE_UPSTREAM_URL}"
    OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
    # ... any LLMTrace flag you want per-tenant
dashboard:
  image: ghcr.io/techlab-innov/llmtrace-dashboard:latest
  port: 3000
  cpu: "1"
  memory: 1Gi
  replicas: 1
  env:
    LLMTRACE_AUTH_ADMIN_KEY: "${LLMTRACE_AUTH_ADMIN_KEY:-}"
```

The product API triggers `workflow_dispatch` with `tenant_id`, `config_path` (or inline `config_json`), and the relevant secrets configured as repo / environment secrets. The workflow's `Run lifecycle action` step writes `proxy_url`, `dashboard_url`, `proxy_instance_id`, `dashboard_instance_id` to `GITHUB_OUTPUT`; the app reads them back via the GitHub API and persists them in its DB.

## Test plan

- [ ] `gh workflow run tenant-lifecycle.yml -f tenant_id=demo -f action=provision -f config_path=deployments/basilica/configs/examples/starter.yaml` returns proxy + dashboard URLs in the run summary
- [ ] Subsequent `action=status` with the captured UUIDs returns matching state
- [ ] `action=deprovision` with the captured UUIDs removes both deployments
- [ ] CI green on this branch (no test suites depend on the new files, so should be a no-op)