### PR TITLE
ci(images): publish proxy + dashboard under techlab-innov

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,155 @@
+# =============================================================================
+# Publish Tenant Images — proxy + dashboard images for the multi-tenant
+# Basilica lifecycle.
+#
+# Unlike release.yml (tag-triggered, cuts a real release + crates.io + PyPI),
+# this workflow only builds + pushes container images to GHCR under the
+# techlab-innov org. Two trigger paths:
+#
+#   - push to main → publish `:main` and `:sha-<short>` tags (auto)
+#   - workflow_dispatch → optionally tag as `:latest` and/or a custom label
+#
+# The product's `tenant-lifecycle.yml` workflow references the published
+# images via the per-tenant config file (image: ghcr.io/techlab-innov/...).
+# =============================================================================
+name: publish-images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Dockerfile"
+      - "dashboard/**"
+      - ".github/workflows/publish-images.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Additional image tag to publish (e.g. 'latest', 'rc1')"
+        required: false
+        type: string
+        default: "latest"
+      mark_latest:
+        description: "Publish :latest alongside the sha + tag"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: techlab-innov
+
+jobs:
+  proxy:
+    name: Proxy image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        env:
+          MARK_LATEST: ${{ inputs.mark_latest }}
+          CUSTOM_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${OWNER}/llmtrace-proxy"
+          short_sha="${GITHUB_SHA::7}"
+          tags=("${image}:sha-${short_sha}" "${image}:main")
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            [[ -n "${CUSTOM_TAG}" ]] && tags+=("${image}:${CUSTOM_TAG}")
+            [[ "${MARK_LATEST}" == "true" ]] && tags+=("${image}:latest")
+          else
+            # Auto push from main always refreshes :latest
+            tags+=("${image}:latest")
+          fi
+          printf 'tags=' >> "${GITHUB_OUTPUT}"
+          printf '%s,' "${tags[@]}" | sed 's/,$//' >> "${GITHUB_OUTPUT}"
+          printf '\n' >> "${GITHUB_OUTPUT}"
+          printf 'tags computed:\n'; printf '  %s\n' "${tags[@]}"
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha,scope=proxy
+          cache-to: type=gha,mode=max,scope=proxy
+
+  dashboard:
+    name: Dashboard image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        env:
+          MARK_LATEST: ${{ inputs.mark_latest }}
+          CUSTOM_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${OWNER}/llmtrace-dashboard"
+          short_sha="${GITHUB_SHA::7}"
+          tags=("${image}:sha-${short_sha}" "${image}:main")
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            [[ -n "${CUSTOM_TAG}" ]] && tags+=("${image}:${CUSTOM_TAG}")
+            [[ "${MARK_LATEST}" == "true" ]] && tags+=("${image}:latest")
+          else
+            tags+=("${image}:latest")
+          fi
+          printf 'tags=' >> "${GITHUB_OUTPUT}"
+          printf '%s,' "${tags[@]}" | sed 's/,$//' >> "${GITHUB_OUTPUT}"
+          printf '\n' >> "${GITHUB_OUTPUT}"
+          printf 'tags computed:\n'; printf '  %s\n' "${tags[@]}"
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: ./dashboard
+          file: ./dashboard/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha,scope=dashboard
+          cache-to: type=gha,mode=max,scope=dashboard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: epappas/llmtrace-proxy
+  IMAGE_NAME: techlab-innov/llmtrace-proxy
 
 permissions:
   contents: write
@@ -59,12 +59,12 @@ jobs:
             echo "### Install"
             echo ""
             echo '```bash'
-            echo "curl -sS https://raw.githubusercontent.com/epappas/llmtrace/main/scripts/install.sh | bash"
+            echo "curl -sS https://raw.githubusercontent.com/techlab-innov/llmtrace/main/scripts/install.sh | bash"
             echo ""
             echo "# Or use:"
             echo "cargo install llmtrace       # Rust proxy"
             echo "pip install llmtracing         # Python SDK"
-            echo "docker pull ghcr.io/epappas/llmtrace-proxy:$VERSION"
+            echo "docker pull ghcr.io/techlab-innov/llmtrace-proxy:$VERSION"
             echo '```'
             echo ""
             echo "- [crates.io/crates/llmtrace](https://crates.io/crates/llmtrace)"


### PR DESCRIPTION
## Summary

Unblocks the multi-tenant Basilica lifecycle (#224) by ensuring the proxy + dashboard images it references actually exist under `ghcr.io/techlab-innov`.

Today:
- `ghcr.io/epappas/llmtrace-proxy:latest` → **404**
- `ghcr.io/techlab-innov/llmtrace-proxy:*` → **missing** (release.yml still pointed at the legacy `epappas` org)
- `ghcr.io/techlab-innov/llmtrace-dashboard:*` → **missing** (release.yml never built a dashboard image at all)

After this PR:
- `publish-images.yml` builds both images on every push to `main` that touches relevant paths, tagging `:main`, `:sha-<short>`, and `:latest`.
- The same workflow can be fired manually via `workflow_dispatch` with a custom `:tag` (e.g. `rc1`) and a `mark_latest` toggle, for the cases where you want a fresh image without a real release.
- `release.yml` keeps doing the formal `v*`-tag release but now publishes the proxy under `techlab-innov` (changelog body + install.sh URL updated to match).

## What this is *not*

- Doesn't cut a release tag — that's still a separate manual `git tag v0.x.y`.
- Doesn't touch crates.io / PyPI / GitHub Release flow — those stay tag-triggered.
- Doesn't change image internals (Dockerfiles unchanged).

## Test plan

- [ ] CI green on this PR (no Rust / Python changes, so existing test jobs should pass cleanly).
- [ ] After merge, `publish-images.yml` runs automatically on the merge commit and pushes `ghcr.io/techlab-innov/llmtrace-{proxy,dashboard}:{main,sha-<short>,latest}`.
- [ ] Anon `curl https://ghcr.io/v2/techlab-innov/llmtrace-proxy/manifests/latest` returns 200 (or 403 if the GHCR packages need to be flipped to public via the org's package settings — separate one-time manual step).
- [ ] The tenant-lifecycle workflow's example configs (`deployments/basilica/configs/examples/{starter,pro}.yaml`) deploy successfully against Basilica once the images are pullable.