### PR TITLE
feat(basilica): per-tenant LLMTrace API key auth, secure by default

### DIFF
--- a/.github/workflows/tenant-lifecycle.yml
+++ b/.github/workflows/tenant-lifecycle.yml
@@ -258,6 +258,19 @@ jobs:
           python3 -m deployments.basilica.cli "${ACTION}" "${args[@]}" > result.json
           code=$?
           set -e
+
+          # Mask the api_key BEFORE any log line (cat / step summary) touches
+          # result.json. ::add-mask:: is per-job and applies to subsequent log
+          # lines, so registering it here covers the cat below + the summary
+          # step + any downstream consumers that print step outputs.
+          python3 - <<'PY'
+          import json, pathlib
+          data = json.loads(pathlib.Path("result.json").read_text() or "{}")
+          key = data.get("api_key")
+          if key:
+              print(f"::add-mask::{key}")
+          PY
+
           cat result.json
           echo "exit_code=${code}" >> "${GITHUB_OUTPUT}"
           python3 - <<'PY' >> "${GITHUB_OUTPUT}"
@@ -267,6 +280,10 @@ jobs:
           print(f"dashboard_instance_id={data.get('dashboard_instance_id') or ''}")
           print(f"proxy_url={data.get('proxy_url') or ''}")
           print(f"dashboard_url={data.get('dashboard_url') or ''}")
+          # api_key is masked; emitting it as a step output is fine because
+          # downstream consumers (the caller's app via the Actions API) need it
+          # to give the tenant their bearer token. The value is opaque to logs.
+          print(f"api_key={data.get('api_key') or ''}")
           PY
           if [[ "${code}" -ne 0 ]]; then
             exit "${code}"

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -247,6 +247,109 @@ wins for that tenant.
 
 Both demonstrate `${VAR}` substitution and the optional override pattern.
 
+## Per-tenant API key auth (secure by default)
+
+LLMTrace's proxy has built-in API-key auth (`crates/llmtrace-proxy/src/auth.rs`).
+Without it, the public Basilica URL accepts any request — anyone with the
+URL can burn the tenant's upstream quota and pollute their traces. With it
+on, every non-`/health` request must carry `Authorization: Bearer llmt_<key>`
+or get a 401.
+
+The lifecycle library enables this **by default** at provision time:
+
+1. Resolves a key, in priority order:
+   - Explicit `spec.api_key` from the caller (or `api_key:` field in the
+     YAML config), used for plan-recreates that must preserve the tenant's
+     existing key
+   - Existing `LLMTRACE_AUTH_ADMIN_KEY` in `proxy.env` (rare — caller wrote
+     it themselves)
+   - Auto-generated `llmt_<64-hex>` via `generate_api_key()` matching the
+     format produced by the Rust proxy at `auth.rs:44`
+2. Injects `LLMTRACE_AUTH_ENABLED=true` + `LLMTRACE_AUTH_ADMIN_KEY=<key>`
+   into the proxy's env, and the same `LLMTRACE_AUTH_ADMIN_KEY` into the
+   dashboard's env (so the dashboard can authenticate to the proxy's admin
+   endpoints)
+3. Returns the plaintext key in `TenantInstances.api_key` — **this is the
+   only time it's exposed**. Persist it in your app DB and ship it to the
+   tenant.
+
+```python
+result = lifecycle.provision(spec)
+tenant_record.api_key = result.api_key      # llmt_xxxxxxxxxxxx... — only exposed here
+tenant_record.proxy_url = result.proxy.url
+db.session.commit()
+```
+
+The CLI emits it in the result JSON:
+
+```json
+{
+  "tenant_id": "acme",
+  "proxy_url": "https://...basilica.ai",
+  "dashboard_url": "https://...basilica.ai",
+  "api_key": "llmt_d34c8a..."
+}
+```
+
+The workflow registers `::add-mask::` for the key before any `cat`
+operation, so it never appears in run logs — only in step outputs (which
+the calling app fetches via the Actions API).
+
+### Tenant-side usage
+
+The tenant programs their downstream apps to send their API key on every
+request to their proxy URL:
+
+```bash
+curl -X POST https://<proxy_uuid>.deployments.basilica.ai/v1/chat/completions \
+  -H "Authorization: Bearer llmt_d34c8a..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
+```
+
+A 401 means they used the wrong key. A 200 means LLMTrace authenticated
+them, then forwarded upstream (with whatever upstream auth was configured
+in `tenant_secrets`).
+
+### Disabling auth
+
+For a trusted-network deploy where the proxy URL won't leak (a VPC-only
+mesh, a dev sandbox, etc.), turn auth off:
+
+```yaml
+enable_proxy_auth: false
+```
+
+The library skips key generation, doesn't inject `LLMTRACE_AUTH_*`, and
+returns `api_key: null` in the result. The proxy URL is then wide open;
+own the consequences.
+
+### Preserving the key across recreates
+
+`update(..., strategy="recreate")` calls `provision()` under the hood,
+which will auto-generate a fresh key unless you pass the existing one.
+For plan upgrades where the tenant's apps shouldn't break, fetch the
+current key from your DB and put it in the spec:
+
+```python
+spec = build_spec_from_tenant_record(tenant_record)
+spec = dataclasses.replace(spec, api_key=tenant_record.api_key)  # preserve
+new_instances = lifecycle.update(spec, proxy_id=..., dashboard_id=..., strategy="recreate")
+# new_instances.api_key == tenant_record.api_key  (carried forward)
+```
+
+### Caveats
+
+- **Admin-key-as-runtime-key is overpowered.** The auto-generated key
+  takes the `auth.admin_key` slot (bootstrap admin role), meaning the
+  tenant's apps technically have admin scope on their own instance.
+  Hardening: after provision, POST a scoped non-admin key via the
+  proxy's `/admin/keys` endpoint and hand THAT to the tenant. Tracked
+  as a follow-up.
+- **Defence-in-depth** still worth doing separately: per-tenant rate
+  limits (LLMTrace likely has them — configure), and DoS protection
+  against CPU burn from ML detectors running before the upstream call.
+
 ## Per-tenant secret injection
 
 Two trigger paths, pick by intended audience:
@@ -757,15 +860,16 @@ win).
 
 | File | Purpose |
 |---|---|
-| `lifecycle.py:51` | `ComponentSpec` dataclass — one component's full deployment shape |
-| `lifecycle.py:76` | `TenantSpec` dataclass — tenant's pair |
-| `lifecycle.py:279` | `provision(spec)` |
-| `lifecycle.py:309` | `update(spec, proxy_id, dashboard_id, strategy)` |
-| `lifecycle.py:360` | `deprovision(tenant_id, proxy_id?, dashboard_id?)` |
-| `lifecycle.py:374` | `status(tenant_id, proxy_id?, dashboard_id?)` |
+| `lifecycle.py:66` | `ComponentSpec` dataclass — one component's full deployment shape |
+| `lifecycle.py:91` | `TenantSpec` dataclass — tenant's pair (incl. `enable_proxy_auth` + `api_key`) |
+| `lifecycle.py:55` | `generate_api_key()` — `llmt_<64-hex>` matching the Rust proxy |
+| `lifecycle.py:343` | `provision(spec)` |
+| `lifecycle.py:387` | `update(spec, proxy_id, dashboard_id, strategy)` |
+| `lifecycle.py:438` | `deprovision(tenant_id, proxy_id?, dashboard_id?)` |
+| `lifecycle.py:452` | `status(tenant_id, proxy_id?, dashboard_id?)` |
 | `cli.py:40` | `_substitute_env` — `${VAR}` resolver |
 | `cli.py:60` | `_load_config` — YAML/JSON loader |
 | `cli.py:113` | `_tenant_spec_from_config` — dict → `TenantSpec` |
-| `cli.py:151` | `_build_parser` — argparse subcommand wiring |
+| `cli.py:154` | `_build_parser` — argparse subcommand wiring |
 | `.github/workflows/tenant-lifecycle.yml` | Spawn workflow (workflow_dispatch + repository_dispatch) |
 | `.github/workflows/publish-images.yml` | Image build/push pipeline |

--- a/deployments/basilica/cli.py
+++ b/deployments/basilica/cli.py
@@ -127,6 +127,8 @@ def _tenant_spec_from_config(tenant_id: str, cfg: dict[str, Any]) -> lifecycle.T
         "dashboard_name_template",
         "inject_proxy_url_into_dashboard",
         "proxy_url_env_var",
+        "enable_proxy_auth",
+        "api_key",
     ):
         if key in cfg:
             kwargs[key] = cfg[key]
@@ -145,6 +147,7 @@ def _serialise(instances: lifecycle.TenantInstances) -> dict[str, Any]:
         "dashboard_instance_id": instances.dashboard.instance_id if instances.dashboard else None,
         "proxy_url": instances.proxy.url if instances.proxy else None,
         "dashboard_url": instances.dashboard.url if instances.dashboard else None,
+        "api_key": instances.api_key,
     }
 
 

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -1,5 +1,9 @@
 # LLMTrace tenant config — pro tier example.
 # Multi-replica proxy, persistent dashboard, debug logging, datamarking on.
+#
+# Auth: per-tenant API key is auto-generated at provision time (or supply
+# `api_key:` at the top level to force a specific value). See starter.yaml
+# for the full auth contract.
 
 proxy:
   image: "ghcr.io/techlab-innov/llmtrace-proxy:${LLMTRACE_VERSION:-latest}"

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -7,6 +7,14 @@
 # `${VAR}` and `${VAR:-default}` placeholders in string values are resolved
 # from the process environment at deploy time. Use this to keep secrets out
 # of the config file.
+#
+# Auth: `enable_proxy_auth` defaults to true. On provision, the lifecycle
+# library either uses a caller-supplied `api_key` (top-level) or auto-generates
+# an `llmt_<64-hex>` key, injects it into both proxy + dashboard envs as
+# LLMTRACE_AUTH_ADMIN_KEY, and returns it in the result JSON. The plaintext
+# key is exposed once on provision — your app must persist it and ship it to
+# the tenant as their `Authorization: Bearer llmt_<key>` header. Set
+# `enable_proxy_auth: false` to deploy an open proxy.
 
 proxy:
   image: ghcr.io/techlab-innov/llmtrace-proxy:latest
@@ -39,10 +47,18 @@ dashboard:
   env:
     HOSTNAME: 0.0.0.0
     NODE_ENV: production
-    LLMTRACE_AUTH_ADMIN_KEY: "${LLMTRACE_AUTH_ADMIN_KEY:-}"
+    # LLMTRACE_AUTH_ADMIN_KEY is set by the lifecycle library at provision
+    # time to match the proxy's resolved key. If you set it here explicitly,
+    # that value wins for the dashboard env (but the proxy's resolved key is
+    # what the tenant must actually send — keep them consistent).
 
 # Optional — override if your tenant naming scheme differs.
 # proxy_name_template: "llmtrace-proxy-{tenant_id}"
 # dashboard_name_template: "llmtrace-dashboard-{tenant_id}"
 # inject_proxy_url_into_dashboard: true
 # proxy_url_env_var: LLMTRACE_PROXY_URL
+
+# Auth controls (defaults shown). Set explicit `api_key` to force a specific
+# value (e.g. when recreating to preserve the existing tenant key).
+# enable_proxy_auth: true
+# api_key: null

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -26,6 +26,7 @@ import dataclasses
 import logging
 import os
 import re
+import secrets as _secrets
 import time
 from dataclasses import dataclass
 from typing import Mapping, Optional
@@ -45,6 +46,20 @@ POLL_INTERVAL_SECONDS = 10
 
 DEFAULT_PROXY_NAME_TEMPLATE = "llmtrace-proxy-{tenant_id}"
 DEFAULT_DASHBOARD_NAME_TEMPLATE = "llmtrace-dashboard-{tenant_id}"
+
+# LLMTrace API key format — matches `crates/llmtrace-proxy/src/auth.rs::generate_api_key`.
+API_KEY_PREFIX = "llmt_"
+API_KEY_RANDOM_BYTES = 32
+
+
+def generate_api_key() -> str:
+    """Generate an LLMTrace-compatible API key.
+
+    Format: `llmt_` + 32 random bytes hex-encoded (64 hex chars).
+    Matches the layout produced by the Rust proxy so a generated key drops
+    straight into `LLMTRACE_AUTH_ADMIN_KEY` without translation.
+    """
+    return API_KEY_PREFIX + _secrets.token_hex(API_KEY_RANDOM_BYTES)
 
 
 @dataclass(frozen=True)
@@ -85,6 +100,13 @@ class TenantSpec:
     # under `proxy_url_env_var` before the dashboard is created.
     inject_proxy_url_into_dashboard: bool = True
     proxy_url_env_var: str = "LLMTRACE_PROXY_URL"
+    # If True, the proxy is provisioned with LLMTRACE_AUTH_ENABLED=true plus
+    # an admin key (caller-supplied via `api_key`, or auto-generated). The
+    # same key is also injected into the dashboard env so it can authenticate
+    # to the proxy's admin endpoints. Set False to deploy an open proxy
+    # (anyone with the URL can use it — only do this for trusted networks).
+    enable_proxy_auth: bool = True
+    api_key: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -106,11 +128,18 @@ class InstanceInfo:
 
 @dataclass(frozen=True)
 class TenantInstances:
-    """A tenant's deployment pair. Either side may be None when absent."""
+    """A tenant's deployment pair. Either side may be None when absent.
+
+    `api_key` is populated only on `provision()` and `update(..., strategy="recreate")`;
+    it is the plaintext bearer the tenant must send as `Authorization: Bearer <key>`
+    on every non-`/health` request to the proxy. None on `status` / `deprovision`
+    and when `enable_proxy_auth=False`.
+    """
 
     tenant_id: str
     proxy: Optional[InstanceInfo]
     dashboard: Optional[InstanceInfo]
+    api_key: Optional[str] = None
 
 
 def validate_tenant_id(tenant_id: str) -> str:
@@ -276,6 +305,41 @@ def _safe_delete(client: BasilicaClient, instance_id: Optional[str], label: str)
         raise
 
 
+def _resolve_api_key(spec: TenantSpec) -> Optional[str]:
+    """Resolve the LLMTrace tenant API key for `provision`.
+
+    Priority: explicit `spec.api_key` > existing `LLMTRACE_AUTH_ADMIN_KEY`
+    in `spec.proxy.env` > newly generated. Returns None when
+    `enable_proxy_auth` is False.
+    """
+    if not spec.enable_proxy_auth:
+        return None
+    if spec.api_key:
+        return spec.api_key
+    env_key = spec.proxy.env.get("LLMTRACE_AUTH_ADMIN_KEY", "")
+    if env_key:
+        return env_key
+    return generate_api_key()
+
+
+def _apply_proxy_auth(
+    proxy_spec: ComponentSpec, dashboard_spec: ComponentSpec, api_key: str
+) -> tuple[ComponentSpec, ComponentSpec]:
+    """Inject `LLMTRACE_AUTH_ENABLED=true` + the admin key into both envs.
+
+    The admin key is set unconditionally (we want proxy + dashboard
+    consistent); `LLMTRACE_AUTH_ENABLED` is only defaulted (caller may
+    explicitly turn it off in env).
+    """
+    proxy_env = {**proxy_spec.env, "LLMTRACE_AUTH_ADMIN_KEY": api_key}
+    proxy_env.setdefault("LLMTRACE_AUTH_ENABLED", "true")
+    dashboard_env = {**dashboard_spec.env, "LLMTRACE_AUTH_ADMIN_KEY": api_key}
+    return (
+        dataclasses.replace(proxy_spec, env=proxy_env),
+        dataclasses.replace(dashboard_spec, env=dashboard_env),
+    )
+
+
 def provision(
     spec: TenantSpec, client: Optional[BasilicaClient] = None
 ) -> TenantInstances:
@@ -286,6 +350,12 @@ def provision(
     operations (status / update / deprovision) — Basilica does not expose
     a friendly-name → UUID lookup, so the IDs cannot be rediscovered.
 
+    If `spec.enable_proxy_auth` is True (default), an LLMTrace API key
+    is resolved (explicit > env > auto-generated) and injected into both
+    component envs as `LLMTRACE_AUTH_ADMIN_KEY`. The plaintext key is
+    returned in `TenantInstances.api_key` so the caller can persist it
+    and hand it to the tenant — it's the only time the key is exposed.
+
     To make provision *idempotent at the caller*: before calling, check
     your own DB for existing IDs; if found, call `status(...)` with those
     IDs instead.
@@ -295,15 +365,23 @@ def provision(
     proxy_name = spec.proxy_name_template.format(tenant_id=tenant_id)
     dashboard_name = spec.dashboard_name_template.format(tenant_id=tenant_id)
 
-    proxy = _create_component(client, proxy_name, spec.proxy)
+    api_key = _resolve_api_key(spec)
+    proxy_spec, dashboard_spec = (spec.proxy, spec.dashboard)
+    if api_key is not None:
+        proxy_spec, dashboard_spec = _apply_proxy_auth(
+            proxy_spec, dashboard_spec, api_key
+        )
 
-    dashboard_spec = spec.dashboard
+    proxy = _create_component(client, proxy_name, proxy_spec)
+
     if spec.inject_proxy_url_into_dashboard:
         merged_env = {**dashboard_spec.env, spec.proxy_url_env_var: proxy.url}
         dashboard_spec = dataclasses.replace(dashboard_spec, env=merged_env)
     dashboard = _create_component(client, dashboard_name, dashboard_spec)
 
-    return TenantInstances(tenant_id=tenant_id, proxy=proxy, dashboard=dashboard)
+    return TenantInstances(
+        tenant_id=tenant_id, proxy=proxy, dashboard=dashboard, api_key=api_key
+    )
 
 
 def update(


### PR DESCRIPTION
## Summary

Closes the wide-open-proxy-URL gap surfaced during today's review. LLMTrace's proxy already has bearer-token auth (`crates/llmtrace-proxy/src/auth.rs`); our tenant configs just didn't enable it. After this PR, every provisioned tenant gets a per-tenant `llmt_<64-hex>` API key auto-generated at create time, injected into the proxy env, and surfaced to the caller exactly once via `TenantInstances.api_key` / result JSON.

## What changes

| Layer | Change |
|---|---|
| `lifecycle.py` | `generate_api_key()`; `TenantSpec.enable_proxy_auth` (default true) + `TenantSpec.api_key` (explicit override); `TenantInstances.api_key`; `_resolve_api_key` (priority: explicit > env > auto); `_apply_proxy_auth` injects `LLMTRACE_AUTH_ENABLED=true` + `LLMTRACE_AUTH_ADMIN_KEY=<key>` into both proxy and dashboard envs |
| `cli.py` | Config loader accepts `enable_proxy_auth` / `api_key` top-level fields; result JSON includes `api_key` |
| `.github/workflows/tenant-lifecycle.yml` | Registers `::add-mask::` for the key before any `cat result.json` line, so it never appears in workflow logs; exposes as step output |
| `configs/examples/{starter,pro}.yaml` | Comment + opt-out fields |
| `README.md` | New "Per-tenant API key auth (secure by default)" section above secret injection — covers resolution priority, tenant-side curl, recreate-with-preserved-key, opt-out, and caveats |

## Live-validated end-to-end (2026-05-18, tenant `auth-85675`)

| Check | Result |
|---|---|
| `provision` returned `api_key=llmt_<69 chars>` | Matches Rust proxy format (`auth.rs:44`) |
| `/health` no auth | 200 (probes still work) |
| `/` no bearer | 401 |
| `/` wrong bearer | 401 |
| `/` correct bearer | 421 from OpenAI — LLMTrace authed, forwarded, upstream rejected for no upstream auth (proxy doing its job) |
| `deprovision` | clean |

## Breaking change call-out

Existing tenants provisioned before this PR keep working unchanged. **New** provisions now require the caller to:

1. Persist `TenantInstances.api_key` in their DB
2. Ship the plaintext to the tenant (one-time)
3. Tenant sends `Authorization: Bearer llmt_<key>` on every non-`/health` request

To preserve the prior wide-open behaviour for trusted-network deploys, set `enable_proxy_auth: false` in the tenant config. The README documents this escape hatch.

## Caveats (in the README, not blocking)

- The auto-generated key takes the bootstrap admin slot — overpowered for runtime use. A follow-up could POST a scoped non-admin key via `/admin/keys` after provision and hand THAT to the tenant.
- Defence in depth still worth doing separately: per-tenant rate limits, CPU-burn protection (LLMTrace's ML detectors run before the upstream call — auth alone doesn't stop a sustained POST flood from burning proxy CPU).

## Test plan

- [ ] CI green (no Rust changes; new Python lints clean per `ruff check`; lifecycle library unit-tested via the inline checks documented in the commit)
- [ ] Post-merge: trigger `gh workflow run tenant-lifecycle.yml ...` and confirm the workflow's "Run lifecycle action" step prints `::add-mask::<value>` BEFORE any `cat result.json` line that contains the key — verify in the run UI that the key shows as `***` in `cat` output