### PR TITLE
feat(proxy): request body cap + per-tenant rate limit plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,6 +4795,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",

--- a/crates/llmtrace-proxy/Cargo.toml
+++ b/crates/llmtrace-proxy/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4"
 sha2 = "0.10"
 rand = "0.8"
 axum = "0.7"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "limit"] }
 hyper = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde_yaml = "0.9"

--- a/crates/llmtrace-proxy/src/config.rs
+++ b/crates/llmtrace-proxy/src/config.rs
@@ -30,7 +30,15 @@ pub fn load_config(path: &Path) -> anyhow::Result<ProxyConfig> {
 /// - `LLMTRACE_CLICKHOUSE_DATABASE` → `storage.clickhouse_database`
 /// - `LLMTRACE_POSTGRES_URL` → `storage.postgres_url`
 /// - `LLMTRACE_REDIS_URL` → `storage.redis_url`
+/// - `LLMTRACE_AUTH_ENABLED` → `auth.enabled`
+/// - `LLMTRACE_AUTH_ADMIN_KEY` → `auth.admin_key`
+/// - `LLMTRACE_RATE_LIMIT_RPS` → `rate_limiting.requests_per_second`
+/// - `LLMTRACE_RATE_LIMIT_BURST` → `rate_limiting.burst_size`
 /// - `LLMTRACE_ML_MAX_CONCURRENT` → `ml_pipeline.max_concurrent_requests`
+///
+/// Rate-limit overrides only take effect when the parsed value is `> 0`
+/// (a `u32`). Invalid or non-positive values are ignored, leaving the
+/// loaded YAML value (or [`RateLimitConfig::default`]) in place.
 pub fn apply_env_overrides(config: &mut ProxyConfig) {
     if let Ok(val) = std::env::var("LLMTRACE_LISTEN_ADDR") {
         config.listen_addr = val;
@@ -63,6 +71,12 @@ pub fn apply_env_overrides(config: &mut ProxyConfig) {
     if let Ok(val) = std::env::var("LLMTRACE_AUTH_ADMIN_KEY") {
         config.auth.admin_key = Some(val);
     }
+    if let Some(rps) = parse_positive_u32("LLMTRACE_RATE_LIMIT_RPS") {
+        config.rate_limiting.requests_per_second = rps;
+    }
+    if let Some(burst) = parse_positive_u32("LLMTRACE_RATE_LIMIT_BURST") {
+        config.rate_limiting.burst_size = burst;
+    }
     if let Ok(val) = std::env::var("LLMTRACE_ML_MAX_CONCURRENT") {
         match val.parse::<usize>() {
             Ok(n) if n > 0 => config.ml_pipeline.max_concurrent_requests = n,
@@ -72,6 +86,14 @@ pub fn apply_env_overrides(config: &mut ProxyConfig) {
             ),
         }
     }
+}
+
+/// Parse a strictly positive `u32` from an env var. Returns `None` for
+/// missing, empty, unparseable, or zero values so the caller leaves the
+/// loaded configuration untouched.
+fn parse_positive_u32(name: &str) -> Option<u32> {
+    let raw = std::env::var(name).ok()?;
+    raw.trim().parse::<u32>().ok().filter(|n| *n > 0)
 }
 
 /// Validate a [`ProxyConfig`] for common configuration errors.
@@ -343,6 +365,44 @@ health_check:
         assert_eq!(config.storage.database_path, "/tmp/test.db");
         std::env::remove_var("LLMTRACE_STORAGE_PROFILE");
         std::env::remove_var("LLMTRACE_STORAGE_DATABASE_PATH");
+    }
+
+    /// Serialises tests that mutate the same rate-limit env vars so they
+    /// do not race when cargo runs them in parallel.
+    static RATE_LIMIT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_apply_env_overrides_rate_limit_rps_and_burst() {
+        let _guard = RATE_LIMIT_ENV_LOCK.lock().unwrap();
+        let mut config = ProxyConfig::default();
+        std::env::set_var("LLMTRACE_RATE_LIMIT_RPS", "250");
+        std::env::set_var("LLMTRACE_RATE_LIMIT_BURST", "500");
+        apply_env_overrides(&mut config);
+        std::env::remove_var("LLMTRACE_RATE_LIMIT_RPS");
+        std::env::remove_var("LLMTRACE_RATE_LIMIT_BURST");
+        assert_eq!(config.rate_limiting.requests_per_second, 250);
+        assert_eq!(config.rate_limiting.burst_size, 500);
+    }
+
+    #[test]
+    fn test_apply_env_overrides_rate_limit_ignores_invalid() {
+        let _guard = RATE_LIMIT_ENV_LOCK.lock().unwrap();
+        let baseline = ProxyConfig::default();
+        let mut config = ProxyConfig::default();
+        std::env::set_var("LLMTRACE_RATE_LIMIT_RPS", "not-a-number");
+        std::env::set_var("LLMTRACE_RATE_LIMIT_BURST", "0");
+        apply_env_overrides(&mut config);
+        std::env::remove_var("LLMTRACE_RATE_LIMIT_RPS");
+        std::env::remove_var("LLMTRACE_RATE_LIMIT_BURST");
+        // Invalid / zero values must leave the loaded config untouched.
+        assert_eq!(
+            config.rate_limiting.requests_per_second,
+            baseline.rate_limiting.requests_per_second
+        );
+        assert_eq!(
+            config.rate_limiting.burst_size,
+            baseline.rate_limiting.burst_size
+        );
     }
 
     #[test]

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -23,6 +23,7 @@ use llmtrace_storage::StorageProfile;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
+use tower_http::limit::RequestBodyLimitLayer;
 use tracing::info;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -246,6 +247,9 @@ async fn run_proxy(
         storage_profile = %config.storage.profile,
         shutdown_timeout_seconds = config.shutdown.timeout_seconds,
         runtime_overlay_path = ?runtime_overlay_path,
+        max_request_bytes = resolve_max_request_bytes(),
+        rate_limit_rps = config.rate_limiting.requests_per_second,
+        rate_limit_burst = config.rate_limiting.burst_size,
         "Starting LLMTrace proxy server"
     );
 
@@ -952,12 +956,36 @@ async fn build_security_analyzer(
     }
 }
 
+/// Default request body cap (1 MiB).
+///
+/// The proxy enforces this hard cap before any handler is invoked so a
+/// single oversized payload cannot drive downstream ML detectors or the
+/// trace pipeline arbitrarily hard. Configurable per-deployment via
+/// the `LLMTRACE_MAX_REQUEST_BYTES` env var.
+const DEFAULT_MAX_REQUEST_BYTES: usize = 1024 * 1024;
+
+/// Resolve the per-request body cap from the environment, falling back
+/// to [`DEFAULT_MAX_REQUEST_BYTES`] on missing, empty, or unparseable
+/// values.
+fn resolve_max_request_bytes() -> usize {
+    match std::env::var("LLMTRACE_MAX_REQUEST_BYTES") {
+        Ok(raw) => raw
+            .trim()
+            .parse::<usize>()
+            .ok()
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_MAX_REQUEST_BYTES),
+        Err(_) => DEFAULT_MAX_REQUEST_BYTES,
+    }
+}
+
 /// Build the axum [`Router`] with all routes.
 fn build_router(state: Arc<AppState>) -> Router {
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
         .allow_headers(Any);
+    let body_cap = resolve_max_request_bytes();
 
     let router = Router::new()
         // OpenAPI / Swagger UI (served by the proxy itself, not forwarded upstream).
@@ -1096,6 +1124,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             llmtrace_proxy::auth::auth_middleware,
         ))
         .layer(cors)
+        // Hard request body cap. Rejects oversized requests with HTTP 413
+        // before any handler executes, protecting downstream detectors and
+        // the trace pipeline from arbitrarily large payloads.
+        .layer(RequestBodyLimitLayer::new(body_cap))
         .with_state(state)
 }
 
@@ -1329,6 +1361,119 @@ mod tests {
         let config = load_and_merge_config(&cli).unwrap();
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "json");
+    }
+
+    /// Mutex serialising tests that mutate process env (env vars are
+    /// per-process, not per-test, so unguarded parallel mutation races).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_resolve_max_request_bytes_defaults_when_unset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("LLMTRACE_MAX_REQUEST_BYTES");
+        assert_eq!(resolve_max_request_bytes(), DEFAULT_MAX_REQUEST_BYTES);
+    }
+
+    #[test]
+    fn test_resolve_max_request_bytes_parses_valid_value() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("LLMTRACE_MAX_REQUEST_BYTES", "2048");
+        let cap = resolve_max_request_bytes();
+        std::env::remove_var("LLMTRACE_MAX_REQUEST_BYTES");
+        assert_eq!(cap, 2048);
+    }
+
+    #[test]
+    fn test_resolve_max_request_bytes_falls_back_on_garbage() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("LLMTRACE_MAX_REQUEST_BYTES", "not-a-number");
+        let cap = resolve_max_request_bytes();
+        std::env::remove_var("LLMTRACE_MAX_REQUEST_BYTES");
+        assert_eq!(cap, DEFAULT_MAX_REQUEST_BYTES);
+    }
+
+    #[test]
+    fn test_resolve_max_request_bytes_falls_back_on_zero() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("LLMTRACE_MAX_REQUEST_BYTES", "0");
+        let cap = resolve_max_request_bytes();
+        std::env::remove_var("LLMTRACE_MAX_REQUEST_BYTES");
+        assert_eq!(cap, DEFAULT_MAX_REQUEST_BYTES);
+    }
+
+    #[tokio::test]
+    async fn test_request_body_cap_rejects_oversized_payload() {
+        // Lock the env mutex so we can override the cap to a small value
+        // without racing other env-touching tests. The router captures the
+        // value at build time, so we can drop the guard after build_router.
+        let cap_bytes = 1024usize;
+        let app = {
+            let _guard = ENV_LOCK.lock().unwrap();
+            std::env::set_var("LLMTRACE_MAX_REQUEST_BYTES", cap_bytes.to_string());
+            let state = build_app_state(memory_config(), None).await.unwrap();
+            let app = build_router(state);
+            std::env::remove_var("LLMTRACE_MAX_REQUEST_BYTES");
+            app
+        };
+
+        // Oversized body must be rejected with 413 Payload Too Large
+        // before reaching the upstream proxy handler. We set
+        // Content-Length explicitly so the body-limit layer can refuse
+        // the request without buffering — matching how real clients
+        // present oversized payloads.
+        let oversized = vec![b'x'; cap_bytes + 1];
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/octet-stream")
+            .header("content-length", oversized.len().to_string())
+            .header("authorization", "Bearer sk-test")
+            .body(Body::from(oversized))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "request body over the configured cap must be rejected with 413"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_body_cap_allows_payload_under_default_limit() {
+        // Default cap is 1 MiB; a small body must route through without
+        // 413. The upstream is intentionally unreachable, so a 502 Bad
+        // Gateway here confirms the request reached the proxy_handler.
+        let config = ProxyConfig {
+            upstream_url: "http://127.0.0.1:1".to_string(),
+            connection_timeout_ms: 100,
+            timeout_ms: 500,
+            storage: llmtrace_core::StorageConfig {
+                profile: "memory".to_string(),
+                database_path: String::new(),
+                ..llmtrace_core::StorageConfig::default()
+            },
+            ..ProxyConfig::default()
+        };
+        let state = build_app_state(config, None).await.unwrap();
+        let app = build_router(state);
+
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer sk-test")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "small body must not be rejected by the body cap layer"
+        );
     }
 
     #[tokio::test]

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -198,6 +198,7 @@ Optional top-level fields:
 | `dashboard_name_template` | `"llmtrace-dashboard-{tenant_id}"` | Same for dashboard |
 | `inject_proxy_url_into_dashboard` | `true` | If true, the resolved proxy URL is auto-injected into the dashboard's env after the proxy is up |
 | `proxy_url_env_var` | `"LLMTRACE_PROXY_URL"` | Which env var to inject the proxy URL under |
+| `rate_limit` | unset | Optional per-tenant rate-limit override surfaced to the proxy as env vars (see below) |
 
 Optional per-component fields (override the defaults shown):
 
@@ -212,6 +213,56 @@ Optional per-component fields (override the defaults shown):
 | `liveness_failure_threshold` | `3` | Liveness probe failures before restart |
 | `readiness_period_seconds` | `10` | Readiness probe interval |
 | `readiness_failure_threshold` | `3` | Readiness probe failures before removing from service |
+
+### Per-tenant `rate_limit`
+
+Optional top-level block. When present, the lifecycle library injects two
+env vars into the proxy's `ComponentSpec` at `provision()` and
+`update(..., strategy="recreate")` time:
+
+| Env var | Source | Effect on the proxy |
+|---|---|---|
+| `LLMTRACE_RATE_LIMIT_RPS` | `rate_limit.requests_per_second` | Overrides `rate_limiting.requests_per_second` (default 100) |
+| `LLMTRACE_RATE_LIMIT_BURST` | `rate_limit.burst_size` | Overrides `rate_limiting.burst_size` (default 200) |
+
+Shape:
+
+```yaml
+rate_limit:
+  requests_per_second: 50   # strictly > 0
+  burst_size: 100           # strictly > 0
+```
+
+Behaviour:
+
+- Both fields are **required when the block is present** and must be
+  strictly positive — `RateLimitSpec.__post_init__` raises `ValueError`
+  otherwise.
+- The injected env vars **override** any same-named values the caller
+  put in `proxy.env` (same precedence as the auth-key injection).
+- On the proxy side, `LLMTRACE_RATE_LIMIT_RPS`/`_BURST` are parsed in
+  `crates/llmtrace-proxy/src/config.rs::apply_env_overrides`. Non-positive
+  or unparseable values are silently ignored so a typo cannot disable
+  rate limiting wholesale.
+- Omit the block to keep the proxy's built-in `RateLimitConfig::default()`
+  (100 rps / 200 burst). Per-tenant `tenant_overrides` set via
+  `RateLimitConfig::tenant_overrides` in the proxy's YAML are unaffected.
+
+### Request body cap
+
+The proxy enforces a hard request body cap before any handler executes
+(see `crates/llmtrace-proxy/src/main.rs::resolve_max_request_bytes`).
+The cap protects downstream ML detectors and the trace pipeline from
+a single oversized payload.
+
+- Default: **1 MiB** (1,048,576 bytes).
+- Configurable per-deployment via the `LLMTRACE_MAX_REQUEST_BYTES` env
+  var. Invalid / non-positive values fall back to the default — set this
+  in your tenant's `proxy.env` if you need a different cap.
+- Requests over the cap are rejected with HTTP `413 Payload Too Large`
+  when the `Content-Length` header is honest. Chunked / streamed bodies
+  that exceed the cap are aborted mid-stream and surface as `400 Bad
+  Request` from the proxy handler.
 
 ### `${VAR}` substitution
 

--- a/deployments/basilica/cli.py
+++ b/deployments/basilica/cli.py
@@ -110,6 +110,19 @@ def _component_from_dict(data: dict[str, Any], label: str) -> lifecycle.Componen
     return lifecycle.ComponentSpec(**kwargs)
 
 
+def _rate_limit_from_dict(data: dict[str, Any]) -> lifecycle.RateLimitSpec:
+    required = {"requests_per_second", "burst_size"}
+    missing = required - data.keys()
+    if missing:
+        raise SystemExit(
+            f"rate_limit is missing required keys: {sorted(missing)}"
+        )
+    return lifecycle.RateLimitSpec(
+        requests_per_second=int(data["requests_per_second"]),
+        burst_size=int(data["burst_size"]),
+    )
+
+
 def _tenant_spec_from_config(tenant_id: str, cfg: dict[str, Any]) -> lifecycle.TenantSpec:
     if "proxy" not in cfg or "dashboard" not in cfg:
         raise SystemExit(
@@ -132,6 +145,13 @@ def _tenant_spec_from_config(tenant_id: str, cfg: dict[str, Any]) -> lifecycle.T
     ):
         if key in cfg:
             kwargs[key] = cfg[key]
+    if "rate_limit" in cfg and cfg["rate_limit"] is not None:
+        rate_limit_block = cfg["rate_limit"]
+        if not isinstance(rate_limit_block, dict):
+            raise SystemExit(
+                f"rate_limit must be a mapping, got {type(rate_limit_block).__name__}"
+            )
+        kwargs["rate_limit"] = _rate_limit_from_dict(rate_limit_block)
     return lifecycle.TenantSpec(**kwargs)
 
 

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -40,3 +40,11 @@ dashboard:
     HOSTNAME: 0.0.0.0
     NODE_ENV: production
     LLMTRACE_AUTH_ADMIN_KEY: "${LLMTRACE_AUTH_ADMIN_KEY:-}"
+
+# Optional per-tenant rate limit. Uncomment to surface tenant-specific
+# limits to the proxy at provision time as `LLMTRACE_RATE_LIMIT_RPS` /
+# `LLMTRACE_RATE_LIMIT_BURST` env vars. Both must be strictly positive.
+# Sized higher than starter to match the pro tier's expected load.
+# rate_limit:
+#   requests_per_second: 500
+#   burst_size: 1000

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -62,3 +62,11 @@ dashboard:
 # value (e.g. when recreating to preserve the existing tenant key).
 # enable_proxy_auth: true
 # api_key: null
+
+# Optional per-tenant rate limit. When uncommented, the lifecycle library
+# injects `LLMTRACE_RATE_LIMIT_RPS` and `LLMTRACE_RATE_LIMIT_BURST` into the
+# proxy env at provision time. Both must be strictly positive. Omit the
+# whole block to keep the proxy's built-in default (100 rps / 200 burst).
+# rate_limit:
+#   requests_per_second: 50
+#   burst_size: 100

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -63,6 +63,34 @@ def generate_api_key() -> str:
 
 
 @dataclass(frozen=True)
+class RateLimitSpec:
+    """Per-tenant rate-limit knobs surfaced to the proxy as env vars.
+
+    `requests_per_second` is the steady-state allowance and `burst_size`
+    is the token-bucket headroom. Both must be strictly positive — the
+    proxy's `RateLimiter::check` treats non-positive values as
+    misconfiguration and falls back to the global default.
+
+    When present on `TenantSpec.rate_limit`, the lifecycle library
+    injects `LLMTRACE_RATE_LIMIT_RPS` and `LLMTRACE_RATE_LIMIT_BURST`
+    into the proxy ComponentSpec's env at provision/recreate time.
+    """
+
+    requests_per_second: int
+    burst_size: int
+
+    def __post_init__(self) -> None:
+        if self.requests_per_second <= 0:
+            raise ValueError(
+                f"rate_limit.requests_per_second must be > 0, got {self.requests_per_second}"
+            )
+        if self.burst_size <= 0:
+            raise ValueError(
+                f"rate_limit.burst_size must be > 0, got {self.burst_size}"
+            )
+
+
+@dataclass(frozen=True)
 class ComponentSpec:
     """Full deployment spec for one component (proxy or dashboard).
 
@@ -107,6 +135,14 @@ class TenantSpec:
     # (anyone with the URL can use it — only do this for trusted networks).
     enable_proxy_auth: bool = True
     api_key: Optional[str] = None
+    # Optional per-tenant rate-limit knobs. When set, the lifecycle
+    # library injects `LLMTRACE_RATE_LIMIT_RPS` and
+    # `LLMTRACE_RATE_LIMIT_BURST` into the proxy ComponentSpec env at
+    # provision time. The proxy reads these env vars in
+    # `config::apply_env_overrides` and applies them on top of any YAML
+    # `rate_limiting:` block. Unset means the proxy keeps whatever it
+    # was built with (default 100 rps / 200 burst).
+    rate_limit: Optional[RateLimitSpec] = None
 
 
 @dataclass(frozen=True)
@@ -340,6 +376,24 @@ def _apply_proxy_auth(
     )
 
 
+def _apply_rate_limit(
+    proxy_spec: ComponentSpec, rate_limit: RateLimitSpec
+) -> ComponentSpec:
+    """Inject `LLMTRACE_RATE_LIMIT_RPS` and `LLMTRACE_RATE_LIMIT_BURST`
+    into the proxy env.
+
+    The `TenantSpec.rate_limit` block is the source of truth for this
+    deployment, so it overwrites any same-named values the caller put
+    in `ComponentSpec.env` — same precedence model as `_apply_proxy_auth`.
+    """
+    proxy_env = {
+        **proxy_spec.env,
+        "LLMTRACE_RATE_LIMIT_RPS": str(rate_limit.requests_per_second),
+        "LLMTRACE_RATE_LIMIT_BURST": str(rate_limit.burst_size),
+    }
+    return dataclasses.replace(proxy_spec, env=proxy_env)
+
+
 def provision(
     spec: TenantSpec, client: Optional[BasilicaClient] = None
 ) -> TenantInstances:
@@ -371,6 +425,8 @@ def provision(
         proxy_spec, dashboard_spec = _apply_proxy_auth(
             proxy_spec, dashboard_spec, api_key
         )
+    if spec.rate_limit is not None:
+        proxy_spec = _apply_rate_limit(proxy_spec, spec.rate_limit)
 
     proxy = _create_component(client, proxy_name, proxy_spec)
 


### PR DESCRIPTION
## Summary

Two SaaS gaps for the Basilica-based per-tenant provisioning shipped in #229 / #233:

1. **Request body size cap (Rust)** — the proxy had no hard cap, so one large payload could drive the ML detectors and trace pipeline arbitrarily hard.
2. **Per-tenant rate limit plumbing (Python + Rust)** — `RateLimitConfig` / `TenantRateLimitOverride` existed in core and were enforced by `RateLimiter::check`, but the per-tenant value could not be surfaced through the Basilica tenant YAML.

This PR closes both.

## What changed

### Rust — `crates/llmtrace-proxy`

- `Cargo.toml` — enable `tower-http`'s `limit` feature.
- `src/main.rs`
  - `DEFAULT_MAX_REQUEST_BYTES = 1 MiB`.
  - `resolve_max_request_bytes()` reads `LLMTRACE_MAX_REQUEST_BYTES`, falling back to the default on missing / unparseable / non-positive values.
  - `build_router` applies `tower_http::limit::RequestBodyLimitLayer::new(body_cap)` so oversized requests (with honest `Content-Length`) get HTTP `413 Payload Too Large` before any handler runs.
  - Startup `info!` log now includes `max_request_bytes`, `rate_limit_rps`, `rate_limit_burst`.
  - New tests: `test_resolve_max_request_bytes_*` (4 cases) + `test_request_body_cap_rejects_oversized_payload` (413 path) + `test_request_body_cap_allows_payload_under_default_limit` (small body still routes through).
- `src/config.rs`
  - `apply_env_overrides` honours `LLMTRACE_RATE_LIMIT_RPS` and `LLMTRACE_RATE_LIMIT_BURST` via a `parse_positive_u32` helper that silently ignores zero / unparseable values (a typo must never disable rate limiting wholesale).
  - New tests: `test_apply_env_overrides_rate_limit_rps_and_burst`, `test_apply_env_overrides_rate_limit_ignores_invalid`.

### Python — `deployments/basilica`

- `lifecycle.py`
  - New frozen `RateLimitSpec(requests_per_second: int, burst_size: int)` dataclass with `__post_init__` validation (both must be > 0).
  - `TenantSpec.rate_limit: Optional[RateLimitSpec]` (default `None`).
  - `_apply_rate_limit(proxy_spec, rate_limit)` injects `LLMTRACE_RATE_LIMIT_RPS` / `LLMTRACE_RATE_LIMIT_BURST` into the proxy `ComponentSpec.env`. Precedence matches `_apply_proxy_auth`: the spec-derived value overrides any same-named value the caller put in `proxy.env`.
  - `provision()` calls `_apply_rate_limit` when `spec.rate_limit is not None`. Because `update(strategy="recreate")` reuses `provision()`, recreates pick this up automatically; `strategy="restart"` does not (matches the existing model — restart keeps the live config).
- `cli.py`
  - Optional top-level `rate_limit:` block. Picked the **top level** (not under `proxy:`) because it is a tenant-shape concern, not a proxy-image config concern — same place as `enable_proxy_auth` and `api_key`. Fails fast on missing required keys or non-mapping shapes.
- `configs/examples/{starter,pro}.yaml` — commented-out `rate_limit:` block so the field is discoverable but optional.
- `README.md` — new **Per-tenant `rate_limit`** subsection (table of env-var bindings, validation rules, precedence, on-proxy parsing) and a new **Request body cap** subsection (default 1 MiB, env override, 413 vs 400 nuance for streamed bodies); the top-level optional-fields table now lists `rate_limit`.

## Validation

### Rust

```
$ cargo fmt --all --check
(clean)

$ cargo build -p llmtrace
Finished `dev` profile [unoptimized + debuginfo] target(s) in 31.36s

$ cargo clippy -p llmtrace --lib --bins -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 04s

$ cargo test -p llmtrace --lib
test result: ok. 597 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p llmtrace --lib --bins
21 binary tests pass, 597 lib tests pass.
```

A first `cargo test -p llmtrace --lib --bins` run flaked once on `action_router::tests::test_webhook_action_delivers_payload` (unrelated to this PR — a network-bound webhook test); a targeted re-run passed cleanly. A second full run also passed without flakes.

### Python

Ran in a venv with `basilica-sdk` + `PyYAML`:

```
$ python -c "from deployments.basilica import lifecycle, cli; print('ok')"
ok

$ python <inline tests>
rate_limit injection OK
rate_limit override semantics OK
rejected rps=0 as expected: rate_limit.requests_per_second must be > 0, got 0
rejected burst=-1 as expected: rate_limit.burst_size must be > 0, got -1
rate_limit optional default OK
ALL OK

$ python <cli parse tests>
cli rate_limit parse OK
cli rate_limit: null OK
cli rate_limit absent OK
missing-key rejected: rate_limit is missing required keys: ['burst_size']
non-mapping rejected: rate_limit must be a mapping, got list
ALL OK
```

Both example YAMLs (`starter.yaml`, `pro.yaml`) still parse via `cli._tenant_spec_from_config` with `rate_limit=None` (block commented out as shipped); uncommenting the block parses into a populated `RateLimitSpec`.

### Body cap end-to-end

Validated **inside the cargo test harness only**. A request with `Content-Length` over the configured cap returns 413; a small body still reaches `proxy_handler` (502 because upstream is unreachable in the test, not 413). I did **not** run the proxy binary outside of `tower::ServiceExt::oneshot` and have not exercised `curl` against a live `axum::serve` instance — flagging this for live verification before going to production tenants.

## What was not validated

- I did not run the proxy binary against a live `LLMTRACE_MAX_REQUEST_BYTES` env var with `curl`. The router-level test exercises the same code path (`build_router` reads the env at construction), but a live binary test is the strongest signal.
- I did not provision a real Basilica deployment with `rate_limit:` set and verify the proxy logs the overridden rps / burst at startup. The proxy startup `info!` log line now includes both values, so the next provision should make this trivial to confirm in CI logs.
- The proxy reads the env vars at startup; the env-var override path is unit-tested. End-to-end, the chain is: Basilica deploy env → proxy container → `apply_env_overrides` → `config.rate_limiting` → `RateLimiter::new`. Each link is covered by an existing or new test, but I did not run a multi-tenant load test.

## Trade-offs / choices

- **`RequestBodyLimitLayer` over `DefaultBodyLimit`** — `DefaultBodyLimit` requires extractors to enforce the cap, and the proxy's `proxy_handler` reads the body manually via `axum::body::to_bytes`. The Tower layer enforces the cap before the handler is invoked, which gives a clean 413 for honest clients.
- **Why streamed-without-Content-Length bodies return 400 rather than 413** — `RequestBodyLimitLayer` short-circuits with 413 only when `Content-Length` is set and exceeds the limit. For chunked bodies the layer wraps the stream and errors mid-read; `proxy_handler` catches that as a generic body-read error and returns 400. The server still does not OOM (the layer caps the bytes streamed), so the protective behaviour is intact — only the status code is downgraded. Worth a follow-up if we want a uniform 413, but it would mean distinguishing the body-limit error from other `to_bytes` errors in `proxy_handler`.
- **Top-level `rate_limit:` vs under `proxy:`** — went with top-level. It is a tenant-shape concern (same category as `enable_proxy_auth`, `api_key`), not a proxy-image config concern. Co-locating with auth controls keeps the YAML readable.
- **Override precedence: spec wins over `proxy.env`** — mirrors `_apply_proxy_auth`. An operator who sets `LLMTRACE_RATE_LIMIT_RPS` directly in `proxy.env` is doing it for a reason, but the tenant spec block is the source of truth for the deployment. If we want the opposite, swap the spread order in `_apply_rate_limit`.

## Test plan

- [ ] CI green on `feat/proxy-body-cap-and-rate-limits` (Rust + Python checks).
- [ ] Live: set `LLMTRACE_MAX_REQUEST_BYTES=2048` on a sandbox proxy, `curl -X POST` with a > 2 KiB body, expect 413.
- [ ] Live: provision a tenant via `cli.py` with `rate_limit: { requests_per_second: 5, burst_size: 10 }`, hit the proxy faster than 5 rps, expect rate-limit hits sooner than the default 100 rps would allow; inspect the startup log line for `rate_limit_rps=5 rate_limit_burst=10`.