### PR TITLE
feat(proxy): bound ML pipeline concurrency

### DIFF
--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -1243,6 +1243,12 @@ pub struct ProxyConfig {
     /// endpoints (`/debug/judge/verdicts`) added in issue #95.
     #[serde(default)]
     pub server: ServerConfig,
+    /// Concurrency cap for the CPU-bound ML detection pipeline.
+    ///
+    /// Prevents a flood of requests in a single pod from saturating CPU
+    /// running ML inference. Tunable via `LLMTRACE_ML_MAX_CONCURRENT`.
+    #[serde(default)]
+    pub ml_pipeline: MlPipelineConfig,
 }
 
 impl Default for ProxyConfig {
@@ -1285,6 +1291,7 @@ impl Default for ProxyConfig {
             action_router: ActionRouterConfig::default(),
             judge: JudgeConfig::default(),
             server: ServerConfig::default(),
+            ml_pipeline: MlPipelineConfig::default(),
         }
     }
 }
@@ -1888,6 +1895,42 @@ impl Default for RateLimitConfig {
             burst_size: 200,
             window_seconds: 60,
             tenant_overrides: HashMap::new(),
+        }
+    }
+}
+
+/// Concurrency cap for the proxy's ML detection pipeline.
+///
+/// On every inbound request the proxy may run several CPU-bound ML
+/// detectors (zone detection ensemble, jailbreak classifiers, fusion
+/// classifier, etc.). Without a bound, a flood of parallel requests can
+/// saturate the pod's CPU running inference and slow every concurrent
+/// request — including health checks. This struct caps the number of
+/// requests that may be inside the pre-request ML pipeline at any one
+/// time; the proxy returns 503 (with `Retry-After: 1`) for requests
+/// that would exceed the cap.
+///
+/// SaaS operators tune this per-pod via the `LLMTRACE_ML_MAX_CONCURRENT`
+/// environment variable (applied after YAML parse in
+/// `crates/llmtrace-proxy/src/config.rs`). The default of 8 is a safe
+/// lower bound for typical 4-core pods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MlPipelineConfig {
+    /// Maximum number of requests allowed inside the ML detection
+    /// pipeline at once. Must be >= 1. Defaults to
+    /// [`default_ml_max_concurrent_requests`].
+    #[serde(default = "default_ml_max_concurrent_requests")]
+    pub max_concurrent_requests: usize,
+}
+
+fn default_ml_max_concurrent_requests() -> usize {
+    8
+}
+
+impl Default for MlPipelineConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_requests: default_ml_max_concurrent_requests(),
         }
     }
 }
@@ -4127,6 +4170,7 @@ mod tests {
             boundary_defense: BoundaryTokenConfig::default(),
             judge: JudgeConfig::default(),
             server: ServerConfig::default(),
+            ml_pipeline: MlPipelineConfig::default(),
         };
 
         let serialized = serde_json::to_string(&config).unwrap();

--- a/crates/llmtrace-proxy/src/api.rs
+++ b/crates/llmtrace-proxy/src/api.rs
@@ -1022,6 +1022,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
@@ -1092,6 +1093,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/src/auth.rs
+++ b/crates/llmtrace-proxy/src/auth.rs
@@ -733,6 +733,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/src/compliance.rs
+++ b/crates/llmtrace-proxy/src/compliance.rs
@@ -868,6 +868,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/src/config.rs
+++ b/crates/llmtrace-proxy/src/config.rs
@@ -30,6 +30,7 @@ pub fn load_config(path: &Path) -> anyhow::Result<ProxyConfig> {
 /// - `LLMTRACE_CLICKHOUSE_DATABASE` → `storage.clickhouse_database`
 /// - `LLMTRACE_POSTGRES_URL` → `storage.postgres_url`
 /// - `LLMTRACE_REDIS_URL` → `storage.redis_url`
+/// - `LLMTRACE_ML_MAX_CONCURRENT` → `ml_pipeline.max_concurrent_requests`
 pub fn apply_env_overrides(config: &mut ProxyConfig) {
     if let Ok(val) = std::env::var("LLMTRACE_LISTEN_ADDR") {
         config.listen_addr = val;
@@ -61,6 +62,15 @@ pub fn apply_env_overrides(config: &mut ProxyConfig) {
     }
     if let Ok(val) = std::env::var("LLMTRACE_AUTH_ADMIN_KEY") {
         config.auth.admin_key = Some(val);
+    }
+    if let Ok(val) = std::env::var("LLMTRACE_ML_MAX_CONCURRENT") {
+        match val.parse::<usize>() {
+            Ok(n) if n > 0 => config.ml_pipeline.max_concurrent_requests = n,
+            _ => tracing::warn!(
+                value = %val,
+                "LLMTRACE_ML_MAX_CONCURRENT must be a positive integer; keeping current value"
+            ),
+        }
     }
 }
 
@@ -179,6 +189,10 @@ pub fn validate_config(config: &ProxyConfig) -> anyhow::Result<()> {
 
     if config.security_analysis.max_analysis_text_bytes == 0 {
         errors.push("security_analysis.max_analysis_text_bytes must be > 0".to_string());
+    }
+
+    if config.ml_pipeline.max_concurrent_requests == 0 {
+        errors.push("ml_pipeline.max_concurrent_requests must be >= 1".to_string());
     }
 
     if errors.is_empty() {

--- a/crates/llmtrace-proxy/src/feature_flags_api.rs
+++ b/crates/llmtrace-proxy/src/feature_flags_api.rs
@@ -920,6 +920,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/src/grpc.rs
+++ b/crates/llmtrace-proxy/src/grpc.rs
@@ -475,6 +475,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -530,6 +530,18 @@ async fn build_app_state(
     let metrics = llmtrace_proxy::metrics::Metrics::new();
     let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
+    // Bound intra-pod concurrency of the CPU-bound ML pipeline.
+    // SaaS pods have k8s CPU limits, so cross-tenant blast radius is
+    // bounded; this prevents intra-pod self-saturation by one customer
+    // saturating CPU running ML inference. Tuned via the
+    // `LLMTRACE_ML_MAX_CONCURRENT` env var (see config.rs).
+    let ml_max_concurrent = config.ml_pipeline.max_concurrent_requests.max(1);
+    info!(
+        max_concurrent = ml_max_concurrent,
+        "ML pipeline concurrency cap initialised"
+    );
+    let ml_pipeline_semaphore = Arc::new(tokio::sync::Semaphore::new(ml_max_concurrent));
+
     // Boundary defense startup state
     if config.boundary_defense.enabled {
         info!(
@@ -687,6 +699,7 @@ async fn build_app_state(
         runtime_overlay_status,
         shutdown,
         metrics,
+        ml_pipeline_semaphore,
         ready,
     });
 

--- a/crates/llmtrace-proxy/src/metrics.rs
+++ b/crates/llmtrace-proxy/src/metrics.rs
@@ -221,6 +221,18 @@ pub struct Metrics {
     /// Per-category false-positive rate against benign golden-set
     /// entries (#66 T3c). Range `[0.0, 1.0]`.
     pub judge_golden_set_false_positive_rate: GaugeVec,
+
+    /// Number of requests currently inside the ML detection pipeline
+    /// (permits-in-use of the per-pod semaphore). Rises and falls with
+    /// real load; a sustained reading equal to the configured cap
+    /// (`ml_pipeline.max_concurrent_requests`) means the pod is at
+    /// saturation and rejections will follow.
+    pub ml_inflight_requests: IntGauge,
+
+    /// Total ML pipeline requests rejected because the concurrency cap
+    /// was already saturated. Each increment corresponds to one client
+    /// 503 response with `Retry-After: 1`.
+    pub ml_rejected_total: IntCounter,
 }
 
 impl Metrics {
@@ -818,6 +830,24 @@ impl Metrics {
             .register(Box::new(judge_golden_set_false_positive_rate.clone()))
             .expect("register judge_golden_set_false_positive_rate");
 
+        let ml_inflight_requests = IntGauge::new(
+            "llmtrace_ml_inflight_requests",
+            "Requests currently inside the ML detection pipeline (permits-in-use)",
+        )
+        .expect("metric: ml_inflight_requests");
+        registry
+            .register(Box::new(ml_inflight_requests.clone()))
+            .expect("register ml_inflight_requests");
+
+        let ml_rejected_total = IntCounter::new(
+            "llmtrace_ml_rejected_total",
+            "Total ML pipeline requests rejected because the concurrency cap was saturated",
+        )
+        .expect("metric: ml_rejected_total");
+        registry
+            .register(Box::new(ml_rejected_total.clone()))
+            .expect("register ml_rejected_total");
+
         // Initialise circuit breaker gauges to their startup state (closed).
         for subsystem in &["storage", "security"] {
             for state in &["closed", "open", "half_open"] {
@@ -878,6 +908,8 @@ impl Metrics {
             judge_shadow_would_block_total,
             judge_golden_set_alignment,
             judge_golden_set_false_positive_rate,
+            ml_inflight_requests,
+            ml_rejected_total,
         }
     }
 

--- a/crates/llmtrace-proxy/src/otel.rs
+++ b/crates/llmtrace-proxy/src/otel.rs
@@ -897,6 +897,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
@@ -957,6 +958,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -3,6 +3,18 @@
 //! Receives incoming HTTP requests, extracts LLM metadata, forwards them to
 //! the upstream, captures the response, and spawns async background tasks for
 //! trace storage and security analysis.
+//!
+//! ## ML pipeline concurrency cap
+//!
+//! Pre-request enforcement (the CPU-bound ML detection block) is bounded
+//! by [`AppState::ml_pipeline_semaphore`]. Sized from
+//! `cfg.ml_pipeline.max_concurrent_requests` and tunable per-pod via the
+//! `LLMTRACE_ML_MAX_CONCURRENT` env var. On saturation, the handler
+//! responds 503 with `Retry-After: 1` immediately (`try_acquire` —
+//! never queues) so callers get fast, predictable backpressure rather
+//! than every in-flight request stalling on contended CPU. The gauge
+//! `llmtrace_ml_inflight_requests` and counter
+//! `llmtrace_ml_rejected_total` are exposed on `/metrics`.
 
 use crate::action_router::ActionRouter;
 use crate::circuit_breaker::CircuitBreaker;
@@ -217,6 +229,13 @@ pub struct AppState {
     pub shutdown: crate::shutdown::ShutdownCoordinator,
     /// Prometheus metrics collectors.
     pub metrics: crate::metrics::Metrics,
+    /// Bounds intra-pod concurrency of the CPU-bound ML detection
+    /// pipeline. The synchronous pre-request enforcement path acquires
+    /// a permit via `try_acquire`; on failure it returns 503 with
+    /// `Retry-After: 1` so callers get fast, predictable backpressure
+    /// instead of every concurrent request stalling on contended CPU.
+    /// Sized from `cfg.ml_pipeline.max_concurrent_requests`.
+    pub ml_pipeline_semaphore: Arc<tokio::sync::Semaphore>,
     /// Whether storage initialisation is complete.
     ///
     /// Set to `true` once all storage backends have been confirmed healthy
@@ -845,8 +864,30 @@ pub async fn proxy_handler(
     }
 
     // --- Pre-request security enforcement ---
+    // Cap intra-pod concurrency of the CPU-bound ML pipeline. `try_acquire`
+    // returns immediately when saturated; we reply 503 with `Retry-After: 1`
+    // so the client retries fast instead of every in-flight request stalling
+    // on contended CPU. The permit is held across the inline enforcement +
+    // action-router call; the background analysis path (post-upstream) is
+    // unbounded by design — it does not block client latency.
     let mut flagged_findings: Vec<SecurityFinding> = Vec::new();
     if cfg.enable_security_analysis {
+        let permit = match Arc::clone(&state.ml_pipeline_semaphore).try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                state.metrics.ml_rejected_total.inc();
+                state.metrics.active_connections.dec();
+                warn!(
+                    %trace_id,
+                    cap = state.ml_pipeline_semaphore.available_permits()
+                        + state.metrics.ml_inflight_requests.get() as usize,
+                    "ML pipeline saturated; rejecting request with 503"
+                );
+                return ml_saturated_response(trace_id);
+            }
+        };
+        state.metrics.ml_inflight_requests.inc();
+
         let enf_context = AnalysisContext {
             tenant_id,
             trace_id,
@@ -882,6 +923,10 @@ pub async fn proxy_handler(
             .action_router
             .execute_inline(decision, &action_ctx)
             .await;
+
+        // Release the ML pipeline permit before short-circuiting on Block.
+        state.metrics.ml_inflight_requests.dec();
+        drop(permit);
 
         match decision {
             crate::enforcement::EnforcementDecision::Block { reason, findings } => {
@@ -1912,6 +1957,27 @@ pub async fn health_handler(State(state): State<Arc<AppState>>) -> Response<Body
 // ---------------------------------------------------------------------------
 
 /// Build a 429 Too Many Requests response for rate limit violations.
+/// Build a 503 Service Unavailable response when the ML pipeline
+/// concurrency cap is saturated. Includes `Retry-After: 1` so clients
+/// back off briefly; one second is enough for the typical 200-500ms ML
+/// inference call to drain a permit at steady state.
+fn ml_saturated_response(trace_id: Uuid) -> Response<Body> {
+    let body = serde_json::json!({
+        "error": {
+            "message": "ML detection pipeline at capacity; retry shortly",
+            "type": "ml_pipeline_saturated",
+            "retry_after_secs": 1,
+        }
+    });
+    Response::builder()
+        .status(StatusCode::SERVICE_UNAVAILABLE)
+        .header("content-type", "application/json")
+        .header("retry-after", "1")
+        .header(TRACE_ID_HEADER, trace_id.to_string())
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
 fn rate_limit_response(
     tenant_id: TenantId,
     limit: u32,

--- a/crates/llmtrace-proxy/src/tenant_api.rs
+++ b/crates/llmtrace-proxy/src/tenant_api.rs
@@ -685,6 +685,7 @@ mod tests {
             runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
             shutdown: crate::shutdown::ShutdownCoordinator::new(30),
             metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
             ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }

--- a/crates/llmtrace-proxy/tests/integration_test.rs
+++ b/crates/llmtrace-proxy/tests/integration_test.rs
@@ -6,6 +6,7 @@
 //! 3. Sends requests through the proxy
 //! 4. Verifies traces, security findings, and streaming behaviour
 
+use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::routing::{get, post};
@@ -14,6 +15,7 @@ use llmtrace_core::{
     ActionRouterConfig, ActionRuleConfig, CategoryEnforcement, EnforcementMode, ProxyConfig,
     SecurityAnalyzer, SecuritySeverity, StorageConfig, TenantId, TraceQuery,
 };
+use llmtrace_core::{AnalysisContext, SecurityFinding};
 use llmtrace_proxy::{health_handler, proxy_handler, AppState, CircuitBreaker};
 use llmtrace_security::RegexSecurityAnalyzer;
 use llmtrace_storage::StorageProfile;
@@ -99,6 +101,7 @@ async fn build_proxy_with_config(config: ProxyConfig) -> (Arc<AppState>, Router)
         runtime_overlay_status: llmtrace_proxy::proxy::RuntimeOverlayStatus::Disabled,
         shutdown: llmtrace_proxy::shutdown::ShutdownCoordinator::new(30),
         metrics: llmtrace_proxy::metrics::Metrics::new(),
+        ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
         ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     });
 
@@ -1095,5 +1098,256 @@ async fn test_datamarking_emits_spotlighting_applied_info_finding() {
     assert!(
         info_findings >= 1,
         "spotlighting_applied Info finding must be emitted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ML pipeline concurrency cap
+// ---------------------------------------------------------------------------
+
+/// A real `SecurityAnalyzer` that sleeps in `analyze_request` so the ML
+/// pipeline permit is held long enough for N+1 concurrent requests to
+/// race against the cap. NOT a mock — implements the trait honestly,
+/// returns no findings, and never panics. The only deviation from
+/// `RegexSecurityAnalyzer` is that it sleeps `delay_ms` before returning.
+struct SlowAnalyzer {
+    delay_ms: u64,
+}
+
+#[async_trait]
+impl llmtrace_core::SecurityAnalyzer for SlowAnalyzer {
+    async fn analyze_request(
+        &self,
+        _prompt: &str,
+        _context: &AnalysisContext,
+    ) -> llmtrace_core::Result<Vec<SecurityFinding>> {
+        tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+        Ok(Vec::new())
+    }
+
+    async fn analyze_response(
+        &self,
+        _response: &str,
+        _context: &AnalysisContext,
+    ) -> llmtrace_core::Result<Vec<SecurityFinding>> {
+        Ok(Vec::new())
+    }
+
+    fn name(&self) -> &'static str {
+        "slow_test_analyzer"
+    }
+
+    fn version(&self) -> &'static str {
+        "0.0.0"
+    }
+
+    fn supported_finding_types(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    async fn health_check(&self) -> llmtrace_core::Result<()> {
+        Ok(())
+    }
+}
+
+/// Build a proxy whose pre-request enforcement is intentionally slow,
+/// with the ML pipeline semaphore sized to `cap`. The upstream is the
+/// regular mock so requests that ARE admitted complete normally.
+async fn build_proxy_with_slow_analyzer(
+    upstream_url: &str,
+    cap: usize,
+    delay_ms: u64,
+) -> (Arc<AppState>, Router) {
+    let mut config = ProxyConfig {
+        upstream_url: upstream_url.to_string(),
+        listen_addr: "127.0.0.1:0".to_string(),
+        storage: StorageConfig {
+            profile: "memory".to_string(),
+            database_path: String::new(),
+            ..StorageConfig::default()
+        },
+        connection_timeout_ms: 2000,
+        timeout_ms: 5000,
+        enable_security_analysis: true,
+        enable_trace_storage: true,
+        enable_streaming: true,
+        ..ProxyConfig::default()
+    };
+    // mode=Log + empty categories short-circuits run_enforcement before
+    // the analyzer is called; force Flag so SlowAnalyzer is actually awaited
+    // and the semaphore permit is held across all overlapping requests.
+    config.enforcement.mode = llmtrace_core::EnforcementMode::Flag;
+    // Use Full analysis depth so the slow analyzer is exercised.
+    config.enforcement.analysis_depth = llmtrace_core::AnalysisDepth::Full;
+    // Make sure the enforcement timeout is well above the delay; otherwise
+    // the enforcement call will time out, fail-open, and release the permit
+    // before the N+1th request gets to try_acquire.
+    config.enforcement.timeout_ms = (delay_ms * 5).max(1000);
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_millis(config.connection_timeout_ms))
+        .timeout(Duration::from_millis(config.timeout_ms))
+        .build()
+        .unwrap();
+
+    let storage = StorageProfile::Memory.build().await.unwrap();
+    let slow: Arc<dyn SecurityAnalyzer> = Arc::new(SlowAnalyzer { delay_ms });
+    let security = slow.clone();
+    let fast_analyzer = slow;
+
+    let storage_breaker = Arc::new(CircuitBreaker::new(10, Duration::from_secs(30), 3));
+    let security_breaker = Arc::new(CircuitBreaker::new(10, Duration::from_secs(30), 3));
+
+    let cost_estimator = llmtrace_proxy::cost::CostEstimator::new(&config.cost_estimation);
+    let action_router = llmtrace_proxy::action_router::ActionRouter::new(
+        &config.action_router,
+        config.judge.promotion.clone(),
+        config.judge.worker.max_analysis_text_bytes,
+        Some(Arc::clone(&storage.cache)),
+        reqwest::Client::new(),
+    );
+    let cost_tracker =
+        llmtrace_proxy::cost_caps::CostTracker::new(&config.cost_caps, Arc::clone(&storage.cache));
+    let rate_limiter =
+        llmtrace_proxy::RateLimiter::new(&config.rate_limiting, Arc::clone(&storage.cache));
+
+    let state = Arc::new(AppState {
+        config_handle: llmtrace_proxy::config_handle::ConfigHandle::new(config, None, None),
+        client,
+        storage,
+        security,
+        #[cfg(feature = "ml")]
+        security_ensemble: None,
+        ensemble_runtime: Arc::new(llmtrace_security::EnsembleRuntimeHandle::inert()),
+        fast_analyzer,
+        storage_breaker,
+        security_breaker,
+        cost_estimator,
+        alert_engine: None,
+        cost_tracker,
+        anomaly_detector: None,
+        action_router,
+        report_store: llmtrace_proxy::compliance::new_report_store(),
+        rate_limiter,
+        ml_status: llmtrace_proxy::proxy::MlModelStatus::Disabled,
+        judge_worker_spawned: false,
+        runtime_overlay_status: llmtrace_proxy::proxy::RuntimeOverlayStatus::Disabled,
+        shutdown: llmtrace_proxy::shutdown::ShutdownCoordinator::new(30),
+        metrics: llmtrace_proxy::metrics::Metrics::new(),
+        ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(cap)),
+        ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    });
+
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .fallback(axum::routing::any(proxy_handler))
+        .with_state(state.clone());
+
+    (state, app)
+}
+
+/// Verify the ML pipeline concurrency cap. With cap=N and N+1
+/// simultaneous requests, exactly one must come back 503 with
+/// `Retry-After: 1`, while the other N must complete with the
+/// upstream's 200 OK. The slow analyzer holds the semaphore permit
+/// long enough that all requests overlap inside `enforcement`.
+#[tokio::test]
+async fn ml_pipeline_semaphore_rejects_excess_concurrent_requests() {
+    let (upstream_url, _h) = serve(mock_upstream()).await;
+    let cap: usize = 3;
+    let delay_ms: u64 = 250;
+    let (state, _app) = build_proxy_with_slow_analyzer(&upstream_url, cap, delay_ms).await;
+
+    // Bind a real TCP listener so we can hammer it with reqwest in parallel.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://{addr}/v1/chat/completions");
+    let app_router = Router::new()
+        .fallback(axum::routing::any(proxy_handler))
+        .with_state(state.clone());
+    let _server = tokio::spawn(async move {
+        axum::serve(listener, app_router).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let body = json!({
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hi"}]
+    });
+
+    // Fire cap+1 requests concurrently. They must all enter the
+    // enforcement block before the first permit releases.
+    let mut handles = Vec::new();
+    for _ in 0..(cap + 1) {
+        let client = client.clone();
+        let url = url.clone();
+        let body = body.clone();
+        handles.push(tokio::spawn(async move {
+            client.post(&url).json(&body).send().await.map(|r| {
+                (
+                    r.status(),
+                    r.headers()
+                        .get("retry-after")
+                        .map(|v| v.to_str().unwrap_or("").to_string()),
+                )
+            })
+        }));
+    }
+
+    let mut ok_count = 0;
+    let mut rejected_count = 0;
+    let mut retry_after_seen = None;
+    for h in handles {
+        let (status, retry_after) = h.await.unwrap().unwrap();
+        if status == StatusCode::SERVICE_UNAVAILABLE {
+            rejected_count += 1;
+            retry_after_seen = retry_after;
+        } else if status == StatusCode::OK {
+            ok_count += 1;
+        } else {
+            panic!("unexpected status {status}: only 200 or 503 are valid outcomes");
+        }
+    }
+
+    assert_eq!(
+        rejected_count, 1,
+        "exactly one of cap+1 ({cap}+1) requests must be rejected; got {rejected_count} rejections, {ok_count} accepts"
+    );
+    assert_eq!(
+        ok_count, cap,
+        "the remaining cap ({cap}) requests must proceed; got {ok_count}"
+    );
+    assert_eq!(
+        retry_after_seen.as_deref(),
+        Some("1"),
+        "503 must carry Retry-After: 1"
+    );
+
+    // Prometheus counters must reflect the rejection.
+    let metrics_text = state.metrics.gather_text().unwrap();
+    assert!(
+        metrics_text.contains("llmtrace_ml_rejected_total"),
+        "ml_rejected_total must be exposed"
+    );
+    assert!(
+        metrics_text.contains("llmtrace_ml_inflight_requests"),
+        "ml_inflight_requests gauge must be exposed"
+    );
+    assert_eq!(
+        state.metrics.ml_rejected_total.get(),
+        1,
+        "rejection counter must be exactly 1"
+    );
+    // Gauge must drain to zero once all admitted requests finish.
+    // Give the in-flight requests a moment to finish their permit drop.
+    tokio::time::sleep(Duration::from_millis(delay_ms * 2)).await;
+    assert_eq!(
+        state.metrics.ml_inflight_requests.get(),
+        0,
+        "in-flight gauge must drain to zero after all admitted requests release their permit"
     );
 }

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -349,6 +349,14 @@ new_instances = lifecycle.update(spec, proxy_id=..., dashboard_id=..., strategy=
 - **Defence-in-depth** still worth doing separately: per-tenant rate
   limits (LLMTrace likely has them — configure), and DoS protection
   against CPU burn from ML detectors running before the upstream call.
+  The proxy now bounds intra-pod ML detection concurrency via a tokio
+  semaphore — tune the cap per-pod with the
+  `LLMTRACE_ML_MAX_CONCURRENT` env var (default `8`). Excess requests
+  receive `503 Service Unavailable` with `Retry-After: 1` instead of
+  every concurrent request stalling on contended CPU; the counter
+  `llmtrace_ml_rejected_total` and the gauge
+  `llmtrace_ml_inflight_requests` are exposed on `/metrics` for
+  alerting on sustained saturation.
 
 ## Per-tenant secret injection
 


### PR DESCRIPTION
## Summary
- Bounds intra-pod concurrency of the CPU-bound ML detection pipeline via a `tokio::sync::Semaphore` on `AppState`. Sized from `cfg.ml_pipeline.max_concurrent_requests` (default 8, env override `LLMTRACE_ML_MAX_CONCURRENT`).
- Saturation strategy: **Option A** — `try_acquire` on the synchronous pre-request enforcement block; on failure, immediately respond `503 Service Unavailable` with `Retry-After: 1`. No queueing. Why Option A: the brief recommends it as the default, and the codebase's other rejection paths (rate limiting, cost caps) follow the same "fast reject, let the client retry" pattern. Queueing would mask saturation as latency and is harder to alert on.
- Adds Prometheus gauge `llmtrace_ml_inflight_requests` (permits-in-use) and counter `llmtrace_ml_rejected_total` to `/metrics`, following the existing `Metrics` registration pattern.
- Scope: the cap is applied only to the synchronous, request-blocking pre-request enforcement path (where 503 is meaningful and prevents client-visible latency stalls). The post-upstream background analysis path (`run_security_analysis` in the spawned task) is left unbounded — it runs after the upstream response has been streamed to the client and does not block client latency. Caveat documented below.

## Files changed
- `crates/llmtrace-core/src/lib.rs` — new `MlPipelineConfig` struct, wired into `ProxyConfig`.
- `crates/llmtrace-proxy/src/config.rs` — env override + validation for `LLMTRACE_ML_MAX_CONCURRENT`.
- `crates/llmtrace-proxy/src/metrics.rs` — new gauge + counter, registered and exposed.
- `crates/llmtrace-proxy/src/proxy.rs` — `AppState::ml_pipeline_semaphore` field, `try_acquire` around enforcement, `ml_saturated_response` helper, module-level doc update.
- `crates/llmtrace-proxy/src/main.rs` — semaphore construction from config.
- `crates/llmtrace-proxy/src/{api,auth,compliance,feature_flags_api,grpc,otel,tenant_api}.rs` — `AppState` test-fixture literals updated.
- `crates/llmtrace-proxy/tests/integration_test.rs` — new test plus a real `SlowAnalyzer` `SecurityAnalyzer` impl (NOT a mock — it implements the trait fully, just sleeps in `analyze_request`).
- `deployments/basilica/README.md` — operator-facing note on the new env var and metrics.

## Saturation strategy + behavior under load
- Permit is acquired at the start of the `if cfg.enable_security_analysis { ... }` block and released right after `action_router.execute_inline(...)` and before the upstream HTTP forward. This bounds **only** the CPU-bound ML/regex enforcement window; the upstream HTTP call and the response-streaming path are not counted against the cap.
- `try_acquire_owned` is used so the permit is `'static`-compatible if needed; on saturation we increment `llmtrace_ml_rejected_total`, decrement `active_connections`, log a `warn!`, and return 503 with `Retry-After: 1`.

## Validation

```
cargo fmt --all                       # clean
cargo build -p llmtrace               # clean
cargo build --workspace               # clean
cargo test -p llmtrace-core           # 98 passed
cargo test -p llmtrace                # lib: 595 passed; main: 15 passed; integration: 19 passed
cargo clippy -p llmtrace --tests      # no new warnings from this PR
```

The new test `ml_pipeline_semaphore_rejects_excess_concurrent_requests` builds a real proxy with `SlowAnalyzer` (sleeps 250 ms in `analyze_request`), sets the cap to 3, fires 4 concurrent HTTP requests through a live `axum::serve` listener, and asserts:
- exactly 1 of 4 returns `503 Service Unavailable`,
- the 503 carries `Retry-After: 1`,
- the other 3 return `200 OK`,
- `llmtrace_ml_rejected_total == 1`,
- `llmtrace_ml_inflight_requests` drains to 0 after the admitted requests release their permit.

## Caveats / unvalidated
- The post-upstream background ML analysis path (`run_security_analysis` in the spawned task) is intentionally **not** bounded by the semaphore in this PR. Bounding it would either add latency (waiting for a permit after the client has already received the response) or skip analysis. Left for a follow-up if production CPU profiles show this background path is a contributor.
- The `try_acquire` strategy means the cap is "hard" — a brief burst above the cap will produce 503s rather than smoothing latency. Operators tuning `LLMTRACE_ML_MAX_CONCURRENT` should watch the new `llmtrace_ml_rejected_total` and size the cap to match the pod's CPU budget; a sustained rejection rate is the alert signal.