### PR TITLE
fix(basilica): raise startup_timeout floor when ML preload is on (closes #243)

### DIFF
--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -973,11 +973,32 @@ client doesn't accept that media type.
 ### ML preload behaviour
 
 The proxy image has `LLMTRACE_ML_ENABLED=1` and `LLMTRACE_ML_PRELOAD=1` by
-default in `starter.yaml`. Cold-boot includes model warm-up; in live tests
-the proxy hit `phase=ready` in ~60s. If your tenant config sets a smaller
-`startup_timeout_seconds`, the deployment may legitimately time out — bump
-the timeout or set `LLMTRACE_ML_PRELOAD=0` to defer model load to
-first-request time.
+default in `starter.yaml` and `pro.yaml`. Preload loads the
+`prompt_injection`, `ner`, `injecguard`, and `piguard` weights before
+`/health` flips to ready.
+
+Cost on small CPU shapes: the cold-boot wall clock is dominated by model
+load. On `cpu=2 / memory=4Gi` (starter) this consistently lands in the
+600–1500s range; the same image without preload reaches ready in ~40s.
+Bigger shapes are proportionally faster but the same band of preload cost
+applies on first boot.
+
+**Auto-bump** (`deployments/basilica/lifecycle.py::_apply_ml_preload_startup_floor`):
+when the resolved proxy env carries both `LLMTRACE_ML_ENABLED ∈ {1,true,yes}`
+and `LLMTRACE_ML_PRELOAD ∈ {1,true,yes}` AND the caller's
+`startup_timeout_seconds` is below `ML_PRELOAD_STARTUP_FLOOR_SECONDS`
+(currently 1500), the lifecycle library raises the timeout to the floor
+and emits a single WARN. This applies to `provision`,
+`update(strategy="recreate")`, and `rotate_admin_key`. Callers who set
+`startup_timeout_seconds >= 1500` keep their value and see no warning.
+
+**Opt out of preload entirely**: set `LLMTRACE_ML_PRELOAD: "0"` in
+`proxy.env` for lazy load. The first request pays the model-load
+latency; every subsequent request is fast. Useful when readiness latency
+matters more than first-request latency.
+
+**Silence the WARN**: set `startup_timeout_seconds: 1500` (or higher)
+explicitly in your config. Both example configs already do this.
 
 ### Cleanup of orphans
 

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -16,7 +16,13 @@ proxy:
   memory: 8Gi
   replicas: 2
   health_check_path: /health
-  startup_timeout_seconds: 600
+  # ML preload (LLMTRACE_ML_ENABLED=1 + LLMTRACE_ML_PRELOAD=1) loads the
+  # prompt_injection / ner / injecguard / piguard weights before /health flips
+  # to ready. On a cpu=2 shape this regularly exceeds 600s; cpu=4 is faster
+  # but still well over the library's old 600s default. The lifecycle library
+  # auto-bumps to 1500s when both flags are on and this value is lower; we set
+  # 1500 explicitly to silence the WARN and document the cost.
+  startup_timeout_seconds: 1500
   env:
     LLMTRACE_UPSTREAM_URL: "${LLMTRACE_UPSTREAM_URL}"
     LLMTRACE_STORAGE_PROFILE: "${LLMTRACE_STORAGE_PROFILE:-sqlite}"

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -32,7 +32,14 @@ proxy:
   memory: 4Gi
   replicas: 1
   health_check_path: /health
-  startup_timeout_seconds: 600
+  # ML preload (LLMTRACE_ML_ENABLED=1 + LLMTRACE_ML_PRELOAD=1) loads the
+  # prompt_injection / ner / injecguard / piguard weights before /health flips
+  # to ready. On this cpu=2 shape that takes 600-1500s in practice. The
+  # lifecycle library auto-bumps to 1500s when both flags are on and this
+  # value is lower; we set 1500 explicitly to silence the WARN and document
+  # the cost. Set LLMTRACE_ML_PRELOAD=0 below for lazy load (first request
+  # pays the model-load latency, subsequent requests are fast).
+  startup_timeout_seconds: 1500
   env:
     LLMTRACE_UPSTREAM_URL: "${LLMTRACE_UPSTREAM_URL}"
     LLMTRACE_STORAGE_PROFILE: memory

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -54,6 +54,19 @@ DEFAULT_DASHBOARD_NAME_TEMPLATE = "llmtrace-dashboard-{tenant_id}"
 API_KEY_PREFIX = "llmt_"
 API_KEY_RANDOM_BYTES = 32
 
+# Minimum startup window the lifecycle library will apply when the resolved
+# proxy env requests ML preload (`LLMTRACE_ML_ENABLED=1`,
+# `LLMTRACE_ML_PRELOAD=1`). On a cpu=2 shape, loading the prompt_injection +
+# ner + injecguard + piguard weights regularly exceeds the
+# `ComponentSpec.startup_timeout_seconds` default of 600s, so callers who
+# leave it at the default would silently time out. 1500s covers the observed
+# worst case with margin. Callers who explicitly set a higher value win.
+ML_PRELOAD_STARTUP_FLOOR_SECONDS = 1500
+
+# Env values that count as "enabled" for the ML preload flags. Matches the
+# truthiness rules in `crates/llmtrace-proxy/src/config.rs::env_flag`.
+_ML_FLAG_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes"})
+
 # Proxy admin API endpoints (see `crates/llmtrace-proxy/src/main.rs` routing).
 TENANTS_PATH = "/api/v1/tenants"
 AUTH_KEYS_PATH = "/api/v1/auth/keys"
@@ -426,6 +439,42 @@ def _apply_proxy_auth(
     )
 
 
+def _apply_ml_preload_startup_floor(
+    spec: ComponentSpec,
+    *,
+    tenant_id: Optional[str] = None,
+    floor: int = ML_PRELOAD_STARTUP_FLOOR_SECONDS,
+) -> ComponentSpec:
+    """Raise `startup_timeout_seconds` when the proxy env requests ML preload.
+
+    When both `LLMTRACE_ML_ENABLED` and `LLMTRACE_ML_PRELOAD` resolve to a
+    truthy value in `spec.env`, the proxy will block readiness on model
+    weight load before flipping `/health` to ready. On small CPU shapes that
+    can take well over the library's 600s default, so we floor the timeout
+    at `floor` (default `ML_PRELOAD_STARTUP_FLOOR_SECONDS`).
+
+    Callers who explicitly set `startup_timeout_seconds >= floor` keep their
+    value and no warning is emitted. The bump is a pure function on the spec
+    — no SDK calls — so it's safe to apply in any code path that creates the
+    proxy deployment.
+    """
+    ml_enabled = spec.env.get("LLMTRACE_ML_ENABLED", "").strip().lower() in _ML_FLAG_TRUTHY
+    ml_preload = spec.env.get("LLMTRACE_ML_PRELOAD", "").strip().lower() in _ML_FLAG_TRUTHY
+    if not (ml_enabled and ml_preload):
+        return spec
+    if spec.startup_timeout_seconds >= floor:
+        return spec
+    LOGGER.warning(
+        "ML preload detected (LLMTRACE_ML_ENABLED=1, LLMTRACE_ML_PRELOAD=1) "
+        "on tenant=%s; raising startup_timeout_seconds from %d to %d to "
+        "accommodate model load. Set explicitly to silence.",
+        tenant_id or "<unknown>",
+        spec.startup_timeout_seconds,
+        floor,
+    )
+    return dataclasses.replace(spec, startup_timeout_seconds=floor)
+
+
 def _apply_rate_limit(
     proxy_spec: ComponentSpec, rate_limit: RateLimitSpec
 ) -> ComponentSpec:
@@ -667,6 +716,7 @@ def rotate_admin_key(
     new_env = {**proxy_spec.env, "LLMTRACE_AUTH_ADMIN_KEY": rotated_key}
     new_env.setdefault("LLMTRACE_AUTH_ENABLED", "true")
     rotated_spec = dataclasses.replace(proxy_spec, env=new_env)
+    rotated_spec = _apply_ml_preload_startup_floor(rotated_spec, tenant_id=tenant_id)
 
     proxy_name = proxy_name_template.format(tenant_id=tenant_id)
     LOGGER.info(
@@ -721,6 +771,7 @@ def provision(
         )
     if spec.rate_limit is not None:
         proxy_spec = _apply_rate_limit(proxy_spec, spec.rate_limit)
+    proxy_spec = _apply_ml_preload_startup_floor(proxy_spec, tenant_id=tenant_id)
 
     proxy = _create_component(client, proxy_name, proxy_spec)
 

--- a/deployments/basilica/tests/test_ml_preload_startup_floor.py
+++ b/deployments/basilica/tests/test_ml_preload_startup_floor.py
@@ -1,0 +1,188 @@
+"""Unit tests for the ML-preload startup-timeout floor.
+
+The bump is implemented as a pure function (`_apply_ml_preload_startup_floor`)
+on `ComponentSpec`, so the tests exercise it directly — no SDK mocking, no
+provision flow stubbing. This matches the production code path: every
+`_create_component` call site for the proxy runs the spec through the same
+helper before handing it to the Basilica SDK.
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from typing import Mapping
+
+from deployments.basilica import lifecycle
+
+
+def _proxy_spec(
+    *, env: Mapping[str, str], startup_timeout_seconds: int
+) -> lifecycle.ComponentSpec:
+    return lifecycle.ComponentSpec(
+        image="ghcr.io/techlab-innov/llmtrace-proxy:latest",
+        port=8080,
+        cpu="2",
+        memory="4Gi",
+        replicas=1,
+        env=env,
+        startup_timeout_seconds=startup_timeout_seconds,
+    )
+
+
+class MLPreloadStartupFloorTests(unittest.TestCase):
+    def test_bumps_when_below_floor_and_ml_preload_on(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_ML_ENABLED": "1", "LLMTRACE_ML_PRELOAD": "1"},
+            startup_timeout_seconds=600,
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.WARNING) as captured:
+            bumped = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme"
+            )
+
+        self.assertEqual(
+            bumped.startup_timeout_seconds,
+            lifecycle.ML_PRELOAD_STARTUP_FLOOR_SECONDS,
+        )
+        # All other fields preserved.
+        self.assertEqual(bumped.image, spec.image)
+        self.assertEqual(bumped.env, spec.env)
+        self.assertEqual(bumped.port, spec.port)
+        # Exactly one warning, mentioning the tenant + the floor.
+        self.assertEqual(len(captured.records), 1)
+        message = captured.records[0].getMessage()
+        self.assertIn("acme", message)
+        self.assertIn("600", message)
+        self.assertIn(str(lifecycle.ML_PRELOAD_STARTUP_FLOOR_SECONDS), message)
+
+    def test_no_bump_when_caller_value_meets_floor(self) -> None:
+        explicit = lifecycle.ML_PRELOAD_STARTUP_FLOOR_SECONDS + 300
+        spec = _proxy_spec(
+            env={"LLMTRACE_ML_ENABLED": "true", "LLMTRACE_ML_PRELOAD": "yes"},
+            startup_timeout_seconds=explicit,
+        )
+        # `assertNoLogs` is Python 3.10+. Capture and assert empty as a portable
+        # alternative that still fails loudly if a warning leaks.
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")  # ensure the context has >=1 record
+            result = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme"
+            )
+
+        self.assertIs(result, spec)
+        self.assertEqual(result.startup_timeout_seconds, explicit)
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_no_bump_when_caller_value_equals_floor(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_ML_ENABLED": "1", "LLMTRACE_ML_PRELOAD": "1"},
+            startup_timeout_seconds=lifecycle.ML_PRELOAD_STARTUP_FLOOR_SECONDS,
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")
+            result = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme"
+            )
+
+        self.assertIs(result, spec)
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_no_bump_when_ml_preload_off(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_ML_ENABLED": "1", "LLMTRACE_ML_PRELOAD": "0"},
+            startup_timeout_seconds=300,
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")
+            result = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme"
+            )
+
+        # Spec untouched, no warning — even though startup_timeout is well
+        # below the floor (caller's choice when preload is off).
+        self.assertIs(result, spec)
+        self.assertEqual(result.startup_timeout_seconds, 300)
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_no_bump_when_ml_disabled(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_ML_ENABLED": "0", "LLMTRACE_ML_PRELOAD": "1"},
+            startup_timeout_seconds=300,
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")
+            result = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme"
+            )
+
+        self.assertIs(result, spec)
+        self.assertEqual(result.startup_timeout_seconds, 300)
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_no_bump_when_both_flags_absent(self) -> None:
+        spec = _proxy_spec(env={}, startup_timeout_seconds=120)
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")
+            result = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme"
+            )
+
+        self.assertIs(result, spec)
+        self.assertEqual(result.startup_timeout_seconds, 120)
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_custom_floor_override(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_ML_ENABLED": "1", "LLMTRACE_ML_PRELOAD": "1"},
+            startup_timeout_seconds=100,
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.WARNING):
+            bumped = lifecycle._apply_ml_preload_startup_floor(
+                spec, tenant_id="acme", floor=2400
+            )
+
+        self.assertEqual(bumped.startup_timeout_seconds, 2400)
+
+    def test_truthy_variants_recognised(self) -> None:
+        # Any value in the truthy set on BOTH flags triggers the bump.
+        for value in ("1", "true", "TRUE", "True", "yes", "YES"):
+            with self.subTest(value=value):
+                spec = _proxy_spec(
+                    env={
+                        "LLMTRACE_ML_ENABLED": value,
+                        "LLMTRACE_ML_PRELOAD": value,
+                    },
+                    startup_timeout_seconds=600,
+                )
+                bumped = lifecycle._apply_ml_preload_startup_floor(
+                    spec, tenant_id="acme"
+                )
+                self.assertEqual(
+                    bumped.startup_timeout_seconds,
+                    lifecycle.ML_PRELOAD_STARTUP_FLOOR_SECONDS,
+                )
+
+    def test_falsy_variants_do_not_trigger(self) -> None:
+        for value in ("0", "false", "no", "", "off", "FALSE"):
+            with self.subTest(value=value):
+                spec = _proxy_spec(
+                    env={
+                        "LLMTRACE_ML_ENABLED": "1",
+                        "LLMTRACE_ML_PRELOAD": value,
+                    },
+                    startup_timeout_seconds=300,
+                )
+                result = lifecycle._apply_ml_preload_startup_floor(
+                    spec, tenant_id="acme"
+                )
+                self.assertIs(result, spec)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #243.

## Summary

When a tenant config has both `LLMTRACE_ML_ENABLED` and `LLMTRACE_ML_PRELOAD` truthy in the proxy env, the lifecycle library now raises `ComponentSpec.startup_timeout_seconds` to a floor (`ML_PRELOAD_STARTUP_FLOOR_SECONDS = 1500`) before creating the Basilica deployment, and emits one WARN line per bump. Callers who explicitly set `startup_timeout_seconds >= 1500` keep their value silently. The bump is wired into every proxy-creating code path: `provision`, `update(strategy="recreate")` (via `provision`), and `rotate_admin_key`.

## Why

From issue #243's live e2e:

```
ERROR deployments.basilica.cli lifecycle failure: deployment 4e514237-94bc-4f08-88bb-c55b9efd091e not ready after 600s (expected_replicas=1)
```

Same image with `LLMTRACE_ML_ENABLED=0` on the same `cpu=2 / memory=4Gi` shape reached ready in 41s. The bottleneck is ML model preload (`prompt_injection` + `ner` + `injecguard` + `piguard`) on a small CPU pod exceeding the library's default `startup_timeout_seconds = 600`. A real tenant using `pro.yaml` or `starter.yaml` defaults would just see the workflow fail with no diagnostic. The auto-bump turns this from "silent timeout" into "succeeds with a clear WARN explaining the bump".

## Per-file changes

- `deployments/basilica/lifecycle.py`
  - New module constant `ML_PRELOAD_STARTUP_FLOOR_SECONDS = 1500`.
  - New helper `_apply_ml_preload_startup_floor(spec, *, tenant_id, floor) -> ComponentSpec`. Pure function on the spec, no SDK calls. Returns the input unchanged when ML preload isn't requested OR when the caller's value already meets the floor.
  - Wired into `provision()` after env resolution but before `_create_component`.
  - Wired into `rotate_admin_key()` after the new env is built but before `_create_component`.
  - `update(strategy="recreate")` is covered transitively (it calls `provision`).
- `deployments/basilica/tests/test_ml_preload_startup_floor.py` (new)
  - 9 unittest cases covering: bump-when-below-floor + warning, no-bump-when-at-or-above-floor + no warning, no-bump-when-preload-off, no-bump-when-ml-disabled, no-bump-when-flags-absent, custom-floor override, truthy variants ({1, true, TRUE, True, yes, YES}), falsy variants ({0, false, no, '', off, FALSE}). All test the real helper, no production code stubs.
- `deployments/basilica/configs/examples/pro.yaml` — `startup_timeout_seconds: 1500` with comment explaining the ML preload cost. Silences the WARN.
- `deployments/basilica/configs/examples/starter.yaml` — same.
- `deployments/basilica/README.md` — expanded "ML preload behaviour" subsection: preload cost band (600–1500s on small CPU), the auto-bump behaviour with file/function reference, how to opt out via `LLMTRACE_ML_PRELOAD: "0"` (lazy load), and how to silence the WARN.

## Validation evidence

Ran locally in this worktree:

```
$ python3 -c "from deployments.basilica import lifecycle, cli; print('ok')"
ok

$ python3 -m py_compile deployments/basilica/lifecycle.py deployments/basilica/cli.py deployments/basilica/tests/*.py
# (silent — exit 0)

$ python3 -m unittest deployments.basilica.tests.test_ml_preload_startup_floor -v
Ran 9 tests in 0.003s
OK
```

`pytest` is not installed in this sandbox; CI will run the full pytest suite.

Two pre-existing rotation tests (`test_no_rotation_when_flag_off`, `test_rotation_runs_when_flag_on`) fail locally because they exercise `provision()` end-to-end which tries to hit the live proxy URL via urllib — the sandbox has no DNS for `*.deployments.basilica.ai`. These failures are environmental and unrelated to this change; they pre-date the branch.

## Not live-validated in this PR

The original failing repro from issue #243:

```bash
gh workflow run tenant-lifecycle.yml \
  -R techlab-innov/llmtrace \
  -f tenant_id=ml-preload-repro \
  -f action=provision \
  -f config_path=deployments/basilica/configs/examples/pro.yaml
```

is intentionally NOT run from this worktree (no Basilica spend on a CI branch). The maintainer should re-run that command post-merge to confirm the auto-bump end-to-end against `:latest` on `cpu=2`. Expected outcome: proxy reaches ready inside the 1500s window with one WARN line in the lifecycle log noting the bump from 600 -> 1500 (or no warning at all, because the updated `pro.yaml` now sets 1500 explicitly).

## Test plan

- [ ] CI green on PR
- [ ] Maintainer re-runs the issue's repro workflow against `pro.yaml` and confirms a successful provision
- [ ] Spot-check the WARN line in the lifecycle log when a tenant config leaves `startup_timeout_seconds` at the old 600 default