### PR TITLE
cleanup(basilica): remove dashboard runtime-key injection (closes #245)

### DIFF
--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -334,9 +334,13 @@ issues TWO keys with distinct scopes:
 5. Calls `POST /api/v1/auth/keys` (auth: admin key, scoped to that
    tenant UUID) with body `{name: "tenant-runtime", role: "operator",
    tenant_id: <uuid>}` and captures the plaintext operator key.
-6. Adds `LLMTRACE_AUTH_RUNTIME_KEY=<operator_key>` to the dashboard env
-   (informational today; consumed by a follow-up dashboard wiring
-   change) and creates the dashboard deployment.
+6. Creates the dashboard deployment. The dashboard env carries the
+   admin key (its only consumer today is the proxy's `/api/v1/*` admin
+   endpoints — see `dashboard/src/lib/api.ts`,
+   `dashboard/src/lib/proxy-helpers.ts`). The operator key is **not**
+   injected into the dashboard env because no dashboard code path
+   consumes it; it is returned to the caller for the tenant's external
+   apps to use against `/v1/*` runtime traffic.
 7. Returns `TenantInstances(api_key=<operator>, admin_key=<admin>)`.
 
 Both plaintext keys are exposed only at this moment. Persist them
@@ -418,12 +422,6 @@ without any control-plane scope. See
 
 ### Caveats and follow-ups
 
-- **Dashboard wiring follow-up**: the Next.js dashboard
-  (`dashboard/src/lib/api.ts`, `dashboard/src/lib/proxy-helpers.ts`)
-  currently only reads `LLMTRACE_AUTH_ADMIN_KEY`. The lifecycle layer
-  injects `LLMTRACE_AUTH_RUNTIME_KEY` informationally; a separate PR
-  should switch the dashboard to use the runtime key for tenant-facing
-  traffic and the admin key only for admin pages.
 - **Admin key rotation** is opt-in via `rotate_admin_after_bootstrap:
   true` in the tenant config — see the "Admin key rotation" section
   below. Without it the bootstrap admin key lives in the proxy env for

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -65,11 +65,11 @@ dashboard:
     NODE_ENV: production
     # LLMTRACE_AUTH_ADMIN_KEY is set by the lifecycle library at provision
     # time to match the proxy's resolved admin key (used by dashboard
-    # server-side handlers for admin endpoints). LLMTRACE_AUTH_RUNTIME_KEY
-    # is set after the operator key is minted — dashboard wiring to
-    # consume the runtime key for tenant-facing traffic is a follow-up.
-    # If you set either var here explicitly, that value wins for the
-    # dashboard env.
+    # server-side handlers for admin endpoints). The operator key minted
+    # for tenant runtime traffic is returned in TenantInstances.api_key
+    # and is NOT injected into the dashboard env — no dashboard code
+    # path consumes it today. If you set LLMTRACE_AUTH_ADMIN_KEY here
+    # explicitly, that value wins for the dashboard env.
 
 # Optional — override if your tenant naming scheme differs.
 # proxy_name_template: "llmtrace-proxy-{tenant_id}"

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -426,9 +426,10 @@ def _apply_proxy_auth(
     can still talk to the proxy's admin endpoints (key management,
     tenant CRUD) on behalf of the portal/self-service UI;
     `LLMTRACE_AUTH_ENABLED` is only defaulted (caller may explicitly turn
-    it off in env). The operator key (`LLMTRACE_AUTH_RUNTIME_KEY`) is
-    injected later in `_inject_runtime_key_into_dashboard` once the proxy
-    is live and the key has been minted.
+    it off in env). The operator key is returned to the caller in
+    `TenantInstances.api_key` for tenant runtime apps to use against
+    `/v1/*`; it is intentionally NOT injected into the dashboard env
+    because no dashboard code path consumes it today.
     """
     proxy_env = {**proxy_spec.env, "LLMTRACE_AUTH_ADMIN_KEY": admin_key}
     proxy_env.setdefault("LLMTRACE_AUTH_ENABLED", "true")
@@ -491,22 +492,6 @@ def _apply_rate_limit(
         "LLMTRACE_RATE_LIMIT_BURST": str(rate_limit.burst_size),
     }
     return dataclasses.replace(proxy_spec, env=proxy_env)
-
-
-def _inject_runtime_key_into_dashboard(
-    dashboard_spec: ComponentSpec, operator_key: str
-) -> ComponentSpec:
-    """Add `LLMTRACE_AUTH_RUNTIME_KEY=<operator_key>` to the dashboard env.
-
-    NOTE: as of this PR the Next.js dashboard only reads
-    `LLMTRACE_AUTH_ADMIN_KEY` (`dashboard/src/lib/api.ts`,
-    `dashboard/src/lib/proxy-helpers.ts`). The runtime variable is set
-    informationally so the dashboard wiring follow-up (consume the
-    operator key for tenant-facing traffic, fall back to admin only for
-    admin pages) is a pure dashboard change with no platform side.
-    """
-    env = {**dashboard_spec.env, "LLMTRACE_AUTH_RUNTIME_KEY": operator_key}
-    return dataclasses.replace(dashboard_spec, env=env)
 
 
 def _admin_http_request(
@@ -750,9 +735,10 @@ def provision(
        tenant row (the operator-key mint requires the tenant to exist).
     4. Calls `POST /api/v1/auth/keys` to mint a scoped Operator-role key
        named `tenant-runtime`. This is the key the tenant gets.
-    5. Injects the operator key into the dashboard env as
-       `LLMTRACE_AUTH_RUNTIME_KEY` (informational; dashboard consumption
-       is a follow-up), then deploys the dashboard.
+    5. Deploys the dashboard. Only the admin key is in the dashboard env
+       because the dashboard's only call path today is the proxy's admin
+       endpoints; the operator key is returned to the caller for the
+       tenant's external runtime apps.
 
     Returns both keys: `api_key` is the operator key (runtime traffic);
     `admin_key` is the bootstrap admin key (retained by the caller for
@@ -796,9 +782,6 @@ def provision(
 
         tenant_uuid = _bootstrap_tenant_in_proxy(proxy.url, admin_key, tenant_id)
         operator_key = _mint_operator_key(proxy.url, admin_key, tenant_uuid)
-        dashboard_spec = _inject_runtime_key_into_dashboard(
-            dashboard_spec, operator_key
-        )
 
     if spec.inject_proxy_url_into_dashboard:
         merged_env = {**dashboard_spec.env, spec.proxy_url_env_var: proxy.url}

--- a/deployments/basilica/tests/test_operator_key_minting.py
+++ b/deployments/basilica/tests/test_operator_key_minting.py
@@ -321,12 +321,15 @@ def _make_dashboard_spec(env: Optional[dict[str, str]] = None) -> lifecycle.Comp
     )
 
 
-def test_inject_runtime_key_adds_var_without_dropping_existing() -> None:
-    spec = _make_dashboard_spec({"HOSTNAME": "0.0.0.0", "LLMTRACE_AUTH_ADMIN_KEY": ADMIN_KEY})
-    updated = lifecycle._inject_runtime_key_into_dashboard(spec, OPERATOR_KEY)
-    assert updated.env["HOSTNAME"] == "0.0.0.0"
-    assert updated.env["LLMTRACE_AUTH_ADMIN_KEY"] == ADMIN_KEY
-    assert updated.env["LLMTRACE_AUTH_RUNTIME_KEY"] == OPERATOR_KEY
+def test_inject_runtime_key_helper_is_absent() -> None:
+    """Lock in that the dashboard does NOT receive the operator key.
+
+    The runtime-key-injection helper was removed (issue #245) because
+    no dashboard call path consumes the operator key; the dashboard
+    only talks to the proxy's admin endpoints with the admin key. This
+    test guards against re-introducing the dead-weight injection.
+    """
+    assert not hasattr(lifecycle, "_inject_runtime_key_into_dashboard")
 
 
 def test_apply_proxy_auth_sets_admin_key_on_both_sides() -> None:
@@ -495,10 +498,11 @@ def test_provision_returns_operator_key_as_api_key_and_admin_key_separately(
     assert proxy_create["env"]["LLMTRACE_AUTH_ADMIN_KEY"] == ADMIN_KEY
     assert proxy_create["env"]["LLMTRACE_AUTH_ENABLED"] == "true"
 
-    # Verify dashboard was created with BOTH admin and runtime keys in env.
+    # Verify dashboard was created with the admin key in env, and NOT the
+    # operator (runtime) key — no dashboard code path consumes it (issue #245).
     dash_create = next(c for c in fake_client.creates if "dashboard" in c["instance_name"])
     assert dash_create["env"]["LLMTRACE_AUTH_ADMIN_KEY"] == ADMIN_KEY
-    assert dash_create["env"]["LLMTRACE_AUTH_RUNTIME_KEY"] == OPERATOR_KEY
+    assert "LLMTRACE_AUTH_RUNTIME_KEY" not in dash_create["env"]
 
 
 def test_provision_skips_key_flow_when_proxy_auth_disabled(fake_proxy: Any) -> None:


### PR DESCRIPTION
## Summary

Closes #245.

PR #239 added `_inject_runtime_key_into_dashboard()` plus a README "Dashboard wiring follow-up" caveat promising that `LLMTRACE_AUTH_RUNTIME_KEY` would be consumed by a future dashboard change. Post-merge investigation showed the Next.js dashboard only calls the proxy's `/api/v1/*` admin endpoints (`dashboard/src/lib/api.ts`, `dashboard/src/lib/proxy-helpers.ts`); no code path consumes the operator key. The injection was dead weight and the note misled future contributors.

This PR is a net deletion: -47 / +32 lines across 4 files. No new functionality.

## Per-file changes

### `deployments/basilica/lifecycle.py`
- Deleted the `_inject_runtime_key_into_dashboard(dashboard_spec, operator_key) -> ComponentSpec` helper entirely.
- Removed the call site in `provision()` (between the `_mint_operator_key` and the proxy-URL injection block).
- Verified by grep that no other call sites exist (`update`, `rotate_admin_key`, etc.). None did.
- Updated the `_apply_proxy_auth()` docstring to describe the actual model (admin key on both sides; operator key returned to caller, intentionally NOT injected into the dashboard env).
- Updated step 5 of the `provision()` docstring accordingly.

### `deployments/basilica/README.md`
- "Per-tenant API key auth" bootstrap sequence: rewrote step 6 to truthfully describe the two-tier model.
  - Admin key: in dashboard env; what the dashboard uses to call the proxy's admin endpoints.
  - Operator key: returned in `TenantInstances.api_key`; what the tenant's external apps use for `/v1/*` runtime traffic.
  - Explicitly notes that no dashboard code path consumes the operator key today.
- "Caveats and follow-ups": removed the "Dashboard wiring follow-up" bullet.

### `deployments/basilica/configs/examples/starter.yaml`
- Updated the dashboard `env:` comment to drop the `LLMTRACE_AUTH_RUNTIME_KEY` follow-up reference and document the truthful state.

### `deployments/basilica/tests/test_operator_key_minting.py`
- `test_inject_runtime_key_adds_var_without_dropping_existing` -> converted into `test_inject_runtime_key_helper_is_absent`: asserts `_inject_runtime_key_into_dashboard` no longer exists on the module, locking in the contract.
- `test_provision_returns_operator_key_as_api_key_and_admin_key_separately`: the positive `dash_create["env"]["LLMTRACE_AUTH_RUNTIME_KEY"] == OPERATOR_KEY` assertion is replaced with a negative `"LLMTRACE_AUTH_RUNTIME_KEY" not in dash_create["env"]`. All other assertions in the test (operator-key minted, returned as `api_key`, admin-key returned, dashboard created with admin key, proxy created with admin key + `AUTH_ENABLED=true`) are untouched.

## Validation evidence

Run inside this branch's worktree:

```
$ python3 -c "from deployments.basilica import lifecycle, cli; print('ok')"
ok

$ python3 -m py_compile deployments/basilica/lifecycle.py deployments/basilica/cli.py deployments/basilica/tests/*.py
(no output -> all compile clean)

$ python3 -m pytest deployments/basilica/tests/test_operator_key_minting.py deployments/basilica/tests/test_ml_preload_startup_floor.py -v --import-mode=importlib
...
======================= 28 passed in 8.06s =======================
```

Note: `test_rotate_admin_key.py` (2 tests) requires outbound DNS for its in-process HTTP fixture and fails in the local sandbox with `urllib.error.URLError: [Errno -5] No address associated with hostname`. The same failures reproduce on `main` (verified by stashing the diff), so they are environmental and unrelated to this change. CI runners have network access and will exercise those tests fully.

Final wider-repo grep for the removed identifiers shows only the negative-assertion sites in the test file:

```
$ grep -rn "_inject_runtime_key_into_dashboard\|LLMTRACE_AUTH_RUNTIME_KEY" deployments/basilica/
deployments/basilica/tests/test_operator_key_minting.py:332:    assert not hasattr(lifecycle, "_inject_runtime_key_into_dashboard")
deployments/basilica/tests/test_operator_key_minting.py:346:    assert "LLMTRACE_AUTH_RUNTIME_KEY" not in d.env
deployments/basilica/tests/test_operator_key_minting.py:505:    assert "LLMTRACE_AUTH_RUNTIME_KEY" not in dash_create["env"]
```

## Test plan
- [x] `python3 -c "from deployments.basilica import lifecycle, cli; print('ok')"` passes (import sanity).
- [x] `python3 -m py_compile` over all touched Python files passes.
- [x] `pytest deployments/basilica/tests/test_operator_key_minting.py` -> 19/19 pass.
- [x] `pytest deployments/basilica/tests/test_ml_preload_startup_floor.py` -> 9/9 pass (no regression from this change).
- [ ] CI runs the full suite, including the network-dependent `test_rotate_admin_key.py` tests that the local sandbox cannot reach.