### PR TITLE
feat(audit): expose GET /api/v1/audit + dashboard page (closes #246)

### DIFF
--- a/crates/llmtrace-proxy/src/audit_api.rs
+++ b/crates/llmtrace-proxy/src/audit_api.rs
@@ -1,0 +1,451 @@
+//! Audit log query API.
+//!
+//! Exposes `GET /api/v1/audit` which returns audit events recorded for the
+//! authenticated tenant. Admin-only; the tenant is resolved from the
+//! `AuthContext` injected by the auth middleware — operators can never see
+//! events from another tenant via this endpoint.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Extension;
+use axum::Json;
+use chrono::{DateTime, Utc};
+use llmtrace_core::{ApiKeyRole, AuditQuery, AuthContext};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::{IntoParams, ToSchema};
+
+use crate::proxy::AppState;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default page size when no `limit` is supplied.
+const DEFAULT_LIMIT: u32 = 100;
+
+/// Hard upper bound for the page size — protects the database from huge scans.
+const MAX_LIMIT: u32 = 1000;
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+/// Query parameters accepted by `GET /api/v1/audit`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListAuditParams {
+    /// Filter by event type (e.g. `tenant_created`, `api_key_created`).
+    pub event_type: Option<String>,
+    /// Inclusive start of the time window (RFC 3339).
+    #[param(value_type = String, format = "date-time")]
+    pub start_time: Option<DateTime<Utc>>,
+    /// Inclusive end of the time window (RFC 3339).
+    #[param(value_type = String, format = "date-time")]
+    pub end_time: Option<DateTime<Utc>>,
+    /// Maximum number of results (default 100, max 1000).
+    pub limit: Option<u32>,
+    /// Number of results to skip (default 0).
+    pub offset: Option<u32>,
+}
+
+/// API error response body.
+#[derive(Debug, Serialize, ToSchema)]
+struct ApiError {
+    error: ApiErrorDetail,
+}
+
+/// Inner error detail.
+#[derive(Debug, Serialize, ToSchema)]
+struct ApiErrorDetail {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: String,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a JSON error response.
+fn api_error(status: StatusCode, message: &str) -> Response {
+    let body = ApiError {
+        error: ApiErrorDetail {
+            message: message.to_string(),
+            error_type: "api_error".to_string(),
+        },
+    };
+    (status, Json(body)).into_response()
+}
+
+/// Clamp `limit` to `[1, MAX_LIMIT]`. Logs a warning when the request value is
+/// reduced so operators can spot abusive clients.
+fn clamp_limit(requested: Option<u32>) -> u32 {
+    let raw = requested.unwrap_or(DEFAULT_LIMIT);
+    if raw > MAX_LIMIT {
+        tracing::warn!(
+            requested = raw,
+            max = MAX_LIMIT,
+            "audit query limit clamped"
+        );
+        MAX_LIMIT
+    } else if raw == 0 {
+        DEFAULT_LIMIT
+    } else {
+        raw
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/audit` — list audit events for the authenticated tenant.
+///
+/// Admin-only. The tenant is derived from the authenticated principal — no
+/// `tenant_id` parameter is accepted. Results are filtered server-side and
+/// returned newest-first (delegated to the storage layer).
+#[utoipa::path(
+    get,
+    path = "/api/v1/audit",
+    params(
+        ListAuditParams
+    ),
+    responses(
+        (status = 200, description = "Audit events for the authenticated tenant", body = [llmtrace_core::AuditEvent]),
+        (status = 400, description = "Missing tenant context", body = ApiError),
+        (status = 401, description = "Unauthorized", body = ApiError),
+        (status = 403, description = "Forbidden — requires admin role", body = ApiError),
+        (status = 500, description = "Internal server error", body = ApiError),
+    ),
+    security(("api_key" = [])),
+    tag = "LLMTrace Proxy"
+)]
+pub async fn list_audit_events(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthContext>,
+    Query(params): Query<ListAuditParams>,
+) -> Response {
+    if !auth.role.has_permission(ApiKeyRole::Admin) {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "Insufficient permissions: requires admin role",
+        );
+    }
+
+    let limit = clamp_limit(params.limit);
+    let offset = params.offset.unwrap_or(0);
+
+    let query = AuditQuery {
+        tenant_id: auth.tenant_id,
+        event_type: params.event_type,
+        start_time: params.start_time,
+        end_time: params.end_time,
+        limit: Some(limit),
+        offset: Some(offset),
+    };
+
+    match state.metadata().query_audit_events(&query).await {
+        Ok(events) => Json(events).into_response(),
+        Err(e) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("Failed to query audit events: {e}"),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use axum::Router;
+    use chrono::Utc;
+    use llmtrace_core::{
+        ApiKeyRecord, ApiKeyRole, AuditEvent, AuthConfig, ProxyConfig, SecurityAnalyzer,
+        StorageConfig, Tenant, TenantId,
+    };
+    use llmtrace_security::RegexSecurityAnalyzer;
+    use llmtrace_storage::StorageProfile;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    /// Build shared state with auth enabled and a known admin key.
+    async fn auth_state(admin_key: &str) -> Arc<AppState> {
+        let storage = StorageProfile::Memory.build().await.unwrap();
+        let security = Arc::new(RegexSecurityAnalyzer::new().unwrap()) as Arc<dyn SecurityAnalyzer>;
+        let client = reqwest::Client::new();
+        let config = ProxyConfig {
+            storage: StorageConfig {
+                profile: "memory".to_string(),
+                database_path: String::new(),
+                ..StorageConfig::default()
+            },
+            auth: AuthConfig {
+                enabled: true,
+                admin_key: Some(admin_key.to_string()),
+            },
+            ..ProxyConfig::default()
+        };
+        let storage_breaker = Arc::new(crate::circuit_breaker::CircuitBreaker::from_config(
+            &config.circuit_breaker,
+        ));
+        let security_breaker = Arc::new(crate::circuit_breaker::CircuitBreaker::from_config(
+            &config.circuit_breaker,
+        ));
+        let cost_estimator = crate::cost::CostEstimator::new(&config.cost_estimation);
+        let cost_tracker =
+            crate::cost_caps::CostTracker::new(&config.cost_caps, Arc::clone(&storage.cache));
+        let rate_limiter =
+            crate::rate_limit::RateLimiter::new(&config.rate_limiting, Arc::clone(&storage.cache));
+
+        Arc::new(AppState {
+            config_handle: crate::config_handle::ConfigHandle::new(config, None, None),
+            client,
+            storage,
+            fast_analyzer: security.clone(),
+            security,
+            #[cfg(feature = "ml")]
+            security_ensemble: None,
+            ensemble_runtime: std::sync::Arc::new(llmtrace_security::EnsembleRuntimeHandle::inert()),
+            storage_breaker,
+            security_breaker,
+            cost_estimator,
+            alert_engine: None,
+            cost_tracker,
+            anomaly_detector: None,
+            action_router: crate::action_router::ActionRouter::new(
+                &llmtrace_core::ActionRouterConfig::default(),
+                llmtrace_core::JudgePromotionConfig::default(),
+                llmtrace_core::JudgeWorkerConfig::default().max_analysis_text_bytes,
+                None,
+                reqwest::Client::new(),
+            ),
+            report_store: crate::compliance::new_report_store(),
+            rate_limiter,
+            ml_status: crate::proxy::MlModelStatus::Disabled,
+            judge_worker_spawned: false,
+            runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
+            shutdown: crate::shutdown::ShutdownCoordinator::new(30),
+            metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(8)),
+            ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        })
+    }
+
+    /// Build a router with the audit handler behind the real auth middleware.
+    fn audit_router(state: Arc<AppState>) -> Router {
+        Router::new()
+            .route("/api/v1/audit", get(super::list_audit_events))
+            .layer(axum::middleware::from_fn_with_state(
+                Arc::clone(&state),
+                crate::auth::auth_middleware,
+            ))
+            .with_state(state)
+    }
+
+    /// Parse a JSON response body.
+    async fn json_body(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Insert a tenant and a key with the requested role into storage.
+    async fn provision_key(state: &Arc<AppState>, role: ApiKeyRole) -> (Tenant, String) {
+        let tenant = Tenant {
+            id: TenantId::new(),
+            name: "Test Tenant".to_string(),
+            api_token: format!("token-{}", Uuid::new_v4()),
+            plan: "pro".to_string(),
+            created_at: Utc::now(),
+            config: serde_json::json!({}),
+        };
+        state.metadata().create_tenant(&tenant).await.unwrap();
+
+        let (plaintext, hash) = crate::auth::generate_api_key();
+        let record = ApiKeyRecord {
+            id: Uuid::new_v4(),
+            tenant_id: tenant.id,
+            name: format!("{role}-key"),
+            key_hash: hash,
+            key_prefix: crate::auth::key_prefix(&plaintext),
+            role,
+            created_at: Utc::now(),
+            revoked_at: None,
+        };
+        state.metadata().create_api_key(&record).await.unwrap();
+        (tenant, plaintext)
+    }
+
+    /// Record a single audit event for a tenant.
+    async fn record_event(
+        state: &Arc<AppState>,
+        tenant_id: TenantId,
+        event_type: &str,
+    ) -> AuditEvent {
+        let event = AuditEvent {
+            id: Uuid::new_v4(),
+            tenant_id,
+            event_type: event_type.to_string(),
+            actor: "test".to_string(),
+            resource: format!("resource:{}", Uuid::new_v4()),
+            data: serde_json::json!({"key": "value"}),
+            timestamp: Utc::now(),
+        };
+        state.metadata().record_audit_event(&event).await.unwrap();
+        event
+    }
+
+    #[test]
+    fn test_clamp_limit_default() {
+        assert_eq!(clamp_limit(None), DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn test_clamp_limit_explicit_within_range() {
+        assert_eq!(clamp_limit(Some(10)), 10);
+        assert_eq!(clamp_limit(Some(MAX_LIMIT)), MAX_LIMIT);
+    }
+
+    #[test]
+    fn test_clamp_limit_exceeds_max() {
+        assert_eq!(clamp_limit(Some(999_999)), MAX_LIMIT);
+    }
+
+    #[test]
+    fn test_clamp_limit_zero_falls_back_to_default() {
+        assert_eq!(clamp_limit(Some(0)), DEFAULT_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn test_audit_endpoint_rejects_unauthenticated() {
+        let state = auth_state("admin-secret").await;
+        let app = audit_router(state);
+
+        let req = Request::get("/api/v1/audit").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_audit_endpoint_rejects_operator_role() {
+        let state = auth_state("admin-secret").await;
+        let (_tenant, plaintext) = provision_key(&state, ApiKeyRole::Operator).await;
+
+        let app = audit_router(Arc::clone(&state));
+        let req = Request::get("/api/v1/audit")
+            .header("authorization", format!("Bearer {plaintext}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_audit_endpoint_returns_events_for_admin() {
+        let state = auth_state("admin-secret").await;
+        let (tenant, plaintext) = provision_key(&state, ApiKeyRole::Admin).await;
+        let event = record_event(&state, tenant.id, "tenant_created").await;
+
+        let app = audit_router(Arc::clone(&state));
+        let req = Request::get("/api/v1/audit")
+            .header("authorization", format!("Bearer {plaintext}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = json_body(resp).await;
+        let arr = body.as_array().expect("response must be a JSON array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], event.id.to_string());
+        assert_eq!(arr[0]["event_type"], "tenant_created");
+        assert_eq!(arr[0]["tenant_id"], tenant.id.0.to_string());
+        // Ensure the locked response shape matches AuditEvent.
+        for field in [
+            "id",
+            "tenant_id",
+            "event_type",
+            "actor",
+            "resource",
+            "data",
+            "timestamp",
+        ] {
+            assert!(arr[0].get(field).is_some(), "missing field {field}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_audit_endpoint_filters_by_event_type() {
+        let state = auth_state("admin-secret").await;
+        let (tenant, plaintext) = provision_key(&state, ApiKeyRole::Admin).await;
+        record_event(&state, tenant.id, "tenant_created").await;
+        record_event(&state, tenant.id, "api_key_created").await;
+
+        let app = audit_router(Arc::clone(&state));
+        let req = Request::get("/api/v1/audit?event_type=tenant_created")
+            .header("authorization", format!("Bearer {plaintext}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = json_body(resp).await;
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["event_type"], "tenant_created");
+    }
+
+    #[tokio::test]
+    async fn test_audit_endpoint_honours_explicit_limit() {
+        let state = auth_state("admin-secret").await;
+        let (tenant, plaintext) = provision_key(&state, ApiKeyRole::Admin).await;
+        for _ in 0..3 {
+            record_event(&state, tenant.id, "config_changed").await;
+        }
+
+        let app = audit_router(Arc::clone(&state));
+        let req = Request::get("/api/v1/audit?limit=2")
+            .header("authorization", format!("Bearer {plaintext}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = json_body(resp).await;
+        assert_eq!(body.as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_audit_endpoint_tenant_isolation() {
+        let state = auth_state("admin-secret").await;
+        let (tenant_a, key_a) = provision_key(&state, ApiKeyRole::Admin).await;
+        let (tenant_b, _key_b) = provision_key(&state, ApiKeyRole::Admin).await;
+
+        // Tenant A and B each get one event.
+        record_event(&state, tenant_a.id, "tenant_created").await;
+        record_event(&state, tenant_b.id, "tenant_created").await;
+
+        // Tenant A's key should ONLY see tenant A's event.
+        let app = audit_router(Arc::clone(&state));
+        let req = Request::get("/api/v1/audit")
+            .header("authorization", format!("Bearer {key_a}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = json_body(resp).await;
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["tenant_id"], tenant_a.id.0.to_string());
+        assert_ne!(arr[0]["tenant_id"], tenant_b.id.0.to_string());
+    }
+}

--- a/crates/llmtrace-proxy/src/lib.rs
+++ b/crates/llmtrace-proxy/src/lib.rs
@@ -7,6 +7,7 @@ pub mod action_router;
 pub mod alerts;
 pub mod anomaly;
 pub mod api;
+pub mod audit_api;
 pub mod auth;
 pub mod boundary;
 pub mod circuit_breaker;

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -1002,6 +1002,11 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/v1/auth/keys/:id",
             delete(llmtrace_proxy::auth::revoke_api_key),
         )
+        // Audit log API
+        .route(
+            "/api/v1/audit",
+            get(llmtrace_proxy::audit_api::list_audit_events),
+        )
         // REST Query API
         .route(
             "/api/v1/config/live",

--- a/crates/llmtrace-proxy/src/openapi.rs
+++ b/crates/llmtrace-proxy/src/openapi.rs
@@ -40,6 +40,7 @@ impl Modify for SecurityAddon {
         crate::api::get_current_costs,
         crate::api::report_action,
         crate::api::actions_summary,
+        crate::audit_api::list_audit_events,
         crate::auth::create_api_key,
         crate::auth::list_api_keys,
         crate::auth::revoke_api_key,

--- a/dashboard/src/app/audit/page.tsx
+++ b/dashboard/src/app/audit/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ScrollText, RefreshCw, AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { DataTable } from "@/components/data-table";
+import {
+  findActiveTenant,
+  listAuditEvents,
+  type AuditEvent,
+  type ListAuditEventsParams,
+} from "@/lib/api";
+
+const PAGE_SIZE = 100;
+
+/** Collapsible JSON viewer for the per-row `data` payload. */
+function DataCell({ value }: { value: unknown }) {
+  const [open, setOpen] = useState(false);
+  const json = useMemo(() => {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }, [value]);
+
+  if (value === null || value === undefined || json === "{}" || json === "null") {
+    return <span className="text-xs text-muted-foreground">—</span>;
+  }
+
+  return (
+    <div className="max-w-xl">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+        data-testid="audit-data-toggle"
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {open ? "Hide" : "Show"} payload
+      </button>
+      {open && (
+        <pre
+          data-testid="audit-data-payload"
+          className="mt-2 max-h-60 overflow-auto rounded-md border bg-muted/30 p-2 text-[11px] leading-relaxed"
+        >
+          {json}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export default function AuditPage() {
+  const [events, setEvents] = useState<AuditEvent[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tenantId, setTenantId] = useState<string | undefined>(undefined);
+  const [filter, setFilter] = useState("");
+  const [offset, setOffset] = useState(0);
+
+  async function load(currentTenant: string | undefined, params: ListAuditEventsParams) {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listAuditEvents(params, currentTenant);
+      setEvents(data);
+    } catch (e) {
+      setEvents(null);
+      setError(e instanceof Error ? e.message : "Failed to load audit events");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const t = await findActiveTenant();
+      if (cancelled) return;
+      setTenantId(t);
+      await load(t, { limit: PAGE_SIZE, offset: 0 });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleFilterApply = () => {
+    setOffset(0);
+    load(tenantId, {
+      limit: PAGE_SIZE,
+      offset: 0,
+      event_type: filter.trim() || undefined,
+    });
+  };
+
+  const handlePage = (direction: "prev" | "next") => {
+    const nextOffset =
+      direction === "prev" ? Math.max(0, offset - PAGE_SIZE) : offset + PAGE_SIZE;
+    setOffset(nextOffset);
+    load(tenantId, {
+      limit: PAGE_SIZE,
+      offset: nextOffset,
+      event_type: filter.trim() || undefined,
+    });
+  };
+
+  const columns = [
+    {
+      header: "Timestamp",
+      accessor: (e: AuditEvent) => (
+        <span className="font-mono text-xs">
+          {new Date(e.timestamp).toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      header: "Event type",
+      accessor: (e: AuditEvent) => (
+        <Badge variant="secondary" className="font-mono text-[11px]">
+          {e.event_type}
+        </Badge>
+      ),
+    },
+    {
+      header: "Actor",
+      accessor: (e: AuditEvent) => (
+        <span className="text-xs text-muted-foreground">{e.actor || "—"}</span>
+      ),
+    },
+    {
+      header: "Resource",
+      accessor: (e: AuditEvent) => (
+        <span className="font-mono text-[11px] break-all">{e.resource || "—"}</span>
+      ),
+      className: "max-w-xs",
+    },
+    {
+      header: "Data",
+      accessor: (e: AuditEvent) => <DataCell value={e.data} />,
+    },
+  ];
+
+  const pageNumber = Math.floor(offset / PAGE_SIZE) + 1;
+  const hasNext = (events?.length ?? 0) === PAGE_SIZE;
+  const hasPrev = offset > 0;
+
+  return (
+    <div className="space-y-6 max-w-6xl mx-auto pb-12">
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <ScrollText className="h-7 w-7 text-primary" /> Audit
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Tenant-scoped audit events: tenant CRUD, API key mint/revoke, config changes, etc.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => load(tenantId, { limit: PAGE_SIZE, offset })}
+          disabled={loading}
+          className="shadow-sm"
+        >
+          <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} /> Refresh
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Filter</CardTitle>
+          <CardDescription className="text-xs">
+            Filter by exact event type (e.g. <code className="font-mono">tenant_created</code>,{" "}
+            <code className="font-mono">api_key_created</code>).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap items-end gap-3">
+          <div className="space-y-1">
+            <label className="text-[10px] font-bold uppercase text-muted-foreground">
+              Event type
+            </label>
+            <input
+              type="text"
+              value={filter}
+              data-testid="audit-event-type-filter"
+              onChange={(e) => setFilter(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleFilterApply();
+              }}
+              placeholder="tenant_created"
+              className="h-9 w-56 rounded-md border border-input bg-background px-3 py-2 text-sm focus:ring-2 focus:ring-primary"
+            />
+          </div>
+          <Button onClick={handleFilterApply} disabled={loading} size="sm" className="h-9">
+            Apply
+          </Button>
+          {filter && (
+            <Button
+              onClick={() => {
+                setFilter("");
+                setOffset(0);
+                load(tenantId, { limit: PAGE_SIZE, offset: 0 });
+              }}
+              variant="ghost"
+              size="sm"
+              className="h-9"
+            >
+              Clear
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3 flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="text-base">Audit Events</CardTitle>
+            <CardDescription className="text-xs">
+              Page {pageNumber} · {events?.length ?? 0} event(s)
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasPrev || loading}
+              onClick={() => handlePage("prev")}
+              data-testid="audit-prev-page"
+            >
+              Prev
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!hasNext || loading}
+              onClick={() => handlePage("next")}
+              data-testid="audit-next-page"
+            >
+              Next
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="mb-4 flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <span data-testid="audit-error">{error}</span>
+            </div>
+          )}
+          {loading ? (
+            <div className="py-12 text-center">
+              <RefreshCw className="mx-auto h-8 w-8 animate-spin text-muted-foreground/40" />
+              <p className="mt-4 text-sm text-muted-foreground animate-pulse">
+                Loading audit events…
+              </p>
+            </div>
+          ) : (
+            <DataTable
+              columns={columns}
+              data={events ?? []}
+              emptyMessage="No audit events recorded yet"
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   FileCheck,
   BookOpen,
   Gauge,
+  ScrollText,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { listTenants, setStoredTenant, type Tenant, DEFAULT_TENANT_ID } from "@/lib/api";
@@ -22,6 +23,7 @@ const navItems = [
   { href: "/", label: "Overview", icon: LayoutDashboard },
   { href: "/traces", label: "Traces", icon: FileSearch },
   { href: "/security", label: "Security", icon: Shield },
+  { href: "/audit", label: "Audit", icon: ScrollText },
   { href: "/costs", label: "Costs", icon: DollarSign },
   { href: "/tenants", label: "Tenants", icon: Users },
   { href: "/compliance", label: "Compliance", icon: FileCheck },

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -2,6 +2,10 @@
 // LLMTrace REST API Client — typed fetch wrapper
 // ---------------------------------------------------------------------------
 
+import type { AuditEvent } from "./types";
+
+export type { AuditEvent };
+
 const API_BASE = "";
 
 /** Default tenant ID used as a fallback for the "default" tenant. */
@@ -532,4 +536,34 @@ export async function listReports(
 /** Get a single compliance report. */
 export async function getReport(id: string, tenantId?: string): Promise<ComplianceReport> {
   return apiFetch(`/api/v1/reports/${id}`, undefined, tenantId);
+}
+
+// -- Audit log -------------------------------------------------------------
+
+/** Query parameters for `GET /api/v1/audit`. */
+export interface ListAuditEventsParams {
+  event_type?: string;
+  start_time?: string;
+  end_time?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * List audit events for the authenticated tenant.
+ *
+ * The proxy returns a flat JSON array (newest-first). The handler is
+ * admin-only and derives the tenant from the auth context — passing
+ * `tenantId` here only sets the `X-LLMTrace-Tenant-ID` header used by the
+ * bootstrap admin key, never to broaden the result set.
+ */
+export async function listAuditEvents(
+  params: ListAuditEventsParams = {},
+  tenantId?: string,
+): Promise<AuditEvent[]> {
+  return apiFetch(
+    `/api/v1/audit${qs(params as Record<string, string | number | undefined>)}`,
+    undefined,
+    tenantId,
+  );
 }

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------
+// Shared TypeScript types that mirror Rust API payloads.
+// ---------------------------------------------------------------------------
+
+/**
+ * An audit log entry recorded by the proxy for tenant-scoped actions
+ * (tenant CRUD, API key mint/revoke, config changes, etc.).
+ *
+ * Mirrors `llmtrace_core::AuditEvent`.
+ */
+export interface AuditEvent {
+  id: string;
+  tenant_id: string;
+  event_type: string;
+  actor: string;
+  resource: string;
+  data: unknown;
+  timestamp: string; // ISO 8601
+}


### PR DESCRIPTION
Closes #246.

## Summary

The proxy already records audit events (tenant CRUD, API-key mint/revoke, config changes, etc.) but neither exposed them via HTTP nor surfaced them in the dashboard. This PR adds both halves.

## Per-file changes

### Rust (proxy)

- `crates/llmtrace-proxy/src/audit_api.rs` (new) — `GET /api/v1/audit` handler. Admin-only via `ApiKeyRole::Admin`. Tenant is derived from `AuthContext` only — there is no `tenant_id` URL/query parameter, so operators cannot inspect another tenant's events. Accepts `event_type`, `start_time`, `end_time` (RFC3339), `limit` (default 100, clamped to 1000 with a warn log), `offset`. Returns a flat JSON array of `AuditEvent`. `#[utoipa::path(...)]` annotated.
- `crates/llmtrace-proxy/src/lib.rs` — register `audit_api` module.
- `crates/llmtrace-proxy/src/main.rs` — register `/api/v1/audit` route.
- `crates/llmtrace-proxy/src/openapi.rs` — include handler in the OpenAPI document so Swagger picks it up.
- 10 unit tests covering `clamp_limit` (default / explicit / over-max / zero), 200 happy path with full response-shape assertions, 401 unauthenticated, 403 operator-role rejection, `event_type` filter, explicit `limit` honoured, and tenant A vs tenant B isolation.

### Dashboard

- `dashboard/src/lib/types.ts` (new) — `AuditEvent` interface mirroring the Rust shape.
- `dashboard/src/lib/api.ts` — re-exports `AuditEvent` and adds `listAuditEvents()` (returns a flat `AuditEvent[]`, matching the locked Rust shape).
- `dashboard/src/app/audit/page.tsx` (new) — table with columns Timestamp / Event type / Actor / Resource / Data (collapsible JSON). Free-text event-type filter, prev/next pagination at 100/page, plus loading / empty / error states.
- `dashboard/src/components/sidebar.tsx` — adds `Audit` entry between Security and Costs with the `ScrollText` lucide icon. Grouping rationale: Audit is observability-adjacent like Security, so it sits next to it.

## Validation evidence

- `cargo fmt --all` — clean.
- `cargo build -p llmtrace` — succeeded.
- `cargo test -p llmtrace --tests` — `607 passed; 0 failed` (unit) + `21 passed` (main) + `19 passed` (integration). The 10 new `audit_api::tests::*` all pass.
- `cd dashboard && npm run lint` — only pre-existing warnings on unrelated files (`compliance/page.tsx`, `guide/page.tsx`, `traces/page.tsx`). No new warnings or errors from this PR.
- `cd dashboard && npm run build` — succeeded; `/audit` route emitted (4.67 kB / 117 kB First Load JS).

## Not validated

- No live smoke test of the dashboard `/audit` page was performed from this worktree (no live proxy running). The page is exercised only by the Next.js build typecheck.

## Out of scope (per the issue)

- Aggregated audit dashboards / charts.
- Cross-tenant audit views.
- Export to CSV / JSON download.