### PR TITLE
fix(proxy): accept 'sqlite' as storage profile alias (closes #249)

### DIFF
--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -1806,10 +1806,12 @@ impl Default for JudgePromotionConfig {
 /// Storage configuration section within [`ProxyConfig`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageConfig {
-    /// Storage profile: `"lite"` (SQLite), `"memory"` (in-memory), or `"production"` (ClickHouse + PostgreSQL + Redis).
+    /// Storage profile: `"lite"` or `"sqlite"` (SQLite, equivalent),
+    /// `"memory"` (in-memory), or `"production"` (ClickHouse +
+    /// PostgreSQL + Redis).
     #[serde(default = "default_storage_profile")]
     pub profile: String,
-    /// Database file path (used by the `"lite"` profile).
+    /// Database file path (used by the `"lite"` / `"sqlite"` profile).
     #[serde(default = "default_database_path")]
     pub database_path: String,
     /// ClickHouse HTTP URL (used by the `"production"` profile).

--- a/crates/llmtrace-proxy/src/config.rs
+++ b/crates/llmtrace-proxy/src/config.rs
@@ -114,10 +114,14 @@ pub fn validate_config(config: &ProxyConfig) -> anyhow::Result<()> {
         errors.push("upstream_url must start with http:// or https://".to_string());
     }
 
+    // `sqlite` is accepted as a documented alias for `lite` because the
+    // basilica example configs default `LLMTRACE_STORAGE_PROFILE` to
+    // `sqlite` and tenants rely on that spelling. Keep both spellings
+    // wired here AND in the `StorageProfile` factory in `main.rs`.
     match config.storage.profile.as_str() {
-        "lite" | "memory" | "production" => {}
+        "lite" | "sqlite" | "memory" | "production" => {}
         other => errors.push(format!(
-            "storage.profile must be 'lite', 'memory', or 'production', got '{other}'"
+            "storage.profile must be 'lite', 'sqlite', 'memory', or 'production', got '{other}'"
         )),
     }
 
@@ -455,6 +459,26 @@ health_check:
         };
         let err = validate_config(&config).unwrap_err();
         assert!(err.to_string().contains("storage.profile"));
+    }
+
+    /// Regression test for issue #249: `LLMTRACE_STORAGE_PROFILE=sqlite`
+    /// must be accepted as a documented alias for `lite`. The basilica
+    /// `pro.yaml` example defaults to `sqlite`, so rejecting it caused
+    /// the proxy to crash-loop before `/health` ever bound, which the
+    /// platform reports as "stuck in starting".
+    #[test]
+    fn test_validate_config_accepts_sqlite_alias() {
+        for profile in ["lite", "sqlite", "memory"] {
+            let config = ProxyConfig {
+                storage: llmtrace_core::StorageConfig {
+                    profile: profile.to_string(),
+                    ..llmtrace_core::StorageConfig::default()
+                },
+                ..ProxyConfig::default()
+            };
+            validate_config(&config)
+                .unwrap_or_else(|e| panic!("profile {profile} must validate cleanly: {e}"));
+        }
     }
 
     #[test]

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -204,7 +204,7 @@ async fn run_migrate(config: &ProxyConfig) -> anyhow::Result<()> {
     );
 
     match config.storage.profile.as_str() {
-        "lite" => {
+        "lite" | "sqlite" => {
             let url = format!("sqlite:{}", config.storage.database_path);
             let pool = llmtrace_storage::migration::open_sqlite_pool(&url).await?;
             llmtrace_storage::migration::run_sqlite_migrations(&pool).await?;
@@ -432,6 +432,9 @@ async fn build_app_state(
         .timeout(std::time::Duration::from_millis(config.timeout_ms))
         .build()?;
 
+    // Both `lite` and `sqlite` resolve to the same SQLite-backed profile;
+    // `sqlite` is documented in `validate_config` as an alias because the
+    // basilica example configs use that spelling.
     let profile =
         match config.storage.profile.as_str() {
             "memory" => StorageProfile::Memory,

--- a/crates/llmtrace-storage/src/sqlite.rs
+++ b/crates/llmtrace-storage/src/sqlite.rs
@@ -1922,4 +1922,52 @@ mod tests {
         let repo = test_metadata().await;
         assert!(repo.health_check().await.is_ok());
     }
+
+    /// Regression for issue #249: on a freshly-provisioned SQLite database
+    /// (backed by a real tempfile, not `:memory:`), the proxy's startup
+    /// sequence must complete without hanging. Specifically:
+    ///
+    /// 1. Migrations must finish within a small bound, leaving the
+    ///    metadata schema (including `audit_events`) in place.
+    /// 2. `health_check()` — what `health_handler` polls before flipping
+    ///    `/health` to 200 — must return `Ok` within a short timeout.
+    /// 3. `query_audit_events()` — invoked by `GET /api/v1/audit` added
+    ///    in PR #248 — must return `Ok(vec![])` on an empty database
+    ///    rather than erroring or blocking.
+    ///
+    /// The 5-second tokio timeout is the hard cap: if the call ever
+    /// hangs we want the CI signal, not a stuck job.
+    #[tokio::test]
+    async fn test_sqlite_metadata_startup_on_fresh_tempfile() {
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("issue249.db");
+        let url = format!("sqlite:{}", db_path.to_string_lossy());
+
+        let repo = timeout(Duration::from_secs(5), SqliteMetadataRepository::new(&url))
+            .await
+            .expect("metadata repo construction must not hang on a fresh tempfile")
+            .expect("metadata repo construction must succeed on a fresh tempfile");
+
+        timeout(Duration::from_secs(5), repo.health_check())
+            .await
+            .expect("health_check must not hang on a fresh sqlite db")
+            .expect("health_check must succeed on a fresh sqlite db");
+
+        let tenant_id = TenantId::new();
+        let events = timeout(
+            Duration::from_secs(5),
+            repo.query_audit_events(&AuditQuery::new(tenant_id)),
+        )
+        .await
+        .expect("query_audit_events must not hang on a fresh sqlite db")
+        .expect("query_audit_events must succeed on a fresh sqlite db");
+        assert!(
+            events.is_empty(),
+            "audit_events on a fresh sqlite db must be empty, got {} rows",
+            events.len()
+        );
+    }
 }


### PR DESCRIPTION
## Root cause

The basilica `pro.yaml` example defaults `LLMTRACE_STORAGE_PROFILE` to `sqlite`, but `crates/llmtrace-proxy/src/config.rs::validate_config` only accepted `"lite" | "memory" | "production"`. Anything else (including `"sqlite"`) produced a validation error before `run_proxy` was called, so the proxy exited non-zero before `/health` ever bound. On Basilica that surfaces as `state=Active phase=starting replicas=0/1` for the entire startup window — exactly matching the symptom in the issue. The `memory` profile sailed through validation, which is why the workaround in the bug report worked.

PR #248's `audit_api.rs` is innocent here: the `audit_events` table is already created by SQLite migration `002_metadata_tables.sql` (present since long before #248), and `query_audit_events` on an empty database returns `Ok(vec![])` within milliseconds. The issue's "missing migration" hypothesis was a red herring — the real failure mode was upstream of the storage layer.

## Fix

Accept `sqlite` as a documented alias for `lite` in the three places that mattered:

1. `config::validate_config` — the gate that was actually rejecting it.
2. `main::build_app_state` — comment clarifies the existing `_ => Lite { ... }` fallback already routes `sqlite` to `StorageProfile::Lite`, so once validation passes the behaviour is unchanged.
3. `main::run_migrate` — added `sqlite` to the `lite` match arm so the `migrate` subcommand also works under the new spelling.
4. `llmtrace-core::StorageConfig::profile` doc comment updated to mention the alias.

## Regression tests

- `crates/llmtrace-proxy/src/config.rs::test_validate_config_accepts_sqlite_alias` — locks the validator on all three accepted spellings (`lite`, `sqlite`, `memory`). Will fail if a future refactor drops the alias.
- `crates/llmtrace-storage/src/sqlite.rs::test_sqlite_metadata_startup_on_fresh_tempfile` — spins up `SqliteMetadataRepository::new` on a real tempfile (not `:memory:`), asserts:
  - construction (i.e. migration run) completes in < 5s
  - `health_check()` returns `Ok` in < 5s
  - `query_audit_events(&AuditQuery::new(tenant_id))` returns `Ok([])` in < 5s on a fresh DB

The 5s tokio timeouts are the hard cap: if any call ever hangs, CI fires immediately instead of waiting for a 30m job timeout.

## Validation evidence

- `cargo fmt --all -- --check` clean.
- `cargo build -p llmtrace` clean.
- `cargo test -p llmtrace-storage --tests` — 57 passed, 0 failed (includes both `test_audit_events` and the new `test_sqlite_metadata_startup_on_fresh_tempfile`).
- `cargo test -p llmtrace --tests` — 21 unit + 19 integration passed, 0 failed (includes the new `test_validate_config_accepts_sqlite_alias`).
- Manual local run with `profile: sqlite` + `LLMTRACE_ML_ENABLED=0`:
  - `./target/debug/llmtrace-proxy --config <sqlite.yaml> validate` prints `✓ Configuration is valid.`
  - Started the binary, polled `/health`, got `HTTP 200 status:"healthy"` within ~3s with `metadata.healthy=true`.

## What still needs maintainer validation

This worktree cannot reach Basilica, so the original end-to-end repro (the GH Actions tenant-lifecycle workflow with the published `:latest` image + `LLMTRACE_STORAGE_PROFILE=sqlite` + cpu=2) must be re-run by the maintainer after the new `:sha-<merge>` image is published. Expected outcome: provision reaches ready in < 60s on cpu=2, matching the acceptance criterion.

## Acceptance map

- [x] Provision succeeds with `:latest` image + `LLMTRACE_STORAGE_PROFILE=sqlite` + cpu=2 in under 60s — verified locally that the proxy reaches `/health=200` in ~3s; needs maintainer Basilica e2e re-run for the full pipeline.
- [x] New regression test: sqlite tempfile + `health_check().await` returns Ok within a short timeout + `query_audit_events(&AuditQuery::new(tenant_id))` returns `Ok([])` on a fresh DB.
- [x] All existing tests still pass.
- [x] Root cause and fix called out above.