### PR TITLE
feat(basilica): seed admin username + password at deployment time

### DIFF
--- a/.github/workflows/tenant-lifecycle.yml
+++ b/.github/workflows/tenant-lifecycle.yml
@@ -50,6 +50,26 @@ on:
         required: false
         type: string
         default: ""
+      admin_username:
+        description: >-
+          Optional display username seeded into the dashboard login form
+          (LLMTRACE_DASHBOARD_ADMIN_USERNAME). The dashboard checks the
+          submitted username matches this case-insensitively before
+          validating the password. Defaults to "admin" when blank.
+        required: false
+        type: string
+        default: ""
+      admin_password:
+        description: >-
+          Optional pinned admin key — becomes both the proxy's
+          LLMTRACE_AUTH_ADMIN_KEY and the dashboard login password.
+          When blank, the lifecycle library auto-generates an
+          `llmt_<64-hex>` key and returns it in the result. Masked in
+          step logs but workflow_dispatch input VALUES are visible in
+          the run UI — use repository_dispatch for production.
+        required: false
+        type: string
+        default: ""
       tenant_secrets_json:
         description: >-
           JSON object of per-tenant secrets to inject as env vars before the
@@ -113,6 +133,8 @@ jobs:
           WF_DASHBOARD_ID: ${{ inputs.dashboard_instance_id }}
           WF_STRATEGY: ${{ inputs.strategy }}
           WF_NEW_ADMIN_KEY: ${{ inputs.new_admin_key }}
+          WF_ADMIN_USERNAME: ${{ inputs.admin_username }}
+          WF_ADMIN_PASSWORD: ${{ inputs.admin_password }}
           WF_SECRETS: ${{ inputs.tenant_secrets_json }}
           RD_PAYLOAD: ${{ toJson(github.event.client_payload) }}
         run: |
@@ -129,6 +151,8 @@ jobs:
               dash_id   = os.environ.get("WF_DASHBOARD_ID", "")
               strategy  = os.environ.get("WF_STRATEGY", "")
               new_admin_key = os.environ.get("WF_NEW_ADMIN_KEY", "")
+              admin_username = os.environ.get("WF_ADMIN_USERNAME", "") or ""
+              admin_password = os.environ.get("WF_ADMIN_PASSWORD", "") or ""
               secrets_json = os.environ.get("WF_SECRETS", "{}") or "{}"
               try:
                   secrets = json.loads(secrets_json)
@@ -146,6 +170,8 @@ jobs:
               dash_id   = payload.get("dashboard_instance_id", "")
               strategy  = payload.get("strategy", "recreate")
               new_admin_key = payload.get("new_admin_key", "") or ""
+              admin_username = payload.get("admin_username", "") or ""
+              admin_password = payload.get("admin_password", "") or ""
               secrets   = payload.get("tenant_secrets", {}) or {}
           else:
               raise SystemExit(f"::error::unsupported event {event!r}")
@@ -158,6 +184,39 @@ jobs:
           # in subsequent log lines.
           if new_admin_key:
               print(f"::add-mask::{new_admin_key}")
+          # Same for the seeded admin password.
+          if admin_password:
+              print(f"::add-mask::{admin_password}")
+
+          # If admin_username / admin_password were supplied as workflow inputs
+          # (the per-tenant ergonomic UX), overlay them onto the resolved
+          # config JSON so the lifecycle library picks them up via the
+          # existing TenantSpec.admin_username / api_key fields. Caller-
+          # supplied values inside config_json still win when both paths set
+          # the same field (caller intent is most explicit there).
+          if (admin_username or admin_password) and (action in ("provision", "update")):
+              base_cfg: dict = {}
+              if cfg_json:
+                  try:
+                      base_cfg = json.loads(cfg_json)
+                  except json.JSONDecodeError as exc:
+                      raise SystemExit(f"::error::config_json is invalid JSON: {exc}")
+              elif cfg_path:
+                  # Read + parse the file so we can overlay the credentials.
+                  text = pathlib.Path(cfg_path).read_text()
+                  try:
+                      import yaml  # type: ignore[import-not-found]
+                      base_cfg = yaml.safe_load(text) or {}
+                  except ImportError:
+                      base_cfg = json.loads(text)
+                  cfg_path = ""  # the overlay supersedes the file
+              if not isinstance(base_cfg, dict):
+                  raise SystemExit("::error::resolved config must be a JSON object")
+              if admin_username and "admin_username" not in base_cfg:
+                  base_cfg["admin_username"] = admin_username
+              if admin_password and "api_key" not in base_cfg:
+                  base_cfg["api_key"] = admin_password
+              cfg_json = json.dumps(base_cfg)
 
           env_path = pathlib.Path(os.environ["GITHUB_ENV"])
           with env_path.open("a") as fh:
@@ -173,7 +232,7 @@ jobs:
                   fh.write(f"CFG_JSON<<__LIFECYCLE_EOF__\n{cfg_json}\n__LIFECYCLE_EOF__\n")
 
           pathlib.Path("/tmp/tenant_secrets.json").write_text(json.dumps(secrets))
-          print(f"resolved: tenant_id={tenant_id} action={action} secret_keys={sorted(secrets.keys())}")
+          print(f"resolved: tenant_id={tenant_id} action={action} secret_keys={sorted(secrets.keys())} admin_creds_supplied={bool(admin_username or admin_password)}")
           PY
 
       - name: Inject tenant secrets
@@ -327,6 +386,11 @@ jobs:
           # admin_key for the platform's own admin pages.
           print(f"api_key={data.get('api_key') or ''}")
           print(f"admin_key={data.get('admin_key') or ''}")
+          # Display username seeded into the dashboard login form. Not
+          # secret on its own — the password (admin_key) is what gates
+          # the dashboard — but emitted so the caller can show "log in
+          # as <username>" in their portal.
+          print(f"admin_username={data.get('admin_username') or ''}")
           PY
           if [[ "${code}" -ne 0 ]]; then
             exit "${code}"

--- a/dashboard/e2e/auth-login.spec.ts
+++ b/dashboard/e2e/auth-login.spec.ts
@@ -54,13 +54,22 @@ test.describe("Admin-key login (issue #250)", () => {
     expect(res.status()).toBe(200);
   });
 
-  test("login page renders the admin-key form", async ({ page }) => {
+  test("login page renders the credentials form", async ({ page }) => {
     await page.goto("/login");
+    await expect(page.getByTestId("login-username")).toBeVisible();
     await expect(page.getByTestId("login-admin-key")).toBeVisible();
     await expect(page.getByTestId("login-submit")).toBeVisible();
   });
 
-  test("login route rejects missing admin_key with 400", async ({ request }) => {
+  test("identity endpoint exposes expected username (default 'admin')", async ({ request }) => {
+    const res = await request.get("/api/auth/identity");
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { username?: string };
+    expect(typeof body.username).toBe("string");
+    expect(body.username!.length).toBeGreaterThan(0);
+  });
+
+  test("login route rejects missing credentials with 400", async ({ request }) => {
     const res = await request.post("/api/auth/login", {
       data: {},
       headers: { "Content-Type": "application/json" },
@@ -68,12 +77,25 @@ test.describe("Admin-key login (issue #250)", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("login route sets host-scoped session cookie on success", async ({ request, baseURL }) => {
-    // The CI proxy accepts any bearer (no admin_key configured), so any
-    // non-empty key will be validated successfully. The point of this test
-    // is to verify the route handler's cookie-set logic with a real upstream.
+  test("login route rejects wrong username with 401", async ({ request }) => {
     const res = await request.post("/api/auth/login", {
-      data: { admin_key: "test-key-for-ci-stack" },
+      data: { username: "definitely-not-the-seeded-user", admin_key: "test-key-for-ci-stack" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test("login route sets host-scoped session cookie on success", async ({ request, baseURL }) => {
+    // Fetch the seeded username via the public identity endpoint so this test
+    // matches whatever the CI stack was provisioned with (defaults to "admin").
+    const identityRes = await request.get("/api/auth/identity");
+    const identity = (await identityRes.json()) as { username: string };
+
+    // The CI proxy accepts any bearer (no admin_key configured), so any
+    // non-empty key will validate successfully. This exercises the real
+    // username check + the real upstream proxy validation + cookie set.
+    const res = await request.post("/api/auth/login", {
+      data: { username: identity.username, admin_key: "test-key-for-ci-stack" },
       headers: { "Content-Type": "application/json" },
     });
     expect(res.status(), `login response: ${await res.text()}`).toBe(200);

--- a/dashboard/src/app/api/auth/identity/route.ts
+++ b/dashboard/src/app/api/auth/identity/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { expectedAdminUsername } from "@/lib/auth";
+
+/**
+ * Returns the expected admin username for this dashboard so the login form
+ * can pre-fill the username field. This is intentionally unauthenticated:
+ * the username is a low-secrecy identifier (the password is the admin key),
+ * and pre-filling avoids a UX trap where the operator types their account's
+ * "alice@acme.example" only to discover the deployment was seeded with
+ * "ops-admin" and a typo gives a generic "invalid credentials" error.
+ */
+export function GET(): NextResponse {
+  return NextResponse.json({ username: expectedAdminUsername() });
+}

--- a/dashboard/src/app/api/auth/login/route.ts
+++ b/dashboard/src/app/api/auth/login/route.ts
@@ -1,23 +1,41 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchWithFallback } from "@/lib/backend";
-import { sessionCookieName, SESSION_TTL_SECONDS } from "@/lib/auth";
+import {
+  sessionCookieName,
+  SESSION_TTL_SECONDS,
+  expectedAdminUsername,
+  usernameMatches,
+} from "@/lib/auth";
 
 interface LoginBody {
+  username?: string;
   admin_key?: string;
 }
 
-async function readAdminKey(req: NextRequest): Promise<string | null> {
+interface SubmittedCredentials {
+  username: string | null;
+  adminKey: string | null;
+}
+
+async function readCredentials(req: NextRequest): Promise<SubmittedCredentials> {
   const ct = req.headers.get("content-type") ?? "";
   if (ct.includes("application/json")) {
     const body = (await req.json().catch(() => null)) as LoginBody | null;
-    return body?.admin_key?.trim() || null;
+    return {
+      username: body?.username?.trim() || null,
+      adminKey: body?.admin_key?.trim() || null,
+    };
   }
   if (ct.includes("application/x-www-form-urlencoded") || ct.includes("multipart/form-data")) {
     const form = await req.formData();
-    const v = form.get("admin_key");
-    return typeof v === "string" ? v.trim() || null : null;
+    const u = form.get("username");
+    const k = form.get("admin_key");
+    return {
+      username: typeof u === "string" && u.trim() ? u.trim() : null,
+      adminKey: typeof k === "string" && k.trim() ? k.trim() : null,
+    };
   }
-  return null;
+  return { username: null, adminKey: null };
 }
 
 async function validateAdminKey(adminKey: string): Promise<boolean> {
@@ -35,9 +53,18 @@ function isSecure(req: NextRequest): boolean {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const adminKey = await readAdminKey(req);
-  if (!adminKey) {
-    return NextResponse.json({ error: "admin_key is required" }, { status: 400 });
+  const { username, adminKey } = await readCredentials(req);
+  if (!username || !adminKey) {
+    return NextResponse.json(
+      { error: "username and admin_key are required" },
+      { status: 400 },
+    );
+  }
+
+  // Username check first (fast, no upstream call). On mismatch return the
+  // same 401 shape as a bad key so we don't leak which half was wrong.
+  if (!usernameMatches(username, expectedAdminUsername())) {
+    return NextResponse.json({ error: "invalid credentials" }, { status: 401 });
   }
 
   let valid = false;
@@ -49,7 +76,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   if (!valid) {
-    return NextResponse.json({ error: "invalid admin key" }, { status: 401 });
+    return NextResponse.json({ error: "invalid credentials" }, { status: 401 });
   }
 
   const res = NextResponse.json({ ok: true });

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, type FormEvent } from "react";
+import { Suspense, useEffect, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Shield } from "lucide-react";
 
@@ -8,14 +8,37 @@ function LoginForm(): React.ReactElement {
   const router = useRouter();
   const search = useSearchParams();
   const next = search.get("next") || "/";
+  const [username, setUsername] = useState("");
   const [adminKey, setAdminKey] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
+  // Pre-fill the username field with the seeded value so operators don't
+  // have to guess. Username is a low-secrecy identifier (the admin key is
+  // the real secret), so exposing it via /api/auth/identity is acceptable
+  // and avoids friction. Field stays editable in case the operator wants
+  // to confirm by typing.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/auth/identity", { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body: { username?: string } | null) => {
+        if (cancelled || !body?.username) return;
+        setUsername(body.username);
+      })
+      .catch(() => {
+        // Identity hint is non-critical; on failure the operator just types
+        // the username manually.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   async function onSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
-    if (!adminKey) {
-      setError("Admin key is required");
+    if (!username || !adminKey) {
+      setError("Username and admin key are required");
       return;
     }
     setError(null);
@@ -24,7 +47,7 @@ function LoginForm(): React.ReactElement {
       const res = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ admin_key: adminKey }),
+        body: JSON.stringify({ username, admin_key: adminKey }),
       });
       if (res.ok) {
         router.replace(next);
@@ -48,7 +71,25 @@ function LoginForm(): React.ReactElement {
       <div className="flex flex-col items-center gap-2">
         <Shield className="h-8 w-8 text-primary" />
         <h1 className="text-xl font-semibold">LLMTrace Dashboard</h1>
-        <p className="text-sm text-muted-foreground">Sign in with your admin key</p>
+        <p className="text-sm text-muted-foreground">
+          Sign in with the credentials seeded at deployment time
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="username" className="text-sm font-medium">
+          Username
+        </label>
+        <input
+          id="username"
+          name="username"
+          type="text"
+          autoComplete="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          data-testid="login-username"
+        />
       </div>
 
       <div className="space-y-2">

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -35,3 +35,34 @@ export function sessionCookieName(host: string | null | undefined): string {
 
 /** Session cookie lifetime in seconds (24h). */
 export const SESSION_TTL_SECONDS = 24 * 60 * 60;
+
+const DEFAULT_ADMIN_USERNAME = "admin";
+
+/**
+ * Expected admin username for this dashboard, seeded at provision time via
+ * `LLMTRACE_DASHBOARD_ADMIN_USERNAME` (set by
+ * `deployments/basilica/lifecycle.py::_apply_dashboard_admin_username`).
+ * Defaults to "admin" when unset so local dev needs no extra setup.
+ */
+export function expectedAdminUsername(): string {
+  const raw = process.env.LLMTRACE_DASHBOARD_ADMIN_USERNAME;
+  if (typeof raw !== "string") return DEFAULT_ADMIN_USERNAME;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : DEFAULT_ADMIN_USERNAME;
+}
+
+/**
+ * Constant-time-ish username comparison (case-insensitive). Used by the
+ * login route so per-character early-exit timing cannot leak which prefix
+ * matched.
+ */
+export function usernameMatches(submitted: string, expected: string): boolean {
+  const a = submitted.trim().toLowerCase();
+  const b = expected.trim().toLowerCase();
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -362,13 +362,72 @@ The CLI emits both in the result JSON:
   "proxy_url": "https://...basilica.ai",
   "dashboard_url": "https://...basilica.ai",
   "api_key": "llmt_op...",
-  "admin_key": "llmt_ad..."
+  "admin_key": "llmt_ad...",
+  "admin_username": "admin"
 }
 ```
 
 The workflow registers `::add-mask::` for BOTH keys before any `cat`
 operation, so neither appears in run logs — only in step outputs (which
 the calling app fetches via the Actions API).
+
+### Seeding dashboard credentials at provision time
+
+The dashboard now requires a sign-in. The login form takes two fields:
+
+| Field | Source | Notes |
+|---|---|---|
+| Username | `LLMTRACE_DASHBOARD_ADMIN_USERNAME` env on the dashboard pod (set by `_apply_dashboard_admin_username`). Defaults to `"admin"`. | Pre-filled from the public `/api/auth/identity` endpoint as a UX nicety. Case-insensitive match. |
+| Admin key | The `admin_key` returned from `provision()` (either auto-generated or pinned). | The actual secret; validated against the proxy's admin endpoint on each login. |
+
+To seed both at provision time, supply them on either dispatch path:
+
+**workflow_dispatch** — two new inputs (`admin_username`, `admin_password`)
+overlay onto the resolved config_json. `admin_password` is automatically
+masked in step logs:
+
+```bash
+gh workflow run tenant-lifecycle.yml -R techlab-innov/llmtrace \
+  -f tenant_id=acme \
+  -f action=provision \
+  -f config_path=deployments/basilica/configs/examples/pro.yaml \
+  -f admin_username="ops@acme.example" \
+  -f admin_password="llmt_<64-hex-of-your-choosing>"
+```
+
+**repository_dispatch** — same two fields inside `client_payload`:
+
+```json
+{
+  "event_type": "tenant-lifecycle",
+  "client_payload": {
+    "tenant_id": "acme",
+    "action": "provision",
+    "config_path": "deployments/basilica/configs/examples/pro.yaml",
+    "admin_username": "ops@acme.example",
+    "admin_password": "llmt_<64-hex-of-your-choosing>"
+  }
+}
+```
+
+**Direct library use** — set the same fields on `TenantSpec`:
+
+```python
+spec = TenantSpec(
+    tenant_id="acme",
+    proxy=...,
+    dashboard=...,
+    admin_username="ops@acme.example",
+    api_key="llmt_<64-hex-of-your-choosing>",  # becomes the dashboard password
+)
+```
+
+If `admin_username` is omitted, the default `"admin"` is used. If `api_key`
+(or `admin_password`) is omitted, the lifecycle library auto-generates an
+`llmt_<64-hex>` key and returns it in the result.
+
+The CLI subcommand's stdout always carries `admin_username` so a calling
+app can render "log in as `<username>`" instructions in its own portal.
 
 ### Tenant-side usage
 

--- a/deployments/basilica/cli.py
+++ b/deployments/basilica/cli.py
@@ -143,6 +143,7 @@ def _tenant_spec_from_config(tenant_id: str, cfg: dict[str, Any]) -> lifecycle.T
         "enable_proxy_auth",
         "api_key",
         "rotate_admin_after_bootstrap",
+        "admin_username",
     ):
         if key in cfg:
             kwargs[key] = cfg[key]
@@ -170,6 +171,7 @@ def _serialise(instances: lifecycle.TenantInstances) -> dict[str, Any]:
         "dashboard_url": instances.dashboard.url if instances.dashboard else None,
         "api_key": instances.api_key,
         "admin_key": instances.admin_key,
+        "admin_username": instances.admin_username,
     }
 
 

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -62,3 +62,8 @@ dashboard:
 # Rotate the admin key once the proxy is up. Adds ~30s and changes the
 # proxy instance_id + url; recommended for production. Opt-in.
 # rotate_admin_after_bootstrap: true
+
+# Dashboard login: the operator signs in with admin_username + the admin
+# key (pinned via `api_key:` above or auto-generated). Default is "admin";
+# override per tenant for a custom display identity.
+# admin_username: "ops@acme.example"

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -84,6 +84,11 @@ dashboard:
 # enable_proxy_auth: true
 # api_key: null
 
+# Dashboard login: the operator signs in to the dashboard with the
+# admin_username below + the admin key (api_key above, or auto-generated).
+# Default username is "admin"; override for a custom seeded identity:
+# admin_username: "alice@acme.example"
+
 # Optional per-tenant rate limit. When uncommented, the lifecycle library
 # injects `LLMTRACE_RATE_LIMIT_RPS` and `LLMTRACE_RATE_LIMIT_BURST` into the
 # proxy env at provision time. Both must be strictly positive. Omit the

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -173,6 +173,13 @@ class TenantSpec:
     # Trade-off: adds one proxy re-roll (~30s) to provisioning. Opt-in
     # because most callers will not need it.
     rotate_admin_after_bootstrap: bool = False
+    # Display username for the dashboard login form. The dashboard's
+    # `/api/auth/login` route checks the submitted username matches
+    # `LLMTRACE_DASHBOARD_ADMIN_USERNAME` (case-insensitive) AND that the
+    # submitted password validates against the proxy as an admin key.
+    # Defaults to "admin"; override at provision time to seed a custom
+    # operator-visible identity ("alice@acme.example" etc.).
+    admin_username: str = "admin"
 
 
 @dataclass(frozen=True)
@@ -218,6 +225,10 @@ class TenantInstances:
     dashboard: Optional[InstanceInfo]
     api_key: Optional[str] = None
     admin_key: Optional[str] = None
+    # Display username seeded into the dashboard's login form (server-side
+    # checked against `LLMTRACE_DASHBOARD_ADMIN_USERNAME`). Defaults to
+    # "admin"; set per-tenant via `TenantSpec.admin_username`.
+    admin_username: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -474,6 +485,21 @@ def _apply_ml_preload_startup_floor(
         floor,
     )
     return dataclasses.replace(spec, startup_timeout_seconds=floor)
+
+
+def _apply_dashboard_admin_username(
+    dashboard_spec: ComponentSpec, username: str
+) -> ComponentSpec:
+    """Inject `LLMTRACE_DASHBOARD_ADMIN_USERNAME` into the dashboard env.
+
+    The dashboard's `/api/auth/login` route reads this env at request time
+    and requires the submitted username to match (case-insensitive) before
+    it even attempts to validate the password against the proxy. Caller-
+    supplied env entries with the same key are overwritten — `TenantSpec`
+    is the source of truth.
+    """
+    env = {**dashboard_spec.env, "LLMTRACE_DASHBOARD_ADMIN_USERNAME": username}
+    return dataclasses.replace(dashboard_spec, env=env)
 
 
 def _apply_rate_limit(
@@ -783,6 +809,10 @@ def provision(
         tenant_uuid = _bootstrap_tenant_in_proxy(proxy.url, admin_key, tenant_id)
         operator_key = _mint_operator_key(proxy.url, admin_key, tenant_uuid)
 
+    dashboard_spec = _apply_dashboard_admin_username(
+        dashboard_spec, spec.admin_username
+    )
+
     if spec.inject_proxy_url_into_dashboard:
         merged_env = {**dashboard_spec.env, spec.proxy_url_env_var: proxy.url}
         dashboard_spec = dataclasses.replace(dashboard_spec, env=merged_env)
@@ -794,6 +824,7 @@ def provision(
         dashboard=dashboard,
         api_key=operator_key,
         admin_key=admin_key,
+        admin_username=spec.admin_username,
     )
 
 
@@ -891,6 +922,7 @@ def update(
             dashboard=dashboard,
             api_key=operator_key,
             admin_key=admin_key,
+            admin_username=spec.admin_username,
         )
 
     if strategy != "recreate":

--- a/deployments/basilica/tests/test_admin_username_seeding.py
+++ b/deployments/basilica/tests/test_admin_username_seeding.py
@@ -1,0 +1,170 @@
+"""Tests for the admin-credential seeding feature.
+
+Verifies that:
+- `TenantSpec.admin_username` defaults to `"admin"` and is propagated to the
+  dashboard env as `LLMTRACE_DASHBOARD_ADMIN_USERNAME`.
+- A caller-supplied `admin_username` overrides the default.
+- The same value flows through to `TenantInstances.admin_username` and the
+  CLI's serialised result JSON.
+- `_apply_dashboard_admin_username` overwrites a caller-supplied env entry
+  with the same key (TenantSpec is the source of truth).
+
+These tests exercise the real lifecycle code paths against a fake Basilica
+SDK + the existing fake-proxy fixture. No production logic is stubbed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from deployments.basilica import cli, lifecycle
+
+# Re-use the helpers from the existing test module.
+from deployments.basilica.tests.test_operator_key_minting import (  # type: ignore[import-not-found]
+    ADMIN_KEY,
+    OPERATOR_KEY,
+    _FakeBasilicaClient,
+    _key_create_payload,
+    _make_dashboard_spec,
+    _tenant_create_payload,
+)
+
+
+def _proxy_spec() -> lifecycle.ComponentSpec:
+    return lifecycle.ComponentSpec(
+        image="ghcr.io/example/proxy:latest",
+        port=8080,
+        cpu="1",
+        memory="1Gi",
+        replicas=1,
+        env={"LLMTRACE_UPSTREAM_URL": "https://upstream.example"},
+    )
+
+
+def test_apply_dashboard_admin_username_injects_env_var() -> None:
+    base = lifecycle.ComponentSpec(
+        image="i", port=3000, cpu="1", memory="1Gi", replicas=1,
+        env={"HOSTNAME": "0.0.0.0"},
+    )
+    result = lifecycle._apply_dashboard_admin_username(base, "alice@acme.example")
+    assert result.env["LLMTRACE_DASHBOARD_ADMIN_USERNAME"] == "alice@acme.example"
+    assert result.env["HOSTNAME"] == "0.0.0.0", "unrelated env entries preserved"
+    assert base.env.get("LLMTRACE_DASHBOARD_ADMIN_USERNAME") is None, "input spec unchanged"
+
+
+def test_apply_dashboard_admin_username_overrides_caller_env() -> None:
+    base = lifecycle.ComponentSpec(
+        image="i", port=3000, cpu="1", memory="1Gi", replicas=1,
+        env={"LLMTRACE_DASHBOARD_ADMIN_USERNAME": "stale"},
+    )
+    result = lifecycle._apply_dashboard_admin_username(base, "fresh")
+    assert result.env["LLMTRACE_DASHBOARD_ADMIN_USERNAME"] == "fresh"
+
+
+def test_tenant_spec_admin_username_defaults_to_admin() -> None:
+    spec = lifecycle.TenantSpec(
+        tenant_id="t",
+        proxy=_proxy_spec(),
+        dashboard=_make_dashboard_spec(),
+    )
+    assert spec.admin_username == "admin"
+
+
+def test_provision_seeds_default_admin_username(fake_proxy: Any) -> None:
+    def responder(method: str, path: str, headers: dict[str, str], body: bytes) -> tuple[int, dict[str, Any]]:
+        if method == "POST" and path == "/api/v1/tenants":
+            return 201, _tenant_create_payload()
+        if method == "POST" and path == "/api/v1/auth/keys":
+            return 201, _key_create_payload()
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    proxy = fake_proxy(responder)
+    fake_client = _FakeBasilicaClient(
+        proxy_url=proxy.url, dashboard_url="https://dashboard.example"
+    )
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_make_dashboard_spec(),
+        api_key=ADMIN_KEY,
+    )
+    result = lifecycle.provision(spec, client=fake_client)
+
+    assert result.admin_username == "admin"
+    dash_create = next(c for c in fake_client.creates if "dashboard" in c["instance_name"])
+    assert dash_create["env"]["LLMTRACE_DASHBOARD_ADMIN_USERNAME"] == "admin"
+
+
+def test_provision_seeds_custom_admin_username(fake_proxy: Any) -> None:
+    def responder(method: str, path: str, headers: dict[str, str], body: bytes) -> tuple[int, dict[str, Any]]:
+        if method == "POST" and path == "/api/v1/tenants":
+            return 201, _tenant_create_payload()
+        if method == "POST" and path == "/api/v1/auth/keys":
+            return 201, _key_create_payload()
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    proxy = fake_proxy(responder)
+    fake_client = _FakeBasilicaClient(
+        proxy_url=proxy.url, dashboard_url="https://dashboard.example"
+    )
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_make_dashboard_spec(),
+        api_key=ADMIN_KEY,
+        admin_username="ops@acme.example",
+    )
+    result = lifecycle.provision(spec, client=fake_client)
+
+    assert result.admin_username == "ops@acme.example"
+    dash_create = next(c for c in fake_client.creates if "dashboard" in c["instance_name"])
+    assert dash_create["env"]["LLMTRACE_DASHBOARD_ADMIN_USERNAME"] == "ops@acme.example"
+    # Operator + admin keys still flow through unchanged.
+    assert result.api_key == OPERATOR_KEY
+    assert result.admin_key == ADMIN_KEY
+
+
+def test_cli_serialise_emits_admin_username() -> None:
+    inst = lifecycle.TenantInstances(
+        tenant_id="t",
+        proxy=lifecycle.InstanceInfo(
+            instance_id="p", state="Active", url="https://p.example",
+            ready_replicas=1, desired_replicas=1,
+        ),
+        dashboard=lifecycle.InstanceInfo(
+            instance_id="d", state="Active", url="https://d.example",
+            ready_replicas=1, desired_replicas=1,
+        ),
+        api_key=OPERATOR_KEY,
+        admin_key=ADMIN_KEY,
+        admin_username="ops@acme.example",
+    )
+    payload = cli._serialise(inst)
+    assert payload["admin_username"] == "ops@acme.example"
+
+
+def test_cli_serialise_admin_username_defaults_none_when_unset() -> None:
+    inst = lifecycle.TenantInstances(
+        tenant_id="t", proxy=None, dashboard=None,
+    )
+    payload = cli._serialise(inst)
+    assert payload["admin_username"] is None
+
+
+def test_cli_loads_admin_username_from_config() -> None:
+    cfg = {
+        "proxy": {
+            "image": "i", "port": 8080, "cpu": "1", "memory": "1Gi",
+            "replicas": 1, "env": {},
+        },
+        "dashboard": {
+            "image": "i", "port": 3000, "cpu": "1", "memory": "1Gi",
+            "replicas": 1, "env": {},
+        },
+        "admin_username": "alice@acme.example",
+    }
+    spec = cli._tenant_spec_from_config("t", cfg)
+    assert spec.admin_username == "alice@acme.example"


### PR DESCRIPTION
## Summary

Adds a workflow-level escape hatch for tenants who want to know their dashboard credentials before they ship and don't want to chase an auto-generated key through the result JSON. Both `admin_username` and `admin_password` are now first-class deployment inputs that:

- flow through `TenantSpec` → dashboard env (`LLMTRACE_DASHBOARD_ADMIN_USERNAME`) and proxy admin key (`api_key`),
- get masked on the workflow log surface (`admin_password` only — username is a low-secrecy identifier),
- are returned in the result JSON / step outputs for the calling app's portal.

The dashboard's `/login` page picks up the username via a new public `/api/auth/identity` endpoint so operators don't have to guess what their deployment was seeded with. The password validation still hits the live proxy's admin endpoint — no plaintext comparison in the dashboard process.

Implements the user's request: "edit the deployment script so that I can seed the initial admin credentials as well when the deployment is initiated. the UI will have the first admin credentials with the ones that's seeded with."

## Per-file changes

### Lifecycle library
- `deployments/basilica/lifecycle.py`
  - `TenantSpec.admin_username: str = "admin"` (new field, defaults preserve old behaviour).
  - `TenantInstances.admin_username: Optional[str]` carries the resolved value back.
  - `_apply_dashboard_admin_username()` helper injects `LLMTRACE_DASHBOARD_ADMIN_USERNAME` into the dashboard env. Same precedence model as `_apply_proxy_auth` — spec wins over caller env on collision.
  - `provision()` calls the helper just before `_create_component(dashboard)`.
  - `update(strategy="restart")` also propagates the username so re-rolls keep the seeded identity.

- `deployments/basilica/cli.py`
  - `_tenant_spec_from_config` accepts `admin_username` in YAML/JSON.
  - `_serialise` emits `admin_username` alongside `api_key` / `admin_key`.

### Workflow
- `.github/workflows/tenant-lifecycle.yml`
  - Two new `workflow_dispatch` inputs: `admin_username` and `admin_password`. Same fields also accepted in `repository_dispatch.client_payload`.
  - `admin_password` is `::add-mask::`-ed at resolution time.
  - When either is supplied AND `action ∈ {provision, update}`, the resolve-inputs step overlays them onto the resolved config (`admin_password → api_key`, `admin_username → admin_username`). Explicit values in `config_json` still win, so callers can mix and match.
  - Step output gains `admin_username`.

### Dashboard
- `dashboard/src/lib/auth.ts`
  - `expectedAdminUsername()` reads `LLMTRACE_DASHBOARD_ADMIN_USERNAME`, defaults to `"admin"`.
  - `usernameMatches()` does a case-insensitive constant-time-ish comparison so per-character timing can't leak which prefix matched.

- `dashboard/src/app/api/auth/identity/route.ts` (new) — public `GET /api/auth/identity` returns `{username}`. Username is a low-secrecy identifier (the admin key is the actual secret), so exposing it avoids a UX trap where the operator types `alice@acme.example` only to discover the deployment was seeded with `ops-admin` and the generic "invalid credentials" error gives no hint.

- `dashboard/src/app/api/auth/login/route.ts` — now requires `{username, admin_key}`. Username checked against `expectedAdminUsername()` first (no upstream call); on mismatch returns the same generic 401 as a bad password. Cookie payload unchanged (still the admin key).

- `dashboard/src/app/login/page.tsx` — username field added, pre-filled from `/api/auth/identity` on mount.

### Examples + docs
- `starter.yaml` / `pro.yaml` document `admin_username` with a placeholder.
- `README.md` "Per-tenant API key auth" section gains a "Seeding dashboard credentials at provision time" subsection with `workflow_dispatch`, `repository_dispatch`, and direct-library examples.

### Tests
- `dashboard/e2e/auth-login.spec.ts` — extended for the username field, identity endpoint, wrong-username 401, and success path uses the identity endpoint to discover the seeded username.
- `deployments/basilica/tests/test_admin_username_seeding.py` (new) — 7 tests covering the helper, default, custom seed, dashboard env injection, CLI serialisation, CLI config loading. Real lifecycle code paths against a fake Basilica SDK; no production stubs.

## Validation evidence

- `python3 -m py_compile deployments/basilica/{lifecycle,cli}.py deployments/basilica/tests/test_admin_username_seeding.py` — clean.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tenant-lifecycle.yml'))"` — clean.

## What is NOT live-validated from this PR

- The dashboard `/login` page rendering with the new username field on a real Basilica deployment (requires the published image to roll out first). Per saved feedback, the maintainer will run a live e2e after merge — that's the next step in the chain anyway (re-provisioning the review tenant with seeded creds).

## Out of scope

- Multi-user RBAC. This is one tenant, one shared admin credential — same as the model PR #250 shipped.
- Password complexity / rotation policy. The existing `rotate-admin-key` workflow action covers rotation; complexity is a caller concern.