### PR TITLE
feat(workflow): promote upstream URL + API key to first-class inputs (closes #261)

### DIFF
--- a/.github/workflows/tenant-lifecycle.yml
+++ b/.github/workflows/tenant-lifecycle.yml
@@ -70,6 +70,28 @@ on:
         required: false
         type: string
         default: ""
+      upstream_url:
+        description: >-
+          Upstream LLM provider base URL the proxy forwards `/v1/*`
+          traffic to (e.g. `https://api.openai.com`,
+          `https://api.anthropic.com`, a self-hosted vLLM endpoint).
+          Becomes `LLMTRACE_UPSTREAM_URL` at runtime. Per-tenant
+          override of the repo's `LLMTRACE_UPSTREAM_URL` secret.
+          Entries in `tenant_secrets_json` still win if both set
+          the same key.
+        required: false
+        type: string
+        default: ""
+      upstream_api_key:
+        description: >-
+          Upstream LLM provider API key (e.g. an OpenAI `sk-...`).
+          Becomes `OPENAI_API_KEY` at runtime. Masked in step logs.
+          Per-tenant override of the repo's `OPENAI_API_KEY` secret.
+          Entries in `tenant_secrets_json` still win if both set the
+          same key.
+        required: false
+        type: string
+        default: ""
       tenant_secrets_json:
         description: >-
           JSON object of per-tenant secrets to inject as env vars before the
@@ -135,6 +157,8 @@ jobs:
           WF_NEW_ADMIN_KEY: ${{ inputs.new_admin_key }}
           WF_ADMIN_USERNAME: ${{ inputs.admin_username }}
           WF_ADMIN_PASSWORD: ${{ inputs.admin_password }}
+          WF_UPSTREAM_URL: ${{ inputs.upstream_url }}
+          WF_UPSTREAM_API_KEY: ${{ inputs.upstream_api_key }}
           WF_SECRETS: ${{ inputs.tenant_secrets_json }}
           RD_PAYLOAD: ${{ toJson(github.event.client_payload) }}
         run: |
@@ -153,6 +177,8 @@ jobs:
               new_admin_key = os.environ.get("WF_NEW_ADMIN_KEY", "")
               admin_username = os.environ.get("WF_ADMIN_USERNAME", "") or ""
               admin_password = os.environ.get("WF_ADMIN_PASSWORD", "") or ""
+              upstream_url = os.environ.get("WF_UPSTREAM_URL", "") or ""
+              upstream_api_key = os.environ.get("WF_UPSTREAM_API_KEY", "") or ""
               secrets_json = os.environ.get("WF_SECRETS", "{}") or "{}"
               try:
                   secrets = json.loads(secrets_json)
@@ -172,6 +198,8 @@ jobs:
               new_admin_key = payload.get("new_admin_key", "") or ""
               admin_username = payload.get("admin_username", "") or ""
               admin_password = payload.get("admin_password", "") or ""
+              upstream_url = payload.get("upstream_url", "") or ""
+              upstream_api_key = payload.get("upstream_api_key", "") or ""
               secrets   = payload.get("tenant_secrets", {}) or {}
           else:
               raise SystemExit(f"::error::unsupported event {event!r}")
@@ -187,6 +215,9 @@ jobs:
           # Same for the seeded admin password.
           if admin_password:
               print(f"::add-mask::{admin_password}")
+          # Same for the upstream provider API key.
+          if upstream_api_key:
+              print(f"::add-mask::{upstream_api_key}")
 
           # If admin_username / admin_password were supplied as workflow inputs
           # (the per-tenant ergonomic UX), overlay them onto the resolved
@@ -231,8 +262,18 @@ jobs:
               if cfg_json:
                   fh.write(f"CFG_JSON<<__LIFECYCLE_EOF__\n{cfg_json}\n__LIFECYCLE_EOF__\n")
 
+          # Overlay the dedicated upstream-provider inputs onto the secrets
+          # dict so the existing `Inject tenant secrets` step picks them up
+          # via the same proven masking + heredoc path. Caller-supplied
+          # entries in `tenant_secrets_json` / `client_payload.tenant_secrets`
+          # take precedence when both paths set the same key.
+          if upstream_url and "LLMTRACE_UPSTREAM_URL" not in secrets:
+              secrets["LLMTRACE_UPSTREAM_URL"] = upstream_url
+          if upstream_api_key and "OPENAI_API_KEY" not in secrets:
+              secrets["OPENAI_API_KEY"] = upstream_api_key
+
           pathlib.Path("/tmp/tenant_secrets.json").write_text(json.dumps(secrets))
-          print(f"resolved: tenant_id={tenant_id} action={action} secret_keys={sorted(secrets.keys())} admin_creds_supplied={bool(admin_username or admin_password)}")
+          print(f"resolved: tenant_id={tenant_id} action={action} secret_keys={sorted(secrets.keys())} admin_creds_supplied={bool(admin_username or admin_password)} upstream_url={upstream_url!r}")
           PY
 
       - name: Inject tenant secrets

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -601,6 +601,88 @@ By the time the CLI runs, every `${VAR}` reference in the tenant config
 resolves against the merged env (platform defaults overridden by
 tenant-supplied values).
 
+### Per-tenant upstream provider
+
+The two most common per-tenant overrides — which upstream LLM provider the
+proxy forwards `/v1/*` traffic to, and the bearer token used to call it —
+are first-class workflow inputs alongside `admin_username` /
+`admin_password`. They map onto the existing env-var substitution path,
+so the tenant YAML keeps using `${LLMTRACE_UPSTREAM_URL}` and
+`${OPENAI_API_KEY}` exactly as before.
+
+| Input | Becomes env var | Purpose |
+|---|---|---|
+| `upstream_url` | `LLMTRACE_UPSTREAM_URL` | Base URL the proxy forwards to (`https://api.openai.com`, `https://api.anthropic.com`, a vLLM endpoint, etc.) |
+| `upstream_api_key` | `OPENAI_API_KEY` | Bearer for the upstream provider. Masked in step logs at resolution time. |
+
+Precedence (most-explicit wins):
+
+1. Caller-supplied entries inside `tenant_secrets_json` (or
+   `client_payload.tenant_secrets`) under the same key still win — those are
+   the most-explicit form and the new inputs do not clobber them.
+2. The dedicated `upstream_url` / `upstream_api_key` workflow inputs.
+3. The repo-level `LLMTRACE_UPSTREAM_URL` / `OPENAI_API_KEY` secrets (job-
+   level `env:` defaults).
+
+#### Example: OpenAI
+
+```bash
+gh workflow run tenant-lifecycle.yml -R techlab-innov/llmtrace \
+  -f tenant_id=acme \
+  -f action=provision \
+  -f config_path=deployments/basilica/configs/examples/pro.yaml \
+  -f upstream_url="https://api.openai.com" \
+  -f upstream_api_key="sk-..."
+```
+
+#### Example: Anthropic
+
+```bash
+gh workflow run tenant-lifecycle.yml -R techlab-innov/llmtrace \
+  -f tenant_id=acme \
+  -f action=provision \
+  -f config_path=deployments/basilica/configs/examples/pro.yaml \
+  -f upstream_url="https://api.anthropic.com" \
+  -f upstream_api_key="sk-ant-..."
+```
+
+Note: Anthropic uses `x-api-key` server-side rather than
+`Authorization: Bearer`. The proxy forwards client headers transparently,
+so the `upstream_api_key` value lands in `OPENAI_API_KEY` for the proxy's
+internal use; Anthropic-specific routing is tracked separately (see the
+Provider examples section below).
+
+#### Example: self-hosted vLLM
+
+```bash
+gh workflow run tenant-lifecycle.yml -R techlab-innov/llmtrace \
+  -f tenant_id=acme \
+  -f action=provision \
+  -f config_path=deployments/basilica/configs/examples/pro.yaml \
+  -f upstream_url="https://vllm.internal.example/v1" \
+  -f upstream_api_key="dummy-or-real-token"
+```
+
+`repository_dispatch` accepts the same two keys inside `client_payload`:
+
+```json
+{
+  "event_type": "tenant-lifecycle",
+  "client_payload": {
+    "tenant_id": "acme",
+    "action": "provision",
+    "config_path": "deployments/basilica/configs/examples/pro.yaml",
+    "upstream_url": "https://api.openai.com",
+    "upstream_api_key": "sk-..."
+  }
+}
+```
+
+If you need to override an env-var name the dedicated inputs do not cover
+(e.g. `ANTHROPIC_API_KEY`, a custom header secret), keep using
+`tenant_secrets_json` / `client_payload.tenant_secrets` — those entries
+also remain authoritative when both paths set the same key.
+
 ### Security caveats
 
 - `workflow_dispatch` input *values* are stored in the run's metadata. The


### PR DESCRIPTION
## Summary

Adds two new dispatch inputs to `tenant-lifecycle.yml` so a tenant's upstream LLM provider URL and API key no longer have to be hidden inside the generic `tenant_secrets_json` blob. Mirrors the dual-input pattern shipped in #256 for `admin_username` / `admin_password`.

- `upstream_url` (optional string) -> populates `LLMTRACE_UPSTREAM_URL` env at runtime.
- `upstream_api_key` (optional string) -> populates `OPENAI_API_KEY` env at runtime. Masked via `::add-mask::` immediately on resolution.

Both inputs are wired through `workflow_dispatch.inputs` AND `repository_dispatch.client_payload` (same key names). The Python "Resolve inputs" block overlays them onto the `secrets` dict before `/tmp/tenant_secrets.json` is written, so the existing proven `Inject tenant secrets` step picks them up via the same heredoc + masking path.

### Precedence (most-explicit wins)

1. Caller-supplied entries inside `tenant_secrets_json` / `client_payload.tenant_secrets` under the same key.
2. The new dedicated `upstream_url` / `upstream_api_key` inputs.
3. Repo-level `LLMTRACE_UPSTREAM_URL` / `OPENAI_API_KEY` secrets (job-level `env:` defaults).

## Per-file changes

- `.github/workflows/tenant-lifecycle.yml`
  - Two new `workflow_dispatch.inputs` entries (`upstream_url`, `upstream_api_key`) with descriptions covering the runtime mapping and precedence.
  - Two new `WF_*` env passthroughs into the Resolve step.
  - Both inputs read from `workflow_dispatch` env AND `repository_dispatch` client_payload.
  - `::add-mask::` on `upstream_api_key` registered at resolution time (same position as `admin_password`).
  - Overlay block writes the two values into `secrets` before `/tmp/tenant_secrets.json` is serialised, with `if key not in secrets` guard so caller entries keep winning.
  - Resolved-log line now also surfaces `upstream_url` for visibility on the run page (api key remains masked).

- `deployments/basilica/README.md`
  - New "Per-tenant upstream provider" subsection inside the existing "Per-tenant secret injection" section.
  - Precedence table + three concrete dispatch examples (OpenAI, Anthropic, self-hosted vLLM).
  - `repository_dispatch` payload example with `client_payload.upstream_url` / `client_payload.upstream_api_key`.
  - Pointer back to `tenant_secrets_json` for provider envs the dedicated inputs do not cover (e.g. `ANTHROPIC_API_KEY`).

## Validation evidence

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tenant-lifecycle.yml')); print('workflow YAML OK')"` -> `workflow YAML OK`.
- `py_compile` of all three embedded Python heredocs in the workflow -> OK (0 errors).
- Standalone overlay-logic smoke test (Python REPL) covering: only inputs set, caller-wins for both keys, partial caller override, empty case -> all 4 cases assert OK.

## What is NOT live-validated

- The new inputs are validated by YAML parse + by-eye reading + isolated Python overlay smoke tests. Live dispatch against Basilica (`gh workflow run tenant-lifecycle.yml -f upstream_url=... -f upstream_api_key=...` followed by a `/v1/chat/completions` round-trip) will be exercised by the maintainer's e2e re-deploy after merge. The workflow file cannot be dispatched from a feature branch without `workflow_dispatch` definition on `main`, and the API-key plumbing needs a real Basilica deployment to verify end-to-end.

## Out of scope

- Provider-aware multi-key routing (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, etc.). The proxy already discriminates server-side; `ANTHROPIC_API_KEY` remains accessible through `tenant_secrets_json`.
- Modifying tenant config YAMLs — they already use `${LLMTRACE_UPSTREAM_URL}` / `${OPENAI_API_KEY}` substitution, which is exactly the env-var path the new inputs feed into.

Closes #261.