### PR TITLE
docs(dashboard): clarify admin_username accepts email or username (closes #260)

### DIFF
--- a/.github/workflows/tenant-lifecycle.yml
+++ b/.github/workflows/tenant-lifecycle.yml
@@ -52,10 +52,9 @@ on:
         default: ""
       admin_username:
         description: >-
-          Optional display username seeded into the dashboard login form
-          (LLMTRACE_DASHBOARD_ADMIN_USERNAME). The dashboard checks the
-          submitted username matches this case-insensitively before
-          validating the password. Defaults to "admin" when blank.
+          Display username (or email) seeded into the dashboard login form.
+          Free string — no validation. The app decides which identifier
+          shape to use.
         required: false
         type: string
         default: ""

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -13,11 +13,13 @@ function LoginForm(): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
-  // Pre-fill the username field with the seeded value so operators don't
-  // have to guess. Username is a low-secrecy identifier (the admin key is
-  // the real secret), so exposing it via /api/auth/identity is acceptable
-  // and avoids friction. Field stays editable in case the operator wants
-  // to confirm by typing.
+  // Pre-fill the identifier field with the seeded value so operators don't
+  // have to guess. The seeded value is a free string — it may be an email,
+  // a username, or any other identifier the app chose to seed. The library
+  // does not validate format. Identifier is a low-secrecy field (the admin
+  // key is the real secret), so exposing it via /api/auth/identity is
+  // acceptable and avoids friction. Field stays editable in case the
+  // operator wants to confirm by typing.
   useEffect(() => {
     let cancelled = false;
     fetch("/api/auth/identity", { cache: "no-store" })
@@ -38,7 +40,7 @@ function LoginForm(): React.ReactElement {
   async function onSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
     if (!username || !adminKey) {
-      setError("Username and admin key are required");
+      setError("Email or username and admin key are required");
       return;
     }
     setError(null);
@@ -78,7 +80,7 @@ function LoginForm(): React.ReactElement {
 
       <div className="space-y-2">
         <label htmlFor="username" className="text-sm font-medium">
-          Username
+          Email or username
         </label>
         <input
           id="username"

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -377,7 +377,7 @@ The dashboard now requires a sign-in. The login form takes two fields:
 
 | Field | Source | Notes |
 |---|---|---|
-| Username | `LLMTRACE_DASHBOARD_ADMIN_USERNAME` env on the dashboard pod (set by `_apply_dashboard_admin_username`). Defaults to `"admin"`. | Pre-filled from the public `/api/auth/identity` endpoint as a UX nicety. Case-insensitive match. |
+| Email or username | `LLMTRACE_DASHBOARD_ADMIN_USERNAME` env on the dashboard pod (set by `_apply_dashboard_admin_username`). Defaults to `"admin"`. | Free string — the app decides whether to seed an email, a username, or any other identifier. The lifecycle library does not validate format; the dashboard accepts whatever was seeded. Pre-filled from the public `/api/auth/identity` endpoint as a UX nicety. Case-insensitive match. |
 | Admin key | The `admin_key` returned from `provision()` (either auto-generated or pinned). | The actual secret; validated against the proxy's admin endpoint on each login. |
 
 To seed both at provision time, supply them on either dispatch path:

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -64,6 +64,8 @@ dashboard:
 # rotate_admin_after_bootstrap: true
 
 # Dashboard login: the operator signs in with admin_username + the admin
-# key (pinned via `api_key:` above or auto-generated). Default is "admin";
-# override per tenant for a custom display identity.
+# key (pinned via `api_key:` above or auto-generated). `admin_username` is
+# a free string — either an email or a username is accepted. The lifecycle
+# library does not validate format; the dashboard accepts whatever was
+# seeded. Default is "admin"; override per tenant for a custom identity.
 # admin_username: "ops@acme.example"

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -86,7 +86,9 @@ dashboard:
 
 # Dashboard login: the operator signs in to the dashboard with the
 # admin_username below + the admin key (api_key above, or auto-generated).
-# Default username is "admin"; override for a custom seeded identity:
+# `admin_username` is a free string — either an email or a username works.
+# The lifecycle library does not validate the format; the dashboard accepts
+# whatever was seeded. Default is "admin"; override for a custom identity:
 # admin_username: "alice@acme.example"
 
 # Optional per-tenant rate limit. When uncommented, the lifecycle library

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -173,12 +173,13 @@ class TenantSpec:
     # Trade-off: adds one proxy re-roll (~30s) to provisioning. Opt-in
     # because most callers will not need it.
     rotate_admin_after_bootstrap: bool = False
-    # Display username for the dashboard login form. The dashboard's
-    # `/api/auth/login` route checks the submitted username matches
+    # Display identifier seeded into the dashboard login form. The
+    # dashboard's `/api/auth/login` route checks the submitted value matches
     # `LLMTRACE_DASHBOARD_ADMIN_USERNAME` (case-insensitive) AND that the
     # submitted password validates against the proxy as an admin key.
-    # Defaults to "admin"; override at provision time to seed a custom
-    # operator-visible identity ("alice@acme.example" etc.).
+    # Free string — the app decides whether to seed an email, a username,
+    # or any other identifier. The library does not validate format. The
+    # dashboard login form accepts whatever was seeded. Defaults to "admin".
     admin_username: str = "admin"
 
 


### PR DESCRIPTION
## Summary

Closes #260. Messaging/label-only change — the `admin_username` field name stays, no format validation added. The library does not care which identifier shape the app seeds.

## Per-file changes

- **`dashboard/src/app/login/page.tsx`** — visible label changed from "Username" to "Email or username". `name="username"`, `id="username"`, and `data-testid="login-username"` preserved exactly. Submit-error string updated. Pre-fill comment reworded so it no longer implies username-only.
- **`deployments/basilica/lifecycle.py`** — `TenantSpec.admin_username` docstring rewritten to state the field is a free string and the library does not validate format.
- **`deployments/basilica/configs/examples/starter.yaml`** + **`deployments/basilica/configs/examples/pro.yaml`** — comments above `admin_username` clarify either an email or a username is accepted; no validation.
- **`deployments/basilica/README.md`** — under "Seeding dashboard credentials at provision time", the field is relabelled "Email or username" and the table cell calls out that the lifecycle library does not validate format.
- **`.github/workflows/tenant-lifecycle.yml`** — `workflow_dispatch` `admin_username` input `description:` rewritten verbatim to the spec wording: "Display username (or email) seeded into the dashboard login form. Free string — no validation. The app decides which identifier shape to use."
- **`dashboard/e2e/auth-login.spec.ts`** — no change. The "login page renders the credentials form" test asserts visibility of the three testids (`login-username`, `login-admin-key`, `login-submit`) which are preserved; there is no literal "Username" assertion anywhere in the spec.

## Validation evidence (run locally on this worktree)

- `python3 -m py_compile deployments/basilica/lifecycle.py` -> `lifecycle.py compiles OK`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tenant-lifecycle.yml'))"` -> `tenant-lifecycle.yml parses OK`
- `python3 -c "import yaml; yaml.safe_load(...starter.yaml + pro.yaml)"` -> `YAML examples parse OK`
- `cd dashboard && npm run lint` -> only pre-existing warnings (`compliance`, `guide`, `traces` pages); no new lint output.
- `cd dashboard && npm run build` -> `Compiled successfully in 6.9s`, 18/18 static pages generated, `/login` route emitted at 2.11 kB.

## Live validation

Not applicable. This PR is a label/docstring/description-only change — there is no behavioural code path to live-test. Cannot run a live Basilica e2e from this worktree, and none is required.

## Test plan

- [x] Build + lint pass locally.
- [ ] CI green on the PR (monitored to terminal state).