### PR TITLE
feat(basilica): slug tenant_id for Basilica naming, accept arbitrary user_id (closes #259)

### DIFF
--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -68,6 +68,35 @@ not in the lifecycle library. After `provision`, your app stores `(tenant_id,
 proxy_instance_id, dashboard_instance_id)` and passes the UUIDs back on every
 subsequent lifecycle call.
 
+### tenant_id is your user identifier; the library slugs it for Basilica
+
+`TenantSpec.tenant_id` is **whatever string your app already uses** to
+identify the user — a UUID, an email, an opaque internal id, etc.
+`validate_tenant_id` accepts any non-empty string up to 256 chars with no
+whitespace or control characters (issue #259).
+
+For Basilica deployment naming (which must match k8s' DNS-1123 rule
+`^[a-z0-9][a-z0-9-]{0,29}$`), the library derives an internal slug via
+`_basilica_slug(tenant_id)`:
+
+- Lowercases the input and rewrites every non-`[a-z0-9-]` character to
+  `-`, collapses dash runs, strips leading/trailing dashes.
+- Appends a 6-char blake2b hex suffix of the original `tenant_id` so two
+  inputs that sanitise to the same prefix (e.g. `alice@acme` and
+  `alice_acme`) get different slugs.
+- Caps the result at 30 chars; falls back to `tenant-<hash6>` if
+  sanitisation strips the input to empty.
+
+The slug is **deterministic** for a given input, so `update` / `status` /
+`deprovision` keep working when the caller passes the same original
+`tenant_id` — the library re-derives the same Basilica deployment name
+each time.
+
+The proxy's `name` column on `POST /api/v1/tenants` is set to the
+**original** `tenant_id` (not the slug) so dashboards / audit logs show
+the human-readable identifier the caller's users see. The slug is purely
+internal to Basilica's k8s namespace.
+
 ## Quick start
 
 ### 1. One-time platform setup
@@ -826,7 +855,7 @@ The library raises three exception classes that your worker should map:
 
 | Exception | Meaning | Recommended action |
 |---|---|---|
-| `ValueError` | Bad input (invalid `tenant_id` slug, unknown `strategy`, missing required spec field) | 4xx to caller; don't retry |
+| `ValueError` | Bad input (empty / whitespace-containing / oversized `tenant_id`, unknown `strategy`, missing required spec field) | 4xx to caller; don't retry |
 | `RuntimeError` | Basilica-side failure (deployment entered terminal `Failed` state, `BASILICA_API_TOKEN` missing, etc.) | 5xx + alert; retry with backoff if transient |
 | `TimeoutError` | `startup_timeout_seconds` elapsed without ready | 5xx; check Basilica's UI for stuck deployment; consider a manual `deprovision` to clean up |
 

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -23,6 +23,7 @@ does a rolling restart of the existing pods (URL stable, no config change).
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -42,8 +43,26 @@ from basilica import (
 
 LOGGER = logging.getLogger(__name__)
 
-# DNS-safe slug, ≤30 chars to leave headroom for friendly-name prefixes.
-TENANT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,29}$")
+# Maximum length accepted by `validate_tenant_id`. The library accepts any
+# caller-supplied identifier (UUID, email, opaque string); slugging to a
+# DNS-safe Basilica deployment name happens internally in `_basilica_slug`.
+MAX_TENANT_ID_LEN = 256
+
+# DNS-safe Basilica deployment slug guarantee. `_basilica_slug` always
+# returns a value matching this regex; downstream Basilica friendly-name
+# templates need a stable k8s-compatible string.
+_BASILICA_SLUG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,29}$")
+
+# Maximum slug length (matches the regex's 30-char ceiling). Splits into
+# a sanitised prefix and a 6-hex collision-resistant suffix joined by `-`.
+_SLUG_MAX_LEN = 30
+_SLUG_HASH_HEX = 6
+_SLUG_PREFIX_MAX = _SLUG_MAX_LEN - 1 - _SLUG_HASH_HEX  # 23
+
+# Anything not in `[a-z0-9-]` after lowercasing is rewritten to `-` in the
+# slug prefix.
+_SLUG_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
+_SLUG_DASH_RUN = re.compile(r"-+")
 
 POLL_INTERVAL_SECONDS = 10
 
@@ -249,11 +268,58 @@ class RotationResult:
 
 
 def validate_tenant_id(tenant_id: str) -> str:
-    if not TENANT_ID_PATTERN.match(tenant_id):
+    """Permissive validation for the caller-supplied tenant identifier.
+
+    The library accepts any non-empty string up to `MAX_TENANT_ID_LEN`
+    chars with no whitespace or control characters. The DNS-safe Basilica
+    deployment slug is derived internally via `_basilica_slug` — the two
+    namespaces are intentionally distinct (see issue #259).
+    """
+    if not isinstance(tenant_id, str):
         raise ValueError(
-            f"tenant_id {tenant_id!r} must match {TENANT_ID_PATTERN.pattern}"
+            f"tenant_id must be a str, got {type(tenant_id).__name__}"
         )
+    if not tenant_id:
+        raise ValueError("tenant_id must be non-empty")
+    if len(tenant_id) > MAX_TENANT_ID_LEN:
+        raise ValueError(
+            f"tenant_id length {len(tenant_id)} exceeds max {MAX_TENANT_ID_LEN}"
+        )
+    for ch in tenant_id:
+        if ch.isspace() or ord(ch) < 0x20 or ord(ch) == 0x7F:
+            raise ValueError(
+                f"tenant_id contains whitespace or control character: {tenant_id!r}"
+            )
     return tenant_id
+
+
+def _basilica_slug(tenant_id: str) -> str:
+    """Derive a DNS-safe Basilica deployment slug from any caller identifier.
+
+    Deterministic for the same input. Result matches
+    `^[a-z0-9][a-z0-9-]{0,29}$` — Basilica's k8s naming rule. The slug is
+    `<sanitised-prefix>-<6-char-blake2b-hex>` capped at 30 chars; the hash
+    suffix prevents collisions between two callers whose identifiers
+    sanitise to the same prefix (e.g. `alice@acme` and `alice_acme`).
+    """
+    lowered = tenant_id.lower()
+    cleaned = _SLUG_INVALID_CHARS.sub("-", lowered)
+    cleaned = _SLUG_DASH_RUN.sub("-", cleaned).strip("-")
+    prefix = cleaned or "tenant"
+    prefix = prefix[:_SLUG_PREFIX_MAX]
+    # Trailing dash from truncation is fine (joined by `-` next); leading
+    # dash would break the leading-alnum requirement.
+    if prefix.startswith("-"):
+        prefix = ("x" + prefix)[:_SLUG_PREFIX_MAX]
+    hash6 = hashlib.blake2b(
+        tenant_id.encode("utf-8"), digest_size=_SLUG_HASH_HEX // 2
+    ).hexdigest()
+    slug = f"{prefix}-{hash6}"
+    if not _BASILICA_SLUG_PATTERN.match(slug):
+        raise RuntimeError(
+            f"internal: derived slug {slug!r} fails Basilica naming rule"
+        )
+    return slug
 
 
 def make_client(api_key: Optional[str] = None) -> BasilicaClient:
@@ -729,7 +795,7 @@ def rotate_admin_key(
     rotated_spec = dataclasses.replace(proxy_spec, env=new_env)
     rotated_spec = _apply_ml_preload_startup_floor(rotated_spec, tenant_id=tenant_id)
 
-    proxy_name = proxy_name_template.format(tenant_id=tenant_id)
+    proxy_name = proxy_name_template.format(tenant_id=_basilica_slug(tenant_id))
     LOGGER.info(
         "rotating admin key tenant=%s old_proxy=%s", tenant_id, proxy_instance_id
     )
@@ -772,8 +838,9 @@ def provision(
     """
     tenant_id = validate_tenant_id(spec.tenant_id)
     client = client or make_client()
-    proxy_name = spec.proxy_name_template.format(tenant_id=tenant_id)
-    dashboard_name = spec.dashboard_name_template.format(tenant_id=tenant_id)
+    slug = _basilica_slug(tenant_id)
+    proxy_name = spec.proxy_name_template.format(tenant_id=slug)
+    dashboard_name = spec.dashboard_name_template.format(tenant_id=slug)
 
     admin_key = _resolve_api_key(spec)
     proxy_spec, dashboard_spec = (spec.proxy, spec.dashboard)

--- a/deployments/basilica/tests/test_rotate_admin_key.py
+++ b/deployments/basilica/tests/test_rotate_admin_key.py
@@ -95,7 +95,10 @@ class RotateAdminKeyTests(unittest.TestCase):
             kwargs["env"]["LLMTRACE_AUTH_ADMIN_KEY"], "llmt_oldkey"
         )
         self.assertEqual(kwargs["env"]["LLMTRACE_AUTH_ENABLED"], "true")
-        self.assertEqual(kwargs["instance_name"], "llmtrace-proxy-acme")
+        # Post-#259 the friendly name is templated against the Basilica
+        # slug (deterministic from the tenant_id), not the raw tenant_id.
+        expected_slug = lifecycle._basilica_slug("acme")
+        self.assertEqual(kwargs["instance_name"], f"llmtrace-proxy-{expected_slug}")
         self.assertEqual(result.tenant_id, "acme")
         self.assertEqual(result.proxy.instance_id, new_proxy_id)
         self.assertEqual(result.admin_key, kwargs["env"]["LLMTRACE_AUTH_ADMIN_KEY"])
@@ -131,10 +134,14 @@ class RotateAdminKeyTests(unittest.TestCase):
         client.create_deployment.assert_not_called()
 
     def test_rotation_propagates_invalid_tenant_id(self) -> None:
+        # Post-#259 the validator accepts arbitrary user identifiers
+        # (uppercase, emails, UUIDs) and only rejects empty / whitespace /
+        # control-char input. We still want a ValueError to short-circuit
+        # the delete+recreate, so feed a value the validator rejects.
         client = MagicMock()
         with self.assertRaises(ValueError):
             lifecycle.rotate_admin_key(
-                tenant_id="UPPER",
+                tenant_id="has space",
                 proxy_instance_id="uuid-old",
                 proxy_spec=_proxy_spec(),
                 client=client,
@@ -155,7 +162,8 @@ class RotateAdminKeyTests(unittest.TestCase):
         )
 
         kwargs = client.create_deployment.call_args.kwargs
-        self.assertEqual(kwargs["instance_name"], "custom-acme-proxy")
+        expected_slug = lifecycle._basilica_slug("acme")
+        self.assertEqual(kwargs["instance_name"], f"custom-{expected_slug}-proxy")
 
 
 class ProvisionWithRotateAfterBootstrapTests(unittest.TestCase):

--- a/deployments/basilica/tests/test_tenant_id_slugging.py
+++ b/deployments/basilica/tests/test_tenant_id_slugging.py
@@ -1,0 +1,151 @@
+"""Tests for the permissive `validate_tenant_id` and the `_basilica_slug`
+derivation (issue #259).
+
+The caller passes any human-readable identifier (UUID, email, opaque
+string). The library accepts it as-is and derives a deterministic
+DNS-safe slug internally for Basilica deployment naming. The slug logic
+itself is exercised directly here — no mocks, no stubs.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from deployments.basilica import lifecycle
+
+
+_SLUG_REGEX = re.compile(r"^[a-z0-9][a-z0-9-]{0,29}$")
+
+
+# ---------------------------------------------------------------------------
+# validate_tenant_id: permissive acceptance + explicit rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tenant_id",
+    [
+        "acme",
+        "ACME",
+        "User-With-Caps",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "alice@acme.example",
+        "user_id:42",
+        "a" * 256,
+        "中文",  # unicode is fine; only whitespace / control are rejected
+    ],
+)
+def test_validate_tenant_id_accepts_arbitrary_identifiers(tenant_id: str) -> None:
+    assert lifecycle.validate_tenant_id(tenant_id) == tenant_id
+
+
+@pytest.mark.parametrize(
+    "tenant_id",
+    [
+        "has space",
+        "has\ttab",
+        "has\nnewline",
+        "has\x00null",
+        "has\x1fctl",
+        "has\x7fdel",
+    ],
+)
+def test_validate_tenant_id_rejects_whitespace_and_control(tenant_id: str) -> None:
+    with pytest.raises(ValueError, match="whitespace or control"):
+        lifecycle.validate_tenant_id(tenant_id)
+
+
+def test_validate_tenant_id_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        lifecycle.validate_tenant_id("")
+
+
+def test_validate_tenant_id_rejects_over_max_length() -> None:
+    with pytest.raises(ValueError, match="exceeds max"):
+        lifecycle.validate_tenant_id("a" * (lifecycle.MAX_TENANT_ID_LEN + 1))
+
+
+def test_validate_tenant_id_rejects_non_string() -> None:
+    with pytest.raises(ValueError, match="must be a str"):
+        lifecycle.validate_tenant_id(12345)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _basilica_slug: DNS-safe + deterministic + collision-resistant
+# ---------------------------------------------------------------------------
+
+
+def test_slug_is_dns_safe_for_short_input() -> None:
+    slug = lifecycle._basilica_slug("acme")
+    assert _SLUG_REGEX.match(slug), slug
+    assert slug.startswith("acme-")
+
+
+def test_slug_for_256_char_input_is_within_30_chars_and_valid() -> None:
+    long_id = "a" * 256
+    slug = lifecycle._basilica_slug(long_id)
+    assert len(slug) <= 30
+    assert _SLUG_REGEX.match(slug), slug
+
+
+def test_slug_for_uuid_is_deterministic_and_dns_safe() -> None:
+    uuid_id = "550e8400-e29b-41d4-a716-446655440000"
+    lifecycle.validate_tenant_id(uuid_id)
+    a = lifecycle._basilica_slug(uuid_id)
+    b = lifecycle._basilica_slug(uuid_id)
+    assert a == b
+    assert _SLUG_REGEX.match(a), a
+
+
+def test_slug_for_email_is_dns_safe_and_keeps_recognisable_prefix() -> None:
+    email_id = "alice@acme.example"
+    lifecycle.validate_tenant_id(email_id)
+    slug = lifecycle._basilica_slug(email_id)
+    assert _SLUG_REGEX.match(slug), slug
+    # The local-part-ish prefix survives slugging so an operator can still
+    # eyeball the deployment back to its tenant.
+    assert slug.startswith("alice-acme-example"[:23])
+
+
+def test_slug_is_deterministic_across_repeated_calls() -> None:
+    tid = "User-With-Caps"
+    first = lifecycle._basilica_slug(tid)
+    for _ in range(5):
+        assert lifecycle._basilica_slug(tid) == first
+
+
+def test_two_inputs_sharing_prefix_get_different_hash_suffix() -> None:
+    """`alice@acme.example` and `alice_acme_example` both clean to a
+    prefix starting with `alice-acme-example`; the 6-char hash suffix
+    must distinguish them.
+    """
+    a = lifecycle._basilica_slug("alice@acme.example")
+    b = lifecycle._basilica_slug("alice_acme_example")
+    assert a != b
+    assert a.rsplit("-", 1)[0] == b.rsplit("-", 1)[0], (
+        "expected the sanitised prefixes to match"
+    )
+    assert a.rsplit("-", 1)[1] != b.rsplit("-", 1)[1], (
+        "expected different hash suffixes"
+    )
+
+
+def test_slug_falls_back_to_tenant_prefix_when_sanitisation_yields_empty() -> None:
+    # All chars are stripped — the helper must still produce a valid slug.
+    slug = lifecycle._basilica_slug("@@@")
+    assert slug.startswith("tenant-")
+    assert _SLUG_REGEX.match(slug), slug
+
+
+def test_slug_collision_suffix_differs_for_different_inputs() -> None:
+    # Different inputs that sanitise to identical prefixes must still
+    # produce different final slugs.
+    inputs = ["acme", "ACME", "a c m e", "@acme@"]
+    # Filter out invalid (whitespace) for the slug call — `_basilica_slug`
+    # accepts anything but `validate_tenant_id` would reject the
+    # space-containing one. For pure slug collision-resistance we feed
+    # the helper directly.
+    slugs = {lifecycle._basilica_slug(inp) for inp in inputs}
+    assert len(slugs) == len(inputs), f"slug collision: {slugs}"


### PR DESCRIPTION
Closes #259.

## Summary

The lifecycle library now treats `TenantSpec.tenant_id` as an opaque caller-supplied user identifier (UUID, email, opaque string) and derives a DNS-safe slug internally for Basilica deployment naming. Two namespaces, one deterministic mapping.

## Per-file changes

- `deployments/basilica/lifecycle.py`
  - Drops the strict `TENANT_ID_PATTERN` regex from `validate_tenant_id`. Now permissive: any non-empty string up to 256 chars with no whitespace or control characters. Wrong-type / empty / oversized / whitespace / control inputs raise `ValueError` with explicit messages.
  - New private `_basilica_slug(tenant_id)`: lowercases, rewrites every non-`[a-z0-9-]` to `-`, collapses dash runs, strips edges, then appends a 6-char blake2b hex suffix of the original input. Capped at 30 chars. Falls back to `tenant-<hash6>` if sanitisation yields empty. Always matches Basilica's `^[a-z0-9][a-z0-9-]{0,29}$` rule (raises `RuntimeError` if the internal invariant breaks).
  - `provision`, `update(recreate)`, `rotate_admin_key` now feed `_basilica_slug(tenant_id)` into the `proxy_name_template` / `dashboard_name_template` instead of the raw tenant_id. The template placeholder name (`{tenant_id}`) is kept for backwards compatibility.
  - `_bootstrap_tenant_in_proxy` continues to receive the ORIGINAL `tenant_id` so the proxy's tenant `name` column stays human-readable.
- `deployments/basilica/tests/test_tenant_id_slugging.py` (new) — 25 cases: 256-char input is slug-safe; UUID/email/uppercase accepted; deterministic across repeats; collision-safe between inputs that sanitise to the same prefix; whitespace/control/empty/oversized/non-str rejected with `ValueError`; empty-after-sanitisation falls back to `tenant-` prefix.
- `deployments/basilica/tests/test_rotate_admin_key.py` — literal `llmtrace-proxy-acme` / `custom-acme-proxy` assertions replaced with computed `_basilica_slug("acme")` so they survive the slugging change. The `test_rotation_propagates_invalid_tenant_id` case switches its input from `"UPPER"` to `"has space"` since uppercase is now valid by design; the test still verifies the validator short-circuits the delete+recreate via a `ValueError`.
- `deployments/basilica/README.md` — new section documenting the user-identifier vs deployment-slug split and the deterministic mapping callers can rely on for `update`/`status`/`deprovision`. Error-handling row updated to drop the obsolete "tenant_id slug" language.

## Validation evidence

Commands run in this worktree:

`python3 -m py_compile deployments/basilica/lifecycle.py deployments/basilica/cli.py deployments/basilica/tests/*.py` — exit 0.

`pytest deployments/basilica/tests/` (with basilica SDK stub and PYTHONPATH=. to avoid the local-package shadow that the repo's pre-existing conftest doesn't fully guard against):

```
...EE....................................F.F................ [ 85%]
..........                                                               [100%]
=========================== short test summary info ============================
FAILED ... ProvisionWithRotateAfterBootstrapTests::test_no_rotation_when_flag_off
FAILED ... ProvisionWithRotateAfterBootstrapTests::test_rotation_runs_when_flag_on
ERROR ... test_admin_username_seeding.py::test_provision_seeds_default_admin_username
ERROR ... test_admin_username_seeding.py::test_provision_seeds_custom_admin_username
2 failed, 66 passed, 2 errors, 12 subtests passed
```

The same 2 failures + 2 errors reproduce on `main` (verified by temporarily swapping in main's `lifecycle.py` + `test_rotate_admin_key.py`): 41 passed, same 2 failed + 2 errored. All four are pre-existing sandbox limitations (DNS lookups blocked + cross-file `fake_proxy` fixture discovery) unrelated to this PR. With this PR's 25 new slug tests, the pass count rises from 41 to 66 with no new failures.

All 25 new `test_tenant_id_slugging.py` cases pass.

## What is NOT live-validated

- A live re-`provision` against Basilica with a UUID-shaped `tenant_id`. The worktree has no Basilica credentials and the sandbox blocks outbound DNS to `*.basilica.ai`, so the acceptance case from the issue ("`tenant_id="user-uuid-550e8400-e29b-41d4-a716-446655440000"` provisions a deployment matching `^llmtrace-(proxy|dashboard)-[a-z0-9][a-z0-9-]{0,29}$`") needs a maintainer with `BASILICA_API_TOKEN` to confirm against a real account.
- The deterministic-across-`update` property (caller passes the same original `tenant_id` on `update` and lands on the same Basilica deployment) is fully verified by `test_slug_is_deterministic_across_repeated_calls` against the helper but not against a live Basilica reconciliation.

## Test plan

- [ ] Maintainer re-provisions an existing dev tenant with a UUID `tenant_id` against a live Basilica account; deployment friendly-names match the Basilica regex.
- [ ] Maintainer runs `update --strategy=restart` for that tenant and confirms the same UUIDs resolve (no orphan creation).