### PR TITLE
docs(proxy): correct /metrics module comment + drop README footnote (closes #270)

### DIFF
--- a/crates/llmtrace-proxy/src/metrics.rs
+++ b/crates/llmtrace-proxy/src/metrics.rs
@@ -4,8 +4,11 @@
 //! (counters, histograms, gauges) and a handler that renders them in
 //! Prometheus exposition text format at `/metrics`.
 //!
-//! The endpoint is intentionally unauthenticated — this is the standard
-//! convention for Prometheus scraping endpoints.
+//! Auth gating: the route is registered behind the standard auth
+//! middleware (see `crate::auth::auth_middleware`). When
+//! `auth.enabled = true`, a valid bearer (any role) is required to
+//! scrape. With auth disabled, the endpoint is open — matching the
+//! traditional Prometheus convention only in trusted-network mode.
 
 use axum::body::Body;
 use axum::extract::State;

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -174,9 +174,9 @@ What each role can do once the dashboard is up. Verified against
 
 | Role | Dashboard sign-in | `/v1/*` traffic | `/api/v1/auth/keys` (admin) | `/metrics` | `/health` |
 | --- | --- | --- | --- | --- | --- |
-| Admin | Yes | Yes | Yes | Yes (authenticated)[^metrics] | Yes (no auth) |
-| Operator | Yes (read-only-ish) | Yes | 403 | Yes (authenticated)[^metrics] | Yes (no auth) |
-| Viewer | Yes (read-only) | See note[^viewer-v1] | 403 | Yes (authenticated)[^metrics] | Yes (no auth) |
+| Admin | Yes | Yes | Yes | Yes (authenticated) | Yes (no auth) |
+| Operator | Yes (read-only-ish) | Yes | 403 | Yes (authenticated) | Yes (no auth) |
+| Viewer | Yes (read-only) | See note[^viewer-v1] | 403 | Yes (authenticated) | Yes (no auth) |
 
 [^viewer-v1]: The user-facing spec calls for Viewer to be 403 on
 `/v1/*`. The current proxy code does not enforce that: the `/v1/*`
@@ -186,15 +186,6 @@ fallback `proxy_handler` (see
 forward inference traffic. Tightening the fallback to require Operator
 is tracked separately; until then, do not hand a Viewer key to a
 caller you do not also trust to forward traffic.
-
-[^metrics]: The `/metrics` route is registered before the auth
-middleware layer (see
-`crates/llmtrace-proxy/src/main.rs::build_router`). The middleware
-allow-list only exempts `/health`, `/swagger-ui`, and `/api-doc`, so
-with `auth.enabled = true` a Prometheus scraper must present a valid
-bearer (any role). The legacy "metrics needs no auth" comment in
-`metrics.rs` reflects the disabled-auth path; treat the table above as
-the live behaviour when auth is on.
 
 ### Identifier vs deployment naming
 


### PR DESCRIPTION
## Summary

Closes #270.

The module-level docstring in `crates/llmtrace-proxy/src/metrics.rs` claimed the endpoint was "intentionally unauthenticated", which is false when `auth.enabled = true` (the production default). The auth middleware allow-list in `crates/llmtrace-proxy/src/auth.rs` only exempts `/health`, `/swagger-ui`, and `/api-doc`, so `/metrics` requires a valid bearer (any role) in the standard configuration.

This PR fixes the comment to describe the live behaviour and drops the now-redundant `[^metrics]` footnote that PR #268 added to `deployments/basilica/README.md`.

No behaviour change.

## Per-file changes

### `crates/llmtrace-proxy/src/metrics.rs`
Replace lines 7-8 ("The endpoint is intentionally unauthenticated...") with a multi-line description of the real auth gating:

```
//! Auth gating: the route is registered behind the standard auth
//! middleware (see `crate::auth::auth_middleware`). When
//! `auth.enabled = true`, a valid bearer (any role) is required to
//! scrape. With auth disabled, the endpoint is open — matching the
//! traditional Prometheus convention only in trusted-network mode.
```

Every other line of the file is untouched.

### `deployments/basilica/README.md`
- Drop the `[^metrics]` footnote definition (8 lines) that explained the discrepancy between the old comment and the runtime behaviour.
- Change three table cells in the `/metrics` column from `Yes (authenticated)[^metrics]` to `Yes (authenticated)` (Admin, Operator, Viewer rows).
- Table renders unchanged; no other footnote anchors are broken (the `[^viewer-v1]` footnote still resolves correctly).

## Validation

All commands executed locally in the worktree at `0169314`:

- `cargo fmt --all` — clean, no diff produced afterwards.
- `grep -rn "intentionally unauthenticated\|\[\^metrics\]" crates/ deployments/` — no hits.
- `cargo build -p llmtrace` — clean (`Finished dev profile [unoptimized + debuginfo] target(s) in 4m 46s`). The change is comment-only but still compiles.
- `cargo test -p llmtrace --tests` — clean. Result counts:
  - `unittests src/lib.rs`: 608 passed; 0 failed; 0 ignored.
  - `unittests src/main.rs`: 21 passed; 0 failed; 0 ignored (includes `tests::test_metrics_endpoint_returns_prometheus_format`).
  - `tests/integration_test.rs`: 19 passed; 0 failed; 0 ignored.
- `cargo clippy -p llmtrace -- -D warnings` — clean, no warnings.

Note: the crate's package name is `llmtrace` (the binary is `llmtrace-proxy`); `cargo … -p llmtrace-proxy` errors with "did not match any packages", so the validation was run against `-p llmtrace` per the actual Cargo manifest.

## Not live-validated

- No end-to-end deployment check was run for this PR; the change is documentation-only and does not affect compiled behaviour or routing. The accuracy of the new comment was verified by reading `crates/llmtrace-proxy/src/auth.rs` (the allow-list) and `crates/llmtrace-proxy/src/main.rs::build_router` (where the `/metrics` route is registered behind `auth_middleware`).