### PR TITLE
security(proxy): require Operator role on /v1/* forwarding (closes #269)

### DIFF
--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -29,7 +29,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use futures_util::StreamExt;
 use llmtrace_core::{
-    truncate_to_byte_limit, AgentAction, AnalysisContext, LLMProvider, ProxyConfig,
+    truncate_to_byte_limit, AgentAction, AnalysisContext, ApiKeyRole, LLMProvider, ProxyConfig,
     SecurityAnalyzer, SecurityFinding, Storage, TenantId, TraceEvent, TraceSpan,
 };
 use reqwest::Client;
@@ -633,6 +633,16 @@ pub async fn proxy_handler(
             TenantId(Uuid::new_v5(&Uuid::NAMESPACE_OID, b"Unknown"))
         }
     };
+
+    // RBAC: when auth is enabled, the catch-all forwarder (/v1/*) requires
+    // at least Operator role. Viewer keys are read-only and must not
+    // forward inference traffic. See issue #269.
+    if cfg.auth.enabled {
+        if let Some(err) = crate::auth::require_role(req.extensions(), ApiKeyRole::Operator) {
+            state.metrics.active_connections.dec();
+            return err;
+        }
+    }
 
     let _api_key = extract_api_key(&headers);
     let agent_id = extract_agent_id(&headers);

--- a/crates/llmtrace-proxy/tests/integration_test.rs
+++ b/crates/llmtrace-proxy/tests/integration_test.rs
@@ -1351,3 +1351,155 @@ async fn ml_pipeline_semaphore_rejects_excess_concurrent_requests() {
         "in-flight gauge must drain to zero after all admitted requests release their permit"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #269 — `/v1/*` forwarder must require at least Operator role.
+// ---------------------------------------------------------------------------
+
+/// Build an auth-enabled proxy app: bootstrap admin key + auth middleware
+/// wired around the proxy_handler fallback. Used by the RBAC tests below.
+async fn build_auth_enabled_proxy(upstream_url: &str, admin_key: &str) -> (Arc<AppState>, Router) {
+    let config = ProxyConfig {
+        upstream_url: upstream_url.to_string(),
+        listen_addr: "127.0.0.1:0".to_string(),
+        storage: StorageConfig {
+            profile: "memory".to_string(),
+            database_path: String::new(),
+            ..StorageConfig::default()
+        },
+        connection_timeout_ms: 2000,
+        timeout_ms: 5000,
+        enable_security_analysis: true,
+        enable_trace_storage: true,
+        enable_streaming: true,
+        auth: llmtrace_core::AuthConfig {
+            enabled: true,
+            admin_key: Some(admin_key.to_string()),
+        },
+        ..ProxyConfig::default()
+    };
+    let (state, _bare) = build_proxy_with_config(config).await;
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .fallback(axum::routing::any(proxy_handler))
+        .layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&state),
+            llmtrace_proxy::auth::auth_middleware,
+        ))
+        .with_state(Arc::clone(&state));
+    (state, app)
+}
+
+/// Seed a tenant + a non-admin API key with the requested role. Returns
+/// the plaintext key value that callers send in `Authorization: Bearer`.
+async fn seed_role_key(state: &Arc<AppState>, role: llmtrace_core::ApiKeyRole) -> String {
+    let tenant = llmtrace_core::Tenant {
+        id: TenantId::new(),
+        name: format!("rbac-{role}"),
+        api_token: format!("token-{role}"),
+        plan: "free".to_string(),
+        created_at: chrono::Utc::now(),
+        config: serde_json::json!({}),
+    };
+    state.metadata().create_tenant(&tenant).await.unwrap();
+
+    let (plaintext, hash) = llmtrace_proxy::auth::generate_api_key();
+    let record = llmtrace_core::ApiKeyRecord {
+        id: uuid::Uuid::new_v4(),
+        tenant_id: tenant.id,
+        name: format!("rbac-{role}-key"),
+        key_hash: hash,
+        key_prefix: llmtrace_proxy::auth::key_prefix(&plaintext),
+        role,
+        created_at: chrono::Utc::now(),
+        revoked_at: None,
+    };
+    state.metadata().create_api_key(&record).await.unwrap();
+    plaintext
+}
+
+#[tokio::test]
+async fn test_v1_forward_admin_role_allowed() {
+    let (upstream_url, _h) = serve(mock_upstream()).await;
+    let (_state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
+
+    let req = Request::post("/v1/chat/completions")
+        .header("authorization", "Bearer admin-bootstrap")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "admin key must be allowed to forward /v1/* traffic"
+    );
+}
+
+#[tokio::test]
+async fn test_v1_forward_operator_role_allowed() {
+    let (upstream_url, _h) = serve(mock_upstream()).await;
+    let (state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
+    let operator_key = seed_role_key(&state, llmtrace_core::ApiKeyRole::Operator).await;
+
+    let req = Request::post("/v1/chat/completions")
+        .header("authorization", format!("Bearer {operator_key}"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "operator key must be allowed to forward /v1/* traffic"
+    );
+}
+
+#[tokio::test]
+async fn test_v1_forward_viewer_role_forbidden() {
+    let (upstream_url, _h) = serve(mock_upstream()).await;
+    let (state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
+    let viewer_key = seed_role_key(&state, llmtrace_core::ApiKeyRole::Viewer).await;
+
+    let req = Request::post("/v1/chat/completions")
+        .header("authorization", format!("Bearer {viewer_key}"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "viewer key must be rejected by /v1/* forwarder (issue #269)"
+    );
+
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&bytes);
+    assert!(
+        body.contains("requires operator role, have viewer"),
+        "403 body must surface the standard require_role message; got: {body}"
+    );
+}

--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -176,16 +176,7 @@ What each role can do once the dashboard is up. Verified against
 | --- | --- | --- | --- | --- | --- |
 | Admin | Yes | Yes | Yes | Yes (authenticated) | Yes (no auth) |
 | Operator | Yes (read-only-ish) | Yes | 403 | Yes (authenticated) | Yes (no auth) |
-| Viewer | Yes (read-only) | See note[^viewer-v1] | 403 | Yes (authenticated) | Yes (no auth) |
-
-[^viewer-v1]: The user-facing spec calls for Viewer to be 403 on
-`/v1/*`. The current proxy code does not enforce that: the `/v1/*`
-fallback `proxy_handler` (see
-`crates/llmtrace-proxy/src/proxy.rs::proxy_handler`) does not call
-`require_role`, so any authenticated key — including Viewer — can
-forward inference traffic. Tightening the fallback to require Operator
-is tracked separately; until then, do not hand a Viewer key to a
-caller you do not also trust to forward traffic.
+| Viewer | Yes (read-only) | 403 | 403 | Yes (authenticated) | Yes (no auth) |
 
 ### Identifier vs deployment naming
 


### PR DESCRIPTION
## Summary

- Fixes #269: the catch-all `proxy_handler` (`crates/llmtrace-proxy/src/proxy.rs::proxy_handler`) extracted `AuthContext` but never gated on it. Any authenticated key — including a Viewer key — could forward `/v1/*` inference traffic. Spec calls for Viewer to be 403 on inference.
- After `resolve_authenticated_tenant` and before any body-read / upstream call, the handler now calls `crate::auth::require_role(req.extensions(), ApiKeyRole::Operator)` when `auth.enabled = true`. The 403 path decrements `active_connections` before returning so the gauge stays accurate. Legacy permissive mode (`auth.enabled = false`) is preserved.
- Docs: removed the `[^viewer-v1]` footnote from `deployments/basilica/README.md` and flipped the Viewer / `/v1/*` cell from "See note" to a plain `403`.

## Per-file changes

| File | Change |
| --- | --- |
| `crates/llmtrace-proxy/src/proxy.rs` | Added `ApiKeyRole` to the `llmtrace_core` import. Inserted `require_role(_, ApiKeyRole::Operator)` gate inside `proxy_handler` (auth-enabled only), with `active_connections.dec()` on 403. |
| `crates/llmtrace-proxy/tests/integration_test.rs` | Added `build_auth_enabled_proxy` and `seed_role_key` helpers plus three new tests covering Admin / Operator / Viewer × `/v1/chat/completions`. Real `AuthContext` is injected via the existing `auth_middleware` — no mocking of `require_role`. |
| `deployments/basilica/README.md` | Removed `[^viewer-v1]` footnote; Viewer / `/v1/*` cell is now `403`. |

## Validation

`cargo fmt --all -- --check` — clean (no output).

`cargo build -p llmtrace` — clean (`Finished` only).

`cargo test -p llmtrace --tests` output:

```
test result: ok. 608 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.02s
  (lib unit tests)

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 32.08s
  (main bin tests)

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.47s
  (integration_test.rs — includes the 3 new RBAC tests)
```

Total: **651 passed, 0 failed**. The three new tests proving the fix:

```
test test_v1_forward_admin_role_allowed ... ok
test test_v1_forward_operator_role_allowed ... ok
test test_v1_forward_viewer_role_forbidden ... ok
```

`cargo clippy -p llmtrace --lib -- -D warnings` — clean.

`cargo clippy -p llmtrace --tests -- -D warnings` surfaces several errors, but every one of them reproduces on `main` (`ca82c0b`) before this branch's changes were applied — they are pre-existing and unrelated to this fix. Verified by stashing the diff, checking out `main`'s `proxy.rs` + `integration_test.rs`, re-running clippy, getting the identical error set, then restoring the diff. The new RBAC test code is clippy-clean.

## What is NOT live-validated here

A live HTTP probe against a Basilica deployment with Viewer / Operator / Admin keys will be run by the maintainer after merge — this worktree cannot dispatch the workflow.

## Test plan

- [ ] CI green on this PR
- [ ] Maintainer runs a live `curl -H "Authorization: Bearer <viewer-key>" $proxy/v1/chat/completions` against a deployed Basilica proxy and confirms `HTTP 403` with body containing `"requires operator role, have viewer"`.
- [ ] Same `curl` with Operator + Admin keys returns the upstream response (200 or whatever the upstream emits).