### PR TITLE
fix(basilica): default proxy replicas to 1 + warn on unsharable multi-replica (closes #275)

### DIFF
--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -1336,6 +1336,44 @@ matters more than first-request latency.
 **Silence the WARN**: set `startup_timeout_seconds: 1500` (or higher)
 explicitly in your config. Both example configs already do this.
 
+### Replica count and metadata storage
+
+The proxy's metadata store (tenant rows, API keys, audit log) is held in
+a sqlite file on the pod's local filesystem when `LLMTRACE_STORAGE_PROFILE`
+resolves to `sqlite`, `lite`, or `memory` (the default for both example
+configs). Basilica deployments **do not share volumes between replicas**:
+each replica gets its own pod-local sqlite file. Setting
+`proxy.replicas > 1` therefore makes the replicas diverge — bootstrap
+writes (`POST /api/v1/tenants`, `POST /api/v1/auth/keys`) land on one
+random pod; subsequent admin reads round-robin between pods and return
+stale results from the replicas that never saw the write.
+
+**Live-reproduced 2026-05-26 against `:sha-ecf142e` with `pro.yaml`
+(then `replicas: 2`, sqlite metadata).** 10 rapid `/api/v1/tenants`
+calls returned `tenant count=0` on 3/10 hits — a 30% empty rate matching
+the routing odds for one of two replicas holding the data. The dashboard
+`/tenants` page intermittently rendered empty, and `/api/v1/auth/keys`
++ `/api/v1/stats` showed the same symptom.
+
+**Default**: both `starter.yaml` and `pro.yaml` ship `replicas: 1`. This
+is the only correct setting for a per-pod metadata profile.
+
+**Running replicas > 1**: switch to a shared backend.
+
+1. Set `LLMTRACE_STORAGE_PROFILE: postgres` in `proxy.env`.
+2. Supply `LLMTRACE_POSTGRES_URL` via `tenant_secrets_json` /
+   `client_payload.tenant_secrets` (so the bearer doesn't end up in
+   the YAML file).
+3. Bump `proxy.replicas` to the desired count.
+
+**Safety net**: `lifecycle.provision()` emits a `LOGGER.warning(...)`
+when it sees `replicas > 1` combined with a non-shared
+`LLMTRACE_STORAGE_PROFILE` (`""`, `sqlite`, `lite`, `memory`). The
+warning calls out the diverging-replicas failure mode and points at the
+postgres path. It is a warning, not an error — an operator running a
+postgres-backed deployment with `LLMTRACE_STORAGE_PROFILE` explicitly
+set to `postgres` will not see it.
+
 ### Cleanup of orphans
 
 The library only deletes UUIDs the caller hands back. If your app loses the

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -14,7 +14,12 @@ proxy:
   port: 8080
   cpu: "4"
   memory: 8Gi
-  replicas: 2
+  # sqlite metadata is per-pod on Basilica — replicas DO NOT share state.
+  # To run replicas > 1, switch LLMTRACE_STORAGE_PROFILE to postgres and
+  # set LLMTRACE_POSTGRES_URL via tenant_secrets_json. Until then,
+  # replicas: 1 is the only correct setting; replicas > 1 will round-robin
+  # to different sqlite files and produce intermittent stale reads.
+  replicas: 1
   health_check_path: /health
   # ML preload (LLMTRACE_ML_ENABLED=1 + LLMTRACE_ML_PRELOAD=1) loads the
   # prompt_injection / ner / injecguard / piguard weights before /health flips

--- a/deployments/basilica/configs/examples/starter.yaml
+++ b/deployments/basilica/configs/examples/starter.yaml
@@ -30,6 +30,11 @@ proxy:
   port: 8080
   cpu: "2"
   memory: 4Gi
+  # sqlite metadata is per-pod on Basilica — replicas DO NOT share state.
+  # To run replicas > 1, switch LLMTRACE_STORAGE_PROFILE to postgres and
+  # set LLMTRACE_POSTGRES_URL via tenant_secrets_json. Until then,
+  # replicas: 1 is the only correct setting; replicas > 1 will round-robin
+  # to different sqlite files and produce intermittent stale reads.
   replicas: 1
   health_check_path: /health
   # ML preload (LLMTRACE_ML_ENABLED=1 + LLMTRACE_ML_PRELOAD=1) loads the

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -86,6 +86,16 @@ ML_PRELOAD_STARTUP_FLOOR_SECONDS = 1500
 # truthiness rules in `crates/llmtrace-proxy/src/config.rs::env_flag`.
 _ML_FLAG_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes"})
 
+# Storage profiles that hold metadata on pod-local disk. Replicas using one
+# of these profiles cannot share state across Basilica pods (no shared
+# volume); `replicas > 1` will round-robin to diverging files. Empty string
+# means "profile not set" which falls through to the sqlite default in the
+# proxy's `StorageConfig::from_env`. See README "Replica count and metadata
+# storage" for the live-reproduced symptom + the postgres-backed fix.
+_UNSHARED_STORAGE_PROFILES: frozenset[str] = frozenset(
+    {"", "sqlite", "lite", "memory"}
+)
+
 # Proxy admin API endpoints (see `crates/llmtrace-proxy/src/main.rs` routing).
 TENANTS_PATH = "/api/v1/tenants"
 AUTH_KEYS_PATH = "/api/v1/auth/keys"
@@ -554,6 +564,39 @@ def _apply_ml_preload_startup_floor(
     return dataclasses.replace(spec, startup_timeout_seconds=floor)
 
 
+def _warn_on_unsharable_replicas(
+    proxy_spec: ComponentSpec, tenant_id: str
+) -> None:
+    """Emit a warning when replicas > 1 with a non-shared metadata profile.
+
+    The proxy's sqlite/memory backends store metadata on the pod's local
+    filesystem. Basilica does not share volumes between replicas, so
+    `replicas > 1` with one of these profiles produces diverging state:
+    bootstrap writes land on one pod, subsequent admin reads round-robin
+    and return stale results from the replicas that never saw the write.
+    See README "Replica count and metadata storage" for the live-repro
+    evidence + the postgres-backed fix.
+
+    Not an error: operators running with `LLMTRACE_STORAGE_PROFILE=postgres`
+    + `LLMTRACE_POSTGRES_URL` legitimately want replicas > 1. The check is
+    a guard rail for the default-sqlite case.
+    """
+    if proxy_spec.replicas <= 1:
+        return
+    profile = proxy_spec.env.get("LLMTRACE_STORAGE_PROFILE", "").strip().lower()
+    if profile not in _UNSHARED_STORAGE_PROFILES:
+        return
+    LOGGER.warning(
+        "tenant=%s proxy.replicas=%d with LLMTRACE_STORAGE_PROFILE=%r — "
+        "replicas WILL diverge because this profile is per-pod. Either "
+        "set replicas=1 or switch to a shared backend (postgres) via "
+        "LLMTRACE_STORAGE_PROFILE + LLMTRACE_POSTGRES_URL.",
+        tenant_id,
+        proxy_spec.replicas,
+        profile or "sqlite (default)",
+    )
+
+
 def _apply_dashboard_admin_username(
     dashboard_spec: ComponentSpec, username: str
 ) -> ComponentSpec:
@@ -852,6 +895,7 @@ def provision(
     if spec.rate_limit is not None:
         proxy_spec = _apply_rate_limit(proxy_spec, spec.rate_limit)
     proxy_spec = _apply_ml_preload_startup_floor(proxy_spec, tenant_id=tenant_id)
+    _warn_on_unsharable_replicas(proxy_spec, tenant_id)
 
     proxy = _create_component(client, proxy_name, proxy_spec)
 

--- a/deployments/basilica/tests/test_replica_metadata_warning.py
+++ b/deployments/basilica/tests/test_replica_metadata_warning.py
@@ -1,0 +1,102 @@
+"""Unit tests for the replica/metadata-profile warning.
+
+`_warn_on_unsharable_replicas` is a pure function on `ComponentSpec`; the
+tests exercise it directly via the real `LOGGER`, captured with the
+standard `unittest.TestCase.assertLogs` context manager (the test-suite
+convention here — see `test_ml_preload_startup_floor.py`). No mocking of
+`LOGGER.warning` — the production logger emits the real record.
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from typing import Mapping
+
+from deployments.basilica import lifecycle
+
+
+def _proxy_spec(
+    *, env: Mapping[str, str], replicas: int
+) -> lifecycle.ComponentSpec:
+    return lifecycle.ComponentSpec(
+        image="ghcr.io/techlab-innov/llmtrace-proxy:latest",
+        port=8080,
+        cpu="2",
+        memory="4Gi",
+        replicas=replicas,
+        env=env,
+    )
+
+
+class ReplicaMetadataWarningTests(unittest.TestCase):
+    def test_no_warning_when_single_replica(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_STORAGE_PROFILE": "sqlite"}, replicas=1
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")
+            lifecycle._warn_on_unsharable_replicas(spec, "acme")
+
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_warning_emitted_for_replicas_two_with_sqlite(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_STORAGE_PROFILE": "sqlite"}, replicas=2
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.WARNING) as captured:
+            lifecycle._warn_on_unsharable_replicas(spec, "acme")
+
+        self.assertEqual(len(captured.records), 1)
+        record = captured.records[0]
+        self.assertEqual(record.levelno, logging.WARNING)
+        message = record.getMessage()
+        self.assertIn("acme", message)
+        self.assertIn("replicas=2", message)
+        self.assertIn("sqlite", message)
+        self.assertIn("postgres", message)
+        self.assertIn("diverge", message)
+
+    def test_no_warning_when_replicas_two_with_postgres(self) -> None:
+        spec = _proxy_spec(
+            env={"LLMTRACE_STORAGE_PROFILE": "postgres"}, replicas=2
+        )
+        with self.assertLogs(lifecycle.LOGGER, level=logging.DEBUG) as captured:
+            lifecycle.LOGGER.debug("anchor")
+            lifecycle._warn_on_unsharable_replicas(spec, "acme")
+
+        warnings = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_warning_when_profile_missing_falls_back_to_sqlite_default(
+        self,
+    ) -> None:
+        # Empty / missing profile resolves to sqlite at the proxy. The
+        # message must surface that explicitly so the operator knows
+        # what's happening.
+        spec = _proxy_spec(env={}, replicas=3)
+        with self.assertLogs(lifecycle.LOGGER, level=logging.WARNING) as captured:
+            lifecycle._warn_on_unsharable_replicas(spec, "acme")
+
+        self.assertEqual(len(captured.records), 1)
+        message = captured.records[0].getMessage()
+        self.assertIn("sqlite (default)", message)
+        self.assertIn("replicas=3", message)
+
+    def test_warning_recognises_lite_and_memory_profiles(self) -> None:
+        for profile in ("lite", "memory", "SQLITE", "Memory"):
+            with self.subTest(profile=profile):
+                spec = _proxy_spec(
+                    env={"LLMTRACE_STORAGE_PROFILE": profile}, replicas=2
+                )
+                with self.assertLogs(
+                    lifecycle.LOGGER, level=logging.WARNING
+                ) as captured:
+                    lifecycle._warn_on_unsharable_replicas(spec, "acme")
+
+                self.assertEqual(len(captured.records), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`pro.yaml` ships `replicas: 2` with sqlite metadata, but Basilica does not share volumes between pods — each replica holds its own sqlite file. Round-robin routing produces a ~30% empty-response rate on `/api/v1/tenants` and other admin endpoints.

Live-reproduced 2026-05-26 against `:sha-ecf142e` with the previous `pro.yaml`, 10 rapid `/api/v1/tenants` calls (quoted from #275):

```
attempt 1: HTTP 200, tenant count=0
attempt 2: HTTP 200, tenant count=1
attempt 3: HTTP 200, tenant count=1
attempt 4: HTTP 200, tenant count=1
attempt 5: HTTP 200, tenant count=1
attempt 6: HTTP 200, tenant count=0
attempt 7: HTTP 200, tenant count=1
attempt 8: HTTP 200, tenant count=0
attempt 9: HTTP 200, tenant count=1
attempt 10: HTTP 200, tenant count=1
```

3/10 empty — matches the 1-of-2-replicas-holding-the-row routing odds.

## Per-file changes

- `deployments/basilica/configs/examples/pro.yaml` — `replicas: 2` → `replicas: 1`; inline comment documenting the per-pod-sqlite constraint and the postgres path for replicas > 1.
- `deployments/basilica/configs/examples/starter.yaml` — `replicas: 1` already correct; added the same explanatory comment for symmetry.
- `deployments/basilica/lifecycle.py` — new `_warn_on_unsharable_replicas(proxy_spec, tenant_id)` helper called from `provision()` after env resolution (after `_apply_ml_preload_startup_floor`, before `_create_component`). Emits `LOGGER.warning` when `replicas > 1` combined with `LLMTRACE_STORAGE_PROFILE in {"", "sqlite", "lite", "memory"}`. Warning, not error: postgres-backed deployments legitimately want replicas > 1.
- `deployments/basilica/README.md` — new "Replica count and metadata storage" subsection under "Operational notes" with the 30% live-repro evidence + the postgres remediation path.
- `deployments/basilica/tests/test_replica_metadata_warning.py` — 5 unit cases: replicas=1 (no warning), replicas=2+sqlite (warning + asserts on message contents), replicas=2+postgres (no warning), replicas=3+missing-profile (warning surfaces `sqlite (default)`), replicas=2+{lite,memory,SQLITE,Memory} (warning, case-insensitive). Uses `assertLogs` against the real `lifecycle.LOGGER` — no mocking of `LOGGER.warning`.

## Validation evidence

```text
$ python3 -m py_compile deployments/basilica/lifecycle.py deployments/basilica/cli.py deployments/basilica/tests/*.py
OK_COMPILE
$ python3 -c "import yaml; yaml.safe_load(open('deployments/basilica/configs/examples/pro.yaml')); yaml.safe_load(open('deployments/basilica/configs/examples/starter.yaml'))"
OK_YAML
```

All 5 new tests pass when run via `unittest` with the basilica SDK stub from `conftest.py` installed:

```
test_no_warning_when_replicas_two_with_postgres ... ok
test_no_warning_when_single_replica ... ok
test_warning_emitted_for_replicas_two_with_sqlite ... ok
test_warning_recognises_lite_and_memory_profiles ... ok
test_warning_when_profile_missing_falls_back_to_sqlite_default ... ok
Ran 5 tests in 0.006s
OK
```

Full local basilica suite passes apart from 2 pre-existing failures in `test_rotate_admin_key.ProvisionWithRotateAfterBootstrapTests` (`test_rotation_runs_when_flag_on`, `test_no_rotation_when_flag_off`) that error on outbound DNS — both reproduce on `main` (pre-this-PR) and are unrelated to this change.

Live e2e of the 20-rapid-calls assertion will be run by the maintainer post-merge.

## Test plan

- [x] `python3 -m py_compile` on all touched Python sources
- [x] YAML safe-load of both example configs
- [x] `unittest` run of the 5 new cases — all pass
- [x] Full basilica `unittest` run — only pre-existing DNS errors fail
- [ ] Maintainer: live e2e — provision a fresh tenant with the updated `pro.yaml`, hit `/api/v1/tenants` 20 times; all 20 should return the same tenant