### PR TITLE
security(proxy): substitute upstream provider key on forward (closes #274)

### DIFF
--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -587,6 +587,97 @@ fn build_upstream_url(config: &ProxyConfig, path: &str, query: Option<&str>) -> 
     }
 }
 
+/// Env-var name for the OpenAI upstream provider key.
+pub(crate) const OPENAI_UPSTREAM_API_KEY_ENV: &str = "OPENAI_API_KEY";
+/// Env-var name for the Anthropic upstream provider key.
+pub(crate) const ANTHROPIC_UPSTREAM_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
+/// Pinned Anthropic Messages API version sent alongside `x-api-key`.
+pub(crate) const ANTHROPIC_VERSION_HEADER_VALUE: &str = "2023-06-01";
+
+/// Extra headers (beyond the primary credential) to inject on the upstream
+/// request. Used today for provider-specific protocol headers such as
+/// Anthropic's mandatory `anthropic-version`.
+pub(crate) fn upstream_extra_headers(
+    provider: &LLMProvider,
+) -> Vec<(reqwest::header::HeaderName, reqwest::header::HeaderValue)> {
+    match provider {
+        LLMProvider::Anthropic => vec![(
+            reqwest::header::HeaderName::from_static("anthropic-version"),
+            reqwest::header::HeaderValue::from_static(ANTHROPIC_VERSION_HEADER_VALUE),
+        )],
+        _ => Vec::new(),
+    }
+}
+
+/// Resolve the upstream credential header for the detected provider.
+///
+/// Returns `Some((header_name, header_value))` when the matching env var is
+/// set; returns `None` (with a `tracing::warn!`) when the var is missing/empty
+/// or when the provider has no known credential convention. The caller is
+/// expected to skip inserting any `Authorization` header in the `None` case so
+/// the upstream surfaces its own 401.
+pub(crate) fn upstream_auth_for(
+    provider: &LLMProvider,
+) -> Option<(reqwest::header::HeaderName, reqwest::header::HeaderValue)> {
+    let (env_var, header_name, value_fmt): (&str, reqwest::header::HeaderName, fn(&str) -> String) =
+        match provider {
+            LLMProvider::OpenAI
+            | LLMProvider::AzureOpenAI
+            | LLMProvider::VLLm
+            | LLMProvider::SGLang
+            | LLMProvider::TGI => (
+                OPENAI_UPSTREAM_API_KEY_ENV,
+                reqwest::header::AUTHORIZATION,
+                |k: &str| format!("Bearer {k}"),
+            ),
+            LLMProvider::Anthropic => (
+                ANTHROPIC_UPSTREAM_API_KEY_ENV,
+                reqwest::header::HeaderName::from_static("x-api-key"),
+                |k: &str| k.to_string(),
+            ),
+            LLMProvider::Ollama => {
+                // Ollama is unauthenticated by default; forward with no creds.
+                return None;
+            }
+            LLMProvider::Bedrock => {
+                // AWS SigV4 — out of scope for env-var substitution.
+                warn!(
+                    "no upstream credential substitution implemented for Bedrock; \
+                     forwarding without Authorization (upstream will reject)"
+                );
+                return None;
+            }
+            LLMProvider::Custom(name) => {
+                warn!(
+                    provider = %name,
+                    "no upstream credential substitution implemented for custom provider; \
+                     forwarding without Authorization (upstream will reject)"
+                );
+                return None;
+            }
+        };
+
+    match std::env::var(env_var) {
+        Ok(raw) if !raw.is_empty() => {
+            match reqwest::header::HeaderValue::from_str(&value_fmt(&raw)) {
+                Ok(hv) => Some((header_name, hv)),
+                Err(e) => {
+                    warn!(env = env_var, error = %e, "upstream credential is not a valid HTTP header value; forwarding without Authorization");
+                    None
+                }
+            }
+        }
+        _ => {
+            warn!(
+                env = env_var,
+                "upstream provider API key env var is unset or empty; \
+                 forwarding without Authorization (upstream will reject)"
+            );
+            None
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Main proxy handler
 // ---------------------------------------------------------------------------
@@ -1065,9 +1156,14 @@ pub async fn proxy_handler(
     // trace capture; reqwest does not enable auto-decompression).
     // When boundary defense is active, also strip `Content-Length` because the
     // body size has changed; reqwest will set it from the new body.
+    //
+    // Security (issue #274): always strip the incoming `Authorization` header
+    // here. It was the tenant-facing LLMTrace bearer (e.g. `llmt_…`) and must
+    // NEVER reach the upstream provider. The correct provider credential is
+    // injected below from `upstream_auth_for(&detected_provider)`.
     let mut forwarded_headers = reqwest::header::HeaderMap::new();
     for (name, value) in headers.iter() {
-        if name == "host" || name == "accept-encoding" {
+        if name == "host" || name == "accept-encoding" || name == "authorization" {
             continue;
         }
         if body_was_rewritten && name == "content-length" {
@@ -1079,6 +1175,18 @@ pub async fn proxy_handler(
             }
         }
     }
+
+    // Substitute the configured upstream provider credential. When the env
+    // var is unset we deliberately forward with NO Authorization header so
+    // the upstream returns its own 401, which surfaces the gap as an
+    // operator-actionable signal rather than a silent 5xx.
+    if let Some((auth_name, auth_value)) = upstream_auth_for(&detected_provider) {
+        forwarded_headers.insert(auth_name, auth_value);
+    }
+    for (extra_name, extra_value) in upstream_extra_headers(&detected_provider) {
+        forwarded_headers.insert(extra_name, extra_value);
+    }
+
     upstream_req = upstream_req.headers(forwarded_headers);
 
     // Forward the modified body whenever any defence in the chain

--- a/crates/llmtrace-proxy/tests/integration_test.rs
+++ b/crates/llmtrace-proxy/tests/integration_test.rs
@@ -1503,3 +1503,299 @@ async fn test_v1_forward_viewer_role_forbidden() {
         "403 body must surface the standard require_role message; got: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #274 — proxy MUST substitute the upstream provider credential and
+// MUST NEVER forward the tenant's `llmt_…` bearer to the upstream.
+// ---------------------------------------------------------------------------
+
+/// Snapshot of inbound headers captured by the credential-substitution mock
+/// upstream. Tests assert directly on this shape.
+#[derive(Debug, Clone, Default)]
+struct CapturedRequest {
+    authorization: Option<String>,
+    x_api_key: Option<String>,
+    anthropic_version: Option<String>,
+}
+
+/// Record the relevant inbound headers and return a canned OpenAI-shaped 200.
+/// Pulled out of `credential_capture_upstream` so two route handlers can
+/// share it without juggling closure-clonability.
+async fn capture_and_respond(
+    store: Arc<Mutex<Vec<CapturedRequest>>>,
+    headers: axum::http::HeaderMap,
+) -> axum::response::Response<Body> {
+    let snapshot = CapturedRequest {
+        authorization: headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string),
+        x_api_key: headers
+            .get("x-api-key")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string),
+        anthropic_version: headers
+            .get("anthropic-version")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string),
+    };
+    store.lock().await.push(snapshot);
+    axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "model": "gpt-4",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            }))
+            .unwrap(),
+        ))
+        .unwrap()
+}
+
+/// Mock upstream that records the inbound `Authorization`, `x-api-key`, and
+/// `anthropic-version` headers on each request, then returns a generic
+/// OpenAI-shaped 200 (the body content is not under test here — only the
+/// inbound auth surface is).
+async fn credential_capture_upstream() -> (String, Arc<Mutex<Vec<CapturedRequest>>>) {
+    let captured: Arc<Mutex<Vec<CapturedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let store = Arc::clone(&captured);
+
+    let store_a = Arc::clone(&store);
+    let handler_a = move |headers: axum::http::HeaderMap, _body: axum::body::Bytes| {
+        let store = Arc::clone(&store_a);
+        capture_and_respond(store, headers)
+    };
+    let store_b = Arc::clone(&store);
+    let handler_b = move |headers: axum::http::HeaderMap, _body: axum::body::Bytes| {
+        let store = Arc::clone(&store_b);
+        capture_and_respond(store, headers)
+    };
+
+    let app = Router::new()
+        .route("/v1/chat/completions", post(handler_a))
+        .route("/v1/messages", post(handler_b));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let _handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (format!("http://{addr}"), captured)
+}
+
+/// Serializes env-var mutation across the credential-substitution tests so
+/// they do not race when `cargo test` runs them in parallel.
+fn env_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+/// RAII guard that snapshots and restores a list of env vars. Holds the
+/// global env lock for its entire lifetime so concurrent tests cannot
+/// observe interleaved mutations. Passing `None` for a value removes the
+/// var.
+struct EnvVarGuard {
+    prev: Vec<(&'static str, Option<String>)>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl EnvVarGuard {
+    fn set(entries: &[(&'static str, Option<&str>)]) -> Self {
+        let lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let mut prev = Vec::with_capacity(entries.len());
+        for (key, value) in entries {
+            prev.push((*key, std::env::var(key).ok()));
+            // SAFETY: env mutation is serialized by `env_lock`.
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        Self { prev, _lock: lock }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for (key, prior) in &self.prev {
+            // SAFETY: still holding `env_lock`; restore prior state.
+            unsafe {
+                match prior {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_upstream_credential_substitution_openai() {
+    let _env = EnvVarGuard::set(&[
+        ("OPENAI_API_KEY", Some("sk-fake-openai")),
+        ("ANTHROPIC_API_KEY", None),
+    ]);
+
+    let (upstream_url, captured) = credential_capture_upstream().await;
+    let (state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
+    let operator_key = seed_role_key(&state, llmtrace_core::ApiKeyRole::Operator).await;
+
+    let req = Request::post("/v1/chat/completions")
+        .header("authorization", format!("Bearer {operator_key}"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "operator-authenticated /v1/chat/completions must round-trip 200"
+    );
+
+    let recorded = captured.lock().await;
+    assert_eq!(
+        recorded.len(),
+        1,
+        "mock upstream must have received exactly one forwarded request"
+    );
+    let inbound = &recorded[0];
+
+    assert_eq!(
+        inbound.authorization.as_deref(),
+        Some("Bearer sk-fake-openai"),
+        "upstream must see the OpenAI provider key, not the tenant bearer"
+    );
+    let auth = inbound.authorization.clone().unwrap_or_default();
+    assert!(
+        !auth.contains("llmt_"),
+        "tenant `llmt_*` key must NEVER leak to upstream; got: {auth}"
+    );
+    assert!(
+        !auth.contains(&operator_key),
+        "tenant operator key must NEVER leak to upstream; got: {auth}"
+    );
+}
+
+#[tokio::test]
+async fn test_upstream_credential_substitution_anthropic() {
+    let _env = EnvVarGuard::set(&[
+        ("ANTHROPIC_API_KEY", Some("sk-ant-fake")),
+        ("OPENAI_API_KEY", None),
+    ]);
+
+    let (upstream_url, captured) = credential_capture_upstream().await;
+    // Build with an Anthropic-looking upstream so detect_provider routes to
+    // Anthropic via path (/v1/messages). The hostname in `upstream_url` is
+    // 127.0.0.1 — detect_provider's path rule at /v1/messages still fires.
+    let (state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
+    let operator_key = seed_role_key(&state, llmtrace_core::ApiKeyRole::Operator).await;
+
+    let req = Request::post("/v1/messages")
+        .header("authorization", format!("Bearer {operator_key}"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "claude-3-sonnet",
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "operator-authenticated /v1/messages must round-trip 200"
+    );
+
+    let recorded = captured.lock().await;
+    assert_eq!(
+        recorded.len(),
+        1,
+        "mock upstream must have captured one request"
+    );
+    let inbound = &recorded[0];
+
+    assert_eq!(
+        inbound.x_api_key.as_deref(),
+        Some("sk-ant-fake"),
+        "Anthropic upstream must see x-api-key set to the configured key"
+    );
+    assert_eq!(
+        inbound.anthropic_version.as_deref(),
+        Some("2023-06-01"),
+        "Anthropic upstream must see the pinned anthropic-version header"
+    );
+    assert!(
+        inbound.authorization.is_none(),
+        "Anthropic upstream must NOT receive any Authorization header; got: {:?}",
+        inbound.authorization
+    );
+}
+
+#[tokio::test]
+async fn test_upstream_no_credential_when_env_missing() {
+    let _env = EnvVarGuard::set(&[("OPENAI_API_KEY", None), ("ANTHROPIC_API_KEY", None)]);
+
+    let (upstream_url, captured) = credential_capture_upstream().await;
+    let (state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
+    let operator_key = seed_role_key(&state, llmtrace_core::ApiKeyRole::Operator).await;
+
+    let req = Request::post("/v1/chat/completions")
+        .header("authorization", format!("Bearer {operator_key}"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "missing OPENAI_API_KEY must still produce a 2xx (mock returns 200); \
+         the proxy must NOT 5xx when env var is unset"
+    );
+
+    let recorded = captured.lock().await;
+    assert_eq!(
+        recorded.len(),
+        1,
+        "mock upstream must have captured one request"
+    );
+    let inbound = &recorded[0];
+
+    assert!(
+        inbound.authorization.is_none(),
+        "with no upstream credential configured, mock MUST see no Authorization; got: {:?}",
+        inbound.authorization
+    );
+    assert!(
+        inbound.x_api_key.is_none(),
+        "with no upstream credential configured, mock MUST see no x-api-key; got: {:?}",
+        inbound.x_api_key
+    );
+}


### PR DESCRIPTION
Closes #274.

## Summary
The catch-all `/v1/*` forwarder (`proxy_handler` in `crates/llmtrace-proxy/src/proxy.rs`) was copying every incoming header to the upstream verbatim, including the tenant's `llmt_...` LLMTrace bearer. Upstream providers (OpenAI / Anthropic / etc.) then rejected the request with their own 401 because that bearer is not a provider key.

This PR strips the incoming `Authorization` header in the forward loop and substitutes the right credential based on the already-detected `LLMProvider`.

## Per-file changes

### `crates/llmtrace-proxy/src/proxy.rs`
- New `pub(crate) const`s: `OPENAI_UPSTREAM_API_KEY_ENV = "OPENAI_API_KEY"`, `ANTHROPIC_UPSTREAM_API_KEY_ENV = "ANTHROPIC_API_KEY"`, `ANTHROPIC_VERSION_HEADER_VALUE = "2023-06-01"`.
- New `pub(crate) fn upstream_auth_for(provider: &LLMProvider) -> Option<(HeaderName, HeaderValue)>` resolves the env-var-backed upstream credential.
- New `pub(crate) fn upstream_extra_headers(provider: &LLMProvider)` returns provider-specific extras (today: Anthropic's `anthropic-version: 2023-06-01`).
- `proxy_handler` forward loop now skips `authorization` in addition to `host` / `accept-encoding` / conditional `content-length`. After the loop, it inserts the substituted credential + extras when `upstream_auth_for` returns `Some`. When the env var is unset/empty the handler intentionally forwards without an `Authorization` header so the upstream surfaces its own 401, never a silent 5xx.

Provider mapping:
- `OpenAI` / `AzureOpenAI` / `VLLm` / `SGLang` / `TGI` -> `Authorization: Bearer $OPENAI_API_KEY`.
- `Anthropic` -> `x-api-key: $ANTHROPIC_API_KEY` + `anthropic-version: 2023-06-01`. No `Authorization`.
- `Ollama` -> pass through unauthenticated (default deployment shape).
- `Bedrock` -> `tracing::warn!` and forward with no auth (AWS SigV4 is out of scope for env-var substitution).
- `Custom(_)` -> `tracing::warn!` and forward with no auth.

### `crates/llmtrace-proxy/tests/integration_test.rs`
- New `CapturedRequest` struct + `capture_and_respond` helper + `credential_capture_upstream` mock that records inbound `Authorization` / `x-api-key` / `anthropic-version` headers and returns a canned 200 OpenAI-shaped body.
- New `EnvVarGuard` RAII type backed by a `OnceLock<Mutex<()>>` serializes env-var mutation across the three new tests so they do not race under parallel `cargo test`.
- Three new integration tests against the real Axum stack + auth-enabled proxy + real TCP mock upstream:
  - `test_upstream_credential_substitution_openai` — sets `OPENAI_API_KEY=sk-fake-openai`, POSTs `/v1/chat/completions` with `Authorization: Bearer <operator_key>`. Asserts mock received `Authorization: Bearer sk-fake-openai` AND did NOT receive `llmt_*` AND did NOT receive the operator key value.
  - `test_upstream_credential_substitution_anthropic` — sets `ANTHROPIC_API_KEY=sk-ant-fake`, POSTs `/v1/messages` (detected as Anthropic by path). Asserts mock received `x-api-key: sk-ant-fake` AND `anthropic-version: 2023-06-01` AND NO `Authorization` header at all.
  - `test_upstream_no_credential_when_env_missing` — clears both env vars, POSTs `/v1/chat/completions`. Asserts the proxy still returns 2xx and the mock saw neither `Authorization` nor `x-api-key`.

## Validation evidence

### `cargo fmt --all -- --check`

```
(no output — clean)
```
Exit 0 (`FMT CLEAN` echoed by wrapper).

### `cargo build -p llmtrace`

```
   Compiling llmtrace v0.2.0 (...crates/llmtrace-proxy)
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 02s
```

### `cargo test -p llmtrace --tests`

Three suites, all green:

- lib tests: `test result: ok. 608 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 13.05s`
- bin `llmtrace-proxy` tests: `test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 33.80s`
- `tests/integration_test.rs`: `test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.82s`

The three new tests are inside the integration test summary above. Direct re-run targeting just the new tests:

```
running 3 tests
test test_upstream_no_credential_when_env_missing ... ok
test test_upstream_credential_substitution_openai ... ok
test test_upstream_credential_substitution_anthropic ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 2.98s
```

### `cargo clippy -p llmtrace -- -D warnings`

```
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 30s
```
No warnings / no errors against the library target.

Note: `cargo clippy -p llmtrace --tests -- -D warnings` surfaces a handful of pre-existing lints in `tests/integration_test.rs` (e.g. `type_complexity` at line 644 in `capturing_upstream`, unchanged in this PR) and in `crates/llmtrace-proxy/src/main.rs` (`await_holding_lock`, unchanged in this PR). All lints in code paths added by this PR are clean.

## What is NOT live-validated

The live Basilica round-trip (real OpenAI / Anthropic upstream, real tenant operator key minted via the deployed control plane) has not been executed from this worktree — it requires maintainer-only credentials and access to the deployed `:sha-<merge>` image. The integration tests above prove the in-process forwarding behavior end-to-end against a real Axum mock upstream; the live confirmation that the upstream provider now responds 200 (no more `Incorrect API key provided: llmt_...`) needs to be done by the maintainer after merge + publish-images.