### PR TITLE
feat(dashboard): move API endpoints reference to its own /api-docs page (closes #281)

### DIFF
--- a/dashboard/e2e/api-docs.spec.ts
+++ b/dashboard/e2e/api-docs.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Smoke test for the dedicated /api-docs page (issue #281).
+//
+// Asserts:
+//   1. Authenticated GET /api-docs returns 200 and renders the heading.
+//   2. The sidebar exposes an "API Docs" link pointing at /api-docs.
+//   3. /settings no longer embeds a Swagger UI iframe but does cross-link to
+//      the new page.
+//
+// CI runs the dashboard with `LLMTRACE_DASHBOARD_AUTH_DISABLED=1` so the
+// middleware short-circuits — same regime exercised by other e2e specs.
+// We still POST through /api/auth/login to mirror auth-login.spec.ts so the
+// test is portable to environments where auth is enabled.
+// ---------------------------------------------------------------------------
+
+const PROXY_BASE = process.env.LLMTRACE_PROXY_URL ?? "http://127.0.0.1:8081";
+
+test.describe("API Docs page (issue #281)", () => {
+  test.beforeAll(async ({ request }, testInfo) => {
+    testInfo.setTimeout(120_000);
+    const deadline = Date.now() + 120_000;
+    while (true) {
+      try {
+        const res = await request.get(`${PROXY_BASE}/health`);
+        if (res.ok()) return;
+      } catch {
+        // ignore — keep polling
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`Proxy not healthy at ${PROXY_BASE}/health`);
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  });
+
+  test.beforeEach(async ({ request }) => {
+    // Mirror auth-login.spec.ts: fetch the seeded username, then login. The
+    // CI proxy accepts any bearer (no admin_key configured) so any non-empty
+    // value passes upstream validation.
+    const identityRes = await request.get("/api/auth/identity");
+    const identity = (await identityRes.json()) as { username: string };
+    const loginRes = await request.post("/api/auth/login", {
+      data: { username: identity.username, admin_key: "test-key-for-ci-stack" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(loginRes.status(), `login failed: ${await loginRes.text()}`).toBe(200);
+  });
+
+  test("/api-docs renders 200 with the API Endpoints heading", async ({ page }) => {
+    const response = await page.goto("/api-docs");
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading", { name: "API Endpoints", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("sidebar exposes API Docs link", async ({ page }) => {
+    await page.goto("/api-docs");
+    const link = page.locator("aside").getByRole("link", { name: "API Docs" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/api-docs");
+  });
+
+  test("/settings no longer embeds Swagger UI and links to /api-docs", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(
+      page.getByRole("heading", { name: "Settings", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Iframe pointing at swagger-ui must be removed.
+    await expect(page.locator('iframe[src*="swagger-ui"]')).toHaveCount(0);
+
+    // Cross-link to the new home must be present.
+    const crossLink = page.locator("main").getByRole("link", { name: "/api-docs" });
+    await expect(crossLink).toBeVisible();
+    await expect(crossLink).toHaveAttribute("href", "/api-docs");
+  });
+});

--- a/dashboard/e2e/feature-gaps.spec.ts
+++ b/dashboard/e2e/feature-gaps.spec.ts
@@ -30,9 +30,18 @@ test.describe("Dashboard Coverage Gaps", () => {
     createdTenantIds = [];
   });
 
-  test("Settings: should embed Swagger UI and expose API doc links", async ({ page }) => {
+  test("API Docs: dedicated page embeds Swagger UI and exposes API doc links", async ({ page }) => {
+    // Issue #281 moved the Swagger UI surface from /settings to its own
+    // /api-docs page. The /settings page now only cross-links to it.
     await page.goto("/settings");
     await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible();
+    await expect(page.locator('iframe[title="LLMTrace Swagger UI"]')).toHaveCount(0);
+    const crossLink = page.locator("main").getByRole("link", { name: "/api-docs" });
+    await expect(crossLink).toBeVisible();
+    await expect(crossLink).toHaveAttribute("href", "/api-docs");
+
+    await page.goto("/api-docs");
+    await expect(page.getByRole("heading", { name: "API Endpoints", exact: true })).toBeVisible();
 
     const swaggerLink = page.getByRole("link", { name: "Open Swagger UI" });
     const openApiLink = page.getByRole("link", { name: "Open OpenAPI JSON" });

--- a/dashboard/src/app/api-docs/page.tsx
+++ b/dashboard/src/app/api-docs/page.tsx
@@ -1,0 +1,60 @@
+import { ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+const SWAGGER_UI_URL = "/api/proxy/swagger-ui/";
+const OPENAPI_JSON_URL = "/api/proxy/api-doc/openapi.json";
+
+export default function ApiDocsPage() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">API Endpoints</h1>
+        <p className="text-sm text-muted-foreground">
+          Interactive OpenAPI documentation served by the LLMTrace proxy. Use the operator
+          API key when calling endpoints from your own apps; see the Tenants page for how to
+          obtain one.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Swagger UI</CardTitle>
+          <CardDescription>
+            Embedded Swagger UI rendered from the proxy&apos;s OpenAPI document.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <a href={SWAGGER_UI_URL} target="_blank" rel="noreferrer">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Open Swagger UI
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <a href={OPENAPI_JSON_URL} target="_blank" rel="noreferrer">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                Open OpenAPI JSON
+              </a>
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Served via dashboard proxy routes
+            </span>
+          </div>
+
+          <div className="rounded-md border">
+            <iframe
+              title="LLMTrace Swagger UI"
+              src={SWAGGER_UI_URL}
+              data-testid="api-docs-swagger-iframe"
+              className="h-[70vh] w-full rounded-md"
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/src/app/settings/settings-client.tsx
+++ b/dashboard/src/app/settings/settings-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { RefreshCw, CheckCircle, XCircle, ExternalLink, Copy, Check } from "lucide-react";
+import Link from "next/link";
+import { RefreshCw, CheckCircle, XCircle, Copy, Check } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -215,8 +216,6 @@ export default function SettingsClient({ proxyUrl }: SettingsClientProps) {
   const [upstream, setUpstream] = useState<UpstreamUrlState>({ status: "loading" });
   const [loading, setLoading] = useState(false);
   const [configLoading, setConfigLoading] = useState(false);
-  const swaggerUiUrl = "/api/proxy/swagger-ui/";
-  const openApiJsonUrl = "/api/proxy/api-doc/openapi.json";
 
   async function checkHealth(): Promise<void> {
     console.log("[Settings] Checking health via API helper...");
@@ -374,42 +373,14 @@ export default function SettingsClient({ proxyUrl }: SettingsClientProps) {
         </CardContent>
       </Card>
 
-      {/* API Endpoints Reference */}
+      {/* API Endpoints moved to /api-docs */}
       <Card>
-        <CardHeader>
-          <CardTitle className="text-base">API Endpoints</CardTitle>
-          <CardDescription>
-            Interactive Swagger UI served by the LLMTrace proxy.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <Button asChild variant="outline" size="sm">
-                <a href={swaggerUiUrl} target="_blank" rel="noreferrer">
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  Open Swagger UI
-                </a>
-              </Button>
-              <Button asChild variant="outline" size="sm">
-                <a href={openApiJsonUrl} target="_blank" rel="noreferrer">
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  Open OpenAPI JSON
-                </a>
-              </Button>
-              <span className="text-xs text-muted-foreground">
-                Served via dashboard proxy routes
-              </span>
-            </div>
-
-            <div className="rounded-md border">
-              <iframe
-                title="LLMTrace Swagger UI"
-                src={swaggerUiUrl}
-                className="h-[70vh] w-full rounded-md"
-              />
-            </div>
-          </div>
+        <CardContent className="py-4 text-sm">
+          API endpoints reference moved to{" "}
+          <Link href="/api-docs" className="underline">
+            /api-docs
+          </Link>
+          .
         </CardContent>
       </Card>
     </div>

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   BookOpen,
   Gauge,
   ScrollText,
+  Code,
   LogOut,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -29,6 +30,7 @@ const navItems = [
   { href: "/tenants", label: "Tenants", icon: Users },
   { href: "/compliance", label: "Compliance", icon: FileCheck },
   { href: "/status", label: "Status", icon: Gauge },
+  { href: "/api-docs", label: "API Docs", icon: Code },
   { href: "/guide", label: "Guide", icon: BookOpen },
   { href: "/settings", label: "Settings", icon: Settings },
 ];


### PR DESCRIPTION
## Summary

Promotes the Swagger UI surface out of `/settings` and into a dedicated top-level `/api-docs` route, reachable directly from the sidebar.

Closes #281.

## Per-file changes

- **`dashboard/src/app/api-docs/page.tsx`** (new, server component): renders `<h1>API Endpoints</h1>` + the lead paragraph from the issue spec, two `Button asChild` link buttons ("Open Swagger UI" -> `/api/proxy/swagger-ui/`, "Open OpenAPI JSON" -> `/api/proxy/api-doc/openapi.json`, both `target="_blank"`), and a full-height iframe (`h-[70vh] w-full`) mirroring the sizing of the card it replaces. Reuses the existing `Button` and `Card` patterns from `settings-client.tsx`.
- **`dashboard/src/components/sidebar.tsx`**: adds `{ href: "/api-docs", label: "API Docs", icon: Code }` between `Status` and `Guide`. `Code` is imported from `lucide-react` (verified it is exported; the icon-import block in this file grows by one entry).
- **`dashboard/src/app/settings/settings-client.tsx`**: drops the entire `<Card>` block containing the Swagger UI iframe + the two link buttons. Replaces it with the one-line cross-link card from the spec (`API endpoints reference moved to /api-docs.`). Adds `import Link from "next/link"`. Removes now-unused `ExternalLink` import and the `swaggerUiUrl`/`openApiJsonUrl` locals.
- **`dashboard/e2e/api-docs.spec.ts`** (new): authenticates via `POST /api/auth/login` (mirroring `auth-login.spec.ts`) and asserts:
  1. `/api-docs` returns 200 and the `API Endpoints` heading is visible.
  2. The sidebar exposes a link with name `API Docs` whose `href` is `/api-docs`.
  3. `/settings` no longer renders an `iframe[src*=\"swagger-ui\"]` (count == 0) and contains a visible link to `/api-docs`.

## Choices

- **Icon**: `Code` (lucide-react). The issue listed `Code`, `BookMarked`, and `Webhook` as acceptable; `Code` matches the API-surface intent most directly.
- **Sidebar position**: between `Status` and `Guide`. The issue offered this slot or between `Audit` and `Settings`; the chosen slot groups it with operator-facing tooling (Status, Guide) and keeps Settings as the trailing terminal entry.

## Validation evidence

Run locally inside `dashboard/`:

- `npm run lint` -> clean. No new warnings/errors introduced (the three pre-existing warnings in `compliance`, `guide`, `traces` are unchanged).
- `npm run build` -> success. Build output lists the new dynamic route:
  ```
  ƒ /api-docs                              147 B         102 kB
  ```
  All 18 pages generated, no type errors.
- Playwright suite runs against the real CI stack (dockerised proxy + dashboard) on every PR via the `e2e` job in `.github/workflows/ci.yml`; the new spec follows the same auth pattern as `auth-login.spec.ts` and hits real routes.

## Out of scope / unvalidated

- I have not run the Playwright suite locally (no live proxy stack in this worktree); the spec is structured exactly like the existing ones and CI will execute it against the docker-compose stack. CI status will be reported below.

## Test plan

- [ ] CI `lint` job green
- [ ] CI `build` job green
- [ ] CI `e2e` job green (executes `e2e/api-docs.spec.ts` along with existing specs)