### PR TITLE
fix(dashboard): /metrics is authenticated — remove from public allow-list (closes #280)

### DIFF
--- a/dashboard/e2e/public-paths.spec.ts
+++ b/dashboard/e2e/public-paths.spec.ts
@@ -1,32 +1,52 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type APIRequestContext } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // Public-path consistency between `middleware.ts` and
-// `proxy-helpers.ts::buildHeaders` (issue #276).
+// `proxy-helpers.ts::buildHeaders` (issues #276, #280).
 //
-// Pre-fix, the middleware allow-listed `/api/proxy/api-doc`, `/metrics`,
-// `/health`, etc. but `buildHeaders` rejected them with 401 when no
-// Authorization header arrived. Result: Swagger UI iframe on `/settings`
-// 401'd; `/status` could not render `/metrics`.
+// History:
+//   - #276: middleware and `buildHeaders` disagreed on which paths are
+//     genuinely public. Spec consolidated them via `UPSTREAM_PUBLIC_PATHS`.
+//   - #280: #276 incorrectly listed `/metrics` as public. The proxy's
+//     auth-middleware (`crates/llmtrace-proxy/src/auth.rs`) only exempts
+//     `/health`, `/swagger-ui`, `/api-doc`. Per R10, `/metrics` requires
+//     a bearer. We removed `/metrics` from `UPSTREAM_PUBLIC_PATHS` and
+//     the dashboard now injects the session cookie as Bearer when
+//     forwarding to the proxy.
 //
 // These tests run against the live stack (the dashboard talks to the real
 // proxy on `LLMTRACE_PROXY_URL`) and never short-circuit through Playwright
 // `page.route` mocks — the proof must come from the real wire response.
 //
-// Note on CI: the CI dashboard runs with `LLMTRACE_DASHBOARD_AUTH_DISABLED=1`
-// so the middleware short-circuits. That is fine for the public-path
-// assertions below — every assertion below should hold REGARDLESS of
-// whether the dashboard auth gate is enforcing or disabled. The regression
-// test for admin-path gating is therefore scoped to "still proxies
-// successfully" (no 5xx, no `auth_required` body leak) under the CI auth-
-// disabled configuration. A maintainer-run live Basilica smoke covers the
-// authenticated branch separately, mirroring the pattern used by
-// `auth-login.spec.ts`.
+// CI environment note: the CI dashboard runs with
+// `LLMTRACE_DASHBOARD_AUTH_DISABLED=1` AND the CI proxy runs with
+// `auth.enabled = false` (no admin_key configured). So both layers are
+// permissive in CI. Tests therefore assert the contract shape that
+// holds across both modes — see per-test comments. The maintainer-run
+// live Basilica smoke covers the auth-enforced branch separately,
+// mirroring the pattern used by `auth-login.spec.ts`.
 // ---------------------------------------------------------------------------
 
 const PROXY_BASE = process.env.LLMTRACE_PROXY_URL ?? "http://127.0.0.1:8081";
 
-test.describe("Public-path consistency (issue #276)", () => {
+async function loginWithSession(request: APIRequestContext): Promise<void> {
+  // Fetch the seeded username via the public identity endpoint so this
+  // mirrors whatever the stack was provisioned with (defaults to "admin").
+  const identityRes = await request.get("/api/auth/identity");
+  const identity = (await identityRes.json()) as { username: string };
+
+  // The CI proxy accepts any bearer (no admin_key configured), so any
+  // non-empty key validates. In auth-enforced deployments the maintainer
+  // smoke supplies a real admin key. Either way, the request fixture
+  // persists the resulting Set-Cookie for follow-up calls.
+  const res = await request.post("/api/auth/login", {
+    data: { username: identity.username, admin_key: "test-key-for-ci-stack" },
+    headers: { "Content-Type": "application/json" },
+  });
+  expect(res.status(), `login response: ${await res.text()}`).toBe(200);
+}
+
+test.describe("Public-path consistency (issues #276, #280)", () => {
   test.beforeAll(async ({ request }, testInfo) => {
     testInfo.setTimeout(120_000);
     const deadline = Date.now() + 120_000;
@@ -51,18 +71,52 @@ test.describe("Public-path consistency (issue #276)", () => {
     expect(body).toContain("\"openapi\"");
   });
 
-  test("unauthenticated /metrics returns Prometheus text with llmtrace_ metrics", async ({ request }) => {
-    const res = await request.get("/metrics");
+  test("unauthenticated /api/proxy/health returns 200", async ({ request }) => {
+    const res = await request.get("/api/proxy/health");
     expect(res.status()).toBe(200);
+  });
+
+  // Issue #280: /metrics is NOT on the public allow-list any more.
+  //
+  // With dashboard auth ENFORCED (production, maintainer smoke): the
+  // middleware short-circuits the cookieless request to 401 (JSON) or
+  // 302 /login (HTML). With dashboard auth DISABLED (CI), the middleware
+  // passes through and the proxy answers — in CI the proxy itself runs
+  // auth-disabled, so it returns 200 + metrics text.
+  //
+  // The regression we are guarding against is: dashboard returns the
+  // synthesised `auth_required` body (the #280 failure mode) or a 502
+  // from `proxy-helpers`. Both are non-contract.
+  test("unauthenticated /metrics never leaks the dashboard auth_required body", async ({ request }) => {
+    const res = await request.get("/metrics", {
+      headers: { Accept: "application/json" },
+    });
+    const body = await res.text().catch(() => "");
+    // Acceptable outcomes:
+    //   200 → CI auth-disabled stack, real proxy response with llmtrace_ metrics
+    //   401 → dashboard middleware rejected the cookieless JSON request
+    //   302 → dashboard middleware redirected (when Accept negotiates HTML)
+    // Unacceptable: the dashboard's pre-fix `auth_required` body shape
+    // (proof of regression to the #276 mis-spec), or a 5xx proxy failure.
+    expect(body).not.toContain("auth_required");
+    expect(res.status()).not.toBe(502);
+    expect([200, 302, 401]).toContain(res.status());
+    if (res.status() === 200) {
+      expect(body).toMatch(/llmtrace_/);
+    }
+  });
+
+  // Issue #280: with a valid session cookie the dashboard middleware
+  // injects `Authorization: Bearer <session>` and the request reaches
+  // the proxy as an authenticated call — proxy returns 200 + metrics.
+  test("authenticated /metrics returns Prometheus text with llmtrace_ metrics", async ({ request }) => {
+    await loginWithSession(request);
+    const res = await request.get("/metrics");
+    expect(res.status(), `body: ${await res.text().catch(() => "<unreadable>")}`).toBe(200);
     const body = await res.text();
     // Any llmtrace_* counter / gauge / histogram name is sufficient proof
     // the response made it through the proxy untouched.
     expect(body).toMatch(/llmtrace_/);
-  });
-
-  test("unauthenticated /api/proxy/health returns 200", async ({ request }) => {
-    const res = await request.get("/api/proxy/health");
-    expect(res.status()).toBe(200);
   });
 
   test("admin path /api/v1/tenants does not leak the auth_required regression body", async ({ request }) => {

--- a/dashboard/src/app/metrics/route.ts
+++ b/dashboard/src/app/metrics/route.ts
@@ -1,27 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchWithFallback } from "@/lib/backend";
+import { proxyGet } from "@/lib/proxy-helpers";
 
-// `/metrics` is exposed unauthenticated by design so scrapers (Prometheus,
-// k8s discovery) can pull it without holding a dashboard session. The
-// upstream proxy enforces network-level ACLs on its metrics port.
-export async function GET(_req: NextRequest): Promise<NextResponse> {
-  try {
-    const { response } = await fetchWithFallback("/metrics", {
-      method: "GET",
-      cache: "no-store",
-    });
-    const body = await response.text();
-    return new NextResponse(body, {
-      status: response.status,
-      headers: {
-        "Content-Type": response.headers.get("Content-Type") ?? "text/plain",
-      },
-    });
-  } catch (e) {
-    console.error("[metrics] proxy error:", e);
-    return NextResponse.json(
-      { error: { message: "Backend unavailable", type: "proxy_error" } },
-      { status: 502 },
-    );
-  }
+// `/metrics` is authenticated by design (issue #280, R10): the upstream
+// proxy's auth middleware does NOT allow-list this path, so the dashboard
+// must forward the operator's session as a bearer. We route through
+// `proxyGet` so the middleware-injected `Authorization` header (or the
+// auth-disabled escape hatch) reaches the proxy. The previous direct
+// `fetchWithFallback` call sent the request unauthenticated and the
+// proxy correctly returned 401 — see #280 for the regression history.
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return proxyGet(req, "/metrics");
 }

--- a/dashboard/src/lib/public-paths.ts
+++ b/dashboard/src/lib/public-paths.ts
@@ -7,7 +7,6 @@
 export const UPSTREAM_PUBLIC_PATHS: readonly string[] = [
   "/api-doc",
   "/swagger-ui",
-  "/metrics",
   "/health",
 ];
 

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -16,9 +16,11 @@ const DASHBOARD_PUBLIC_PREFIXES: readonly string[] = [
 
 // Upstream-related public prefixes are derived from the single source of
 // truth so the middleware and `proxy-helpers.ts::buildHeaders` cannot
-// disagree (see issue #276). For each upstream public path we expose:
-//   - the dashboard-side mount (`<path>` — e.g. `/health`, `/metrics`)
+// disagree (see issues #276, #280). For each upstream public path we expose:
+//   - the dashboard-side mount (`<path>` — e.g. `/health`, `/api-doc`)
 //   - the `/api/proxy/*` mount used by the catch-all proxy route
+// Note: `/metrics` is intentionally NOT public — per R10 it requires a
+// tenant/operator bearer. The session cookie is injected as Bearer below.
 const UPSTREAM_PUBLIC_PREFIXES: readonly string[] = UPSTREAM_PUBLIC_PATHS.flatMap(
   (p) => [p, `/api/proxy${p}`],
 );


### PR DESCRIPTION
## Summary
PR #276 incorrectly listed `/metrics` as a public upstream path. The proxy's auth middleware (`crates/llmtrace-proxy/src/auth.rs:115`) only allow-lists `/health`, `/swagger-ui`, `/api-doc`. Per R10, `/metrics` requires a tenant / operator bearer — this PR fixes the dashboard so it stops sending the request unauthenticated.

## Live evidence from issue #280 (before fix, against `:sha-4c973ba`)

```
GET /metrics → HTTP 401
{"error":{"message":"Authentication required: Missing or invalid Authorization header or X-LLMTrace-Token","type":"auth_error"}}
```

## Per-file changes

- **`dashboard/src/lib/public-paths.ts`** — drop `"/metrics"` from `UPSTREAM_PUBLIC_PATHS`. Keep `/api-doc`, `/swagger-ui`, `/health` (those ARE on the proxy's open allow-list).
- **`dashboard/src/middleware.ts`** — `PUBLIC_PREFIXES` derives from `UPSTREAM_PUBLIC_PATHS`, so `/metrics` is no longer skipped. Updated the explanatory comment to reflect R10.
- **`dashboard/src/app/metrics/route.ts`** — replace the direct `fetchWithFallback` (which sent the request without an Authorization header — the actual source of the 401 reported in #280) with `proxyGet`. `proxyGet` runs `buildHeaders`, which now forwards the middleware-injected `Authorization: Bearer <session>` to the upstream proxy. Under `LLMTRACE_DASHBOARD_AUTH_DISABLED=1` the existing escape-hatch branch handles local dev.
- **`dashboard/e2e/public-paths.spec.ts`** — the previous "unauthenticated `/metrics` → 200" test was based on the wrong contract. Replaced with two tests:
  - `unauthenticated /metrics never leaks the dashboard auth_required body` — proves the dashboard never returns the `auth_required` regression body (the #280 failure shape) and never returns 5xx. Accepts `200 | 302 | 401` depending on auth-enforced vs auth-disabled stack.
  - `authenticated /metrics returns Prometheus text with llmtrace_ metrics` — logs in via `/api/auth/login`, then GETs `/metrics`. Asserts 200 + body matches `/llmtrace_/`.

The other test cases (`/api/proxy/api-doc/openapi.json`, `/api/proxy/health`, admin `/api/v1/tenants`) stay as-is.

## Validation

- `npm run lint` — clean (only pre-existing warnings in unrelated files).
- `npm run build` — clean. Build output shows `/metrics` is still a server-rendered route.
- `grep '/metrics'` in `public-paths.ts` and `middleware.ts` (the two allow-lists) returns only the explanatory comment.

## Test plan

- [ ] CI Playwright e2e (`public-paths.spec.ts`) passes the two new `/metrics` tests against the CI compose stack.
- [ ] Maintainer-run live Basilica smoke against an auth-enforced deployment verifies the cookieless `/metrics` request returns 401 (or 302 to `/login`) and the session-authenticated request returns 200 + Prometheus text.
- [ ] `/status` page's metrics card renders against a real stack (manual check).

## Out of scope

- Adding a separate scrape-only credential type for Prometheus. The current contract is "use the tenant API key" (R10).

Closes #280.