### PR TITLE
feat(dashboard): /playground chat panel for exercising the proxy (closes #284)

### DIFF
--- a/dashboard/e2e/playground.spec.ts
+++ b/dashboard/e2e/playground.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Smoke + behaviour test for /playground (issue #284).
+//
+// Why we mock `/api/proxy/v1/chat/completions` via Playwright's `page.route`:
+//
+//   The CI proxy stack does NOT have an upstream provider API key (OpenAI,
+//   Anthropic, etc.) configured — a real round-trip would fail at the
+//   upstream provider, not in any LLMTrace code we control. That makes a
+//   live POST useless as a regression signal here. To keep this spec
+//   deterministic and runnable in CI, we intercept ONLY the upstream call
+//   and return a canned OpenAI-shaped response. Every other request hits
+//   the real proxy. The actual live round-trip is gated to a manual
+//   maintainer-run smoke against a deployed environment with provider
+//   credentials.
+//
+// What we assert end-to-end against the CI stack:
+//   1. Authenticated GET /playground -> 200 + "Playground" heading.
+//   2. The sidebar exposes a "Playground" link to /playground.
+//   3. The page renders the model dropdown, temperature slider, system
+//      prompt textarea, message input, and send button.
+//   4. With the upstream mocked, sending a message appends an assistant
+//      message containing the canned content to the transcript.
+// ---------------------------------------------------------------------------
+
+const PROXY_BASE = process.env.LLMTRACE_PROXY_URL ?? "http://127.0.0.1:8081";
+
+test.describe("Playground page (issue #284)", () => {
+  test.beforeAll(async ({ request }, testInfo) => {
+    testInfo.setTimeout(120_000);
+    const deadline = Date.now() + 120_000;
+    while (true) {
+      try {
+        const res = await request.get(`${PROXY_BASE}/health`);
+        if (res.ok()) return;
+      } catch {
+        // ignore — keep polling
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`Proxy not healthy at ${PROXY_BASE}/health`);
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  });
+
+  test.beforeEach(async ({ request }) => {
+    // Mirror api-docs.spec.ts: fetch the seeded username, then login.
+    const identityRes = await request.get("/api/auth/identity");
+    const identity = (await identityRes.json()) as { username: string };
+    const loginRes = await request.post("/api/auth/login", {
+      data: { username: identity.username, admin_key: "test-key-for-ci-stack" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(loginRes.status(), `login failed: ${await loginRes.text()}`).toBe(200);
+  });
+
+  test("/playground renders 200 with the Playground heading", async ({ page }) => {
+    const response = await page.goto("/playground");
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByRole("heading", { name: "Playground", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("sidebar exposes Playground link", async ({ page }) => {
+    await page.goto("/playground");
+    const link = page.locator("aside").getByRole("link", { name: "Playground" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/playground");
+  });
+
+  test("renders model, temperature, system prompt, input, and send button", async ({ page }) => {
+    await page.goto("/playground");
+    await expect(page.getByTestId("playground-model")).toBeVisible();
+    await expect(page.getByTestId("playground-temperature")).toBeVisible();
+    await expect(page.getByTestId("playground-system-prompt")).toBeVisible();
+    await expect(page.getByTestId("playground-input")).toBeVisible();
+    await expect(page.getByTestId("playground-send")).toBeVisible();
+  });
+
+  test("sending a message renders the assistant reply (upstream mocked)", async ({ page }) => {
+    // Intercept the dashboard proxy route ONLY. Every other request reaches
+    // the live stack untouched. See header comment for rationale.
+    await page.route("**/api/proxy/v1/chat/completions", async (route) => {
+      const fakeOpenAi = {
+        id: "chatcmpl-test-fixture",
+        object: "chat.completion",
+        created: 1_700_000_000,
+        model: "gpt-4o-mini",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "Pong from the mocked upstream." },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "x-llmtrace-trace-id": "trace-fixture-1" },
+        body: JSON.stringify(fakeOpenAi),
+      });
+    });
+
+    await page.goto("/playground");
+    await page.getByTestId("playground-input").fill("ping");
+    await page.getByTestId("playground-send").click();
+
+    const assistant = page.getByTestId("playground-msg-assistant");
+    await expect(assistant).toBeVisible({ timeout: 10_000 });
+    await expect(assistant).toContainText("Pong from the mocked upstream.");
+  });
+});

--- a/dashboard/src/app/playground/_client.tsx
+++ b/dashboard/src/app/playground/_client.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState, type ReactElement, type KeyboardEvent } from "react";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+type Role = "system" | "user" | "assistant";
+type Msg = { role: Role; content: string };
+
+const DEFAULT_MODELS: readonly string[] = [
+  "gpt-4o-mini",
+  "gpt-4o",
+  "claude-3-5-sonnet-latest",
+  "claude-3-5-haiku-latest",
+  "gpt-4-turbo",
+];
+
+type SendArgs = {
+  systemPrompt: string;
+  messages: Msg[];
+  draft: string;
+  model: string;
+  temperature: number;
+};
+
+type SendResult =
+  | { kind: "ok"; assistant: string; traceId: string | null }
+  | { kind: "err"; error: string; traceId: string | null };
+
+function buildPayload(args: SendArgs): { model: string; temperature: number; messages: Msg[] } {
+  const trimmedSystem = args.systemPrompt.trim();
+  const prefix: Msg[] = trimmedSystem ? [{ role: "system", content: trimmedSystem }] : [];
+  const all: Msg[] = [...prefix, ...args.messages, { role: "user", content: args.draft }];
+  return { model: args.model, temperature: args.temperature, messages: all };
+}
+
+async function postChat(args: SendArgs): Promise<SendResult> {
+  const res = await fetch("/api/proxy/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(buildPayload(args)),
+  });
+  const traceId = res.headers.get("x-llmtrace-trace-id");
+  if (!res.ok) {
+    const body = await res.text();
+    return { kind: "err", error: `HTTP ${res.status}: ${body.slice(0, 500)}`, traceId };
+  }
+  const body = (await res.json()) as { choices?: Array<{ message?: { content?: unknown } }> };
+  const content = body?.choices?.[0]?.message?.content;
+  return { kind: "ok", assistant: typeof content === "string" ? content : String(content ?? ""), traceId };
+}
+
+export default function PlaygroundClient(): ReactElement {
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [draft, setDraft] = useState<string>("");
+  const [model, setModel] = useState<string>("gpt-4o-mini");
+  const [customModel, setCustomModel] = useState<string>("");
+  const [temperature, setTemperature] = useState<number>(0.7);
+  const [systemPrompt, setSystemPrompt] = useState<string>("");
+  const [pending, setPending] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastTraceId, setLastTraceId] = useState<string | null>(null);
+
+  const effectiveModel = customModel.trim() !== "" ? customModel.trim() : model;
+
+  async function send(): Promise<void> {
+    if (pending || draft.trim() === "") return;
+    setPending(true);
+    setError(null);
+    const userMsg: Msg = { role: "user", content: draft };
+    try {
+      const result = await postChat({ systemPrompt, messages, draft, model: effectiveModel, temperature });
+      if (result.traceId) setLastTraceId(result.traceId);
+      if (result.kind === "err") {
+        setError(result.error);
+        return;
+      }
+      setMessages((prev) => [...prev, userMsg, { role: "assistant", content: result.assistant }]);
+      setDraft("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      void send();
+    }
+  }
+
+  function clear(): void {
+    setMessages([]);
+    setError(null);
+    setLastTraceId(null);
+  }
+
+  return (
+    <div className="space-y-4">
+      <PlaygroundControls
+        model={model}
+        setModel={setModel}
+        customModel={customModel}
+        setCustomModel={setCustomModel}
+        temperature={temperature}
+        setTemperature={setTemperature}
+        onClear={clear}
+        disabled={pending}
+      />
+      <SystemPromptField value={systemPrompt} setValue={setSystemPrompt} disabled={pending} />
+      <Transcript messages={messages} />
+      <StatusRow pending={pending} error={error} traceId={lastTraceId} />
+      <InputArea
+        draft={draft}
+        setDraft={setDraft}
+        onKeyDown={onKeyDown}
+        onSend={() => void send()}
+        disabled={pending}
+      />
+    </div>
+  );
+}
+
+type ControlsProps = {
+  model: string;
+  setModel: (v: string) => void;
+  customModel: string;
+  setCustomModel: (v: string) => void;
+  temperature: number;
+  setTemperature: (v: number) => void;
+  onClear: () => void;
+  disabled: boolean;
+};
+
+function PlaygroundControls(props: ControlsProps): ReactElement {
+  return (
+    <div className="flex flex-wrap items-end gap-3 rounded-md border bg-card p-3">
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="font-medium text-muted-foreground">Model</span>
+        <select
+          data-testid="playground-model"
+          value={props.model}
+          onChange={(e) => props.setModel(e.target.value)}
+          disabled={props.disabled}
+          className="rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        >
+          {DEFAULT_MODELS.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="font-medium text-muted-foreground">Custom model (overrides)</span>
+        <input
+          type="text"
+          data-testid="playground-custom-model"
+          value={props.customModel}
+          onChange={(e) => props.setCustomModel(e.target.value)}
+          disabled={props.disabled}
+          placeholder="e.g. my-org/my-model"
+          className="rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="font-medium text-muted-foreground">
+          Temperature: {props.temperature.toFixed(2)}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={2}
+          step={0.05}
+          data-testid="playground-temperature"
+          value={props.temperature}
+          onChange={(e) => props.setTemperature(Number(e.target.value))}
+          disabled={props.disabled}
+          className="w-48"
+        />
+      </label>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={props.onClear}
+        disabled={props.disabled}
+        data-testid="playground-clear"
+      >
+        Clear conversation
+      </Button>
+    </div>
+  );
+}
+
+function SystemPromptField(props: {
+  value: string;
+  setValue: (v: string) => void;
+  disabled: boolean;
+}): ReactElement {
+  return (
+    <label className="flex flex-col gap-1 text-xs">
+      <span className="font-medium text-muted-foreground">System prompt (optional)</span>
+      <textarea
+        data-testid="playground-system-prompt"
+        value={props.value}
+        onChange={(e) => props.setValue(e.target.value)}
+        disabled={props.disabled}
+        rows={2}
+        placeholder="Prepended as a `system` message on every send"
+        className="rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+      />
+    </label>
+  );
+}
+
+function Transcript(props: { messages: Msg[] }): ReactElement {
+  if (props.messages.length === 0) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-sm text-muted-foreground">
+          No messages yet. Send a message below to exercise the proxy.
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <div className="space-y-2" data-testid="playground-transcript">
+      {props.messages.map((m, i) => (
+        <MessageBubble key={i} msg={m} />
+      ))}
+    </div>
+  );
+}
+
+function MessageBubble(props: { msg: Msg }): ReactElement {
+  const isUser = props.msg.role === "user";
+  const align = isUser ? "ml-auto" : "mr-auto";
+  const tone = isUser ? "bg-primary text-primary-foreground" : "bg-card";
+  return (
+    <div
+      data-testid={`playground-msg-${props.msg.role}`}
+      className={`max-w-[80%] rounded-md border p-3 text-sm whitespace-pre-wrap ${align} ${tone}`}
+    >
+      <div className="mb-1 text-[10px] font-bold uppercase opacity-70">{props.msg.role}</div>
+      {props.msg.content}
+    </div>
+  );
+}
+
+function StatusRow(props: {
+  pending: boolean;
+  error: string | null;
+  traceId: string | null;
+}): ReactElement {
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+      {props.pending && (
+        <span className="flex items-center gap-1" data-testid="playground-pending">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Sending...
+        </span>
+      )}
+      {props.traceId && (
+        <span data-testid="playground-trace-id">
+          Last trace:{" "}
+          <Link className="underline" href={`/traces/${props.traceId}`}>
+            {props.traceId}
+          </Link>
+        </span>
+      )}
+      {props.error && (
+        <span className="text-destructive" data-testid="playground-error">
+          {props.error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function InputArea(props: {
+  draft: string;
+  setDraft: (v: string) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSend: () => void;
+  disabled: boolean;
+}): ReactElement {
+  return (
+    <div className="flex gap-2">
+      <textarea
+        data-testid="playground-input"
+        value={props.draft}
+        onChange={(e) => props.setDraft(e.target.value)}
+        onKeyDown={props.onKeyDown}
+        disabled={props.disabled}
+        rows={3}
+        placeholder="Type a message. Cmd/Ctrl+Enter to send."
+        className="flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+      />
+      <Button
+        type="button"
+        onClick={props.onSend}
+        disabled={props.disabled || props.draft.trim() === ""}
+        data-testid="playground-send"
+      >
+        Send
+      </Button>
+    </div>
+  );
+}

--- a/dashboard/src/app/playground/page.tsx
+++ b/dashboard/src/app/playground/page.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement } from "react";
+import PlaygroundClient from "./_client";
+
+// Force dynamic rendering: the playground POSTs through `/api/proxy/...`
+// at request time, so there is no static output worth caching.
+export const dynamic = "force-dynamic";
+
+/**
+ * Server component wrapper for /playground (issue #284).
+ *
+ * The interactive chat panel lives in the `_client` module; this server
+ * shell renders the lead copy and embeds it. No data is fetched here —
+ * the client component drives the whole conversation in memory.
+ */
+export default function PlaygroundPage(): ReactElement {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Playground</h1>
+        <p className="text-sm text-muted-foreground">
+          Send chat-style requests through your proxy URL. Useful for quick
+          smoke tests and verifying upstream provider auth. Traces and findings
+          show up in the Traces / Security / Audit pages as usual.
+        </p>
+      </div>
+      <PlaygroundClient />
+    </div>
+  );
+}

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Gauge,
   ScrollText,
   Code,
+  MessageSquare,
   LogOut,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -26,6 +27,7 @@ const navItems = [
   { href: "/traces", label: "Traces", icon: FileSearch },
   { href: "/security", label: "Security", icon: Shield },
   { href: "/audit", label: "Audit", icon: ScrollText },
+  { href: "/playground", label: "Playground", icon: MessageSquare },
   { href: "/costs", label: "Costs", icon: DollarSign },
   { href: "/tenants", label: "Tenants", icon: Users },
   { href: "/compliance", label: "Compliance", icon: FileCheck },


### PR DESCRIPTION
## Summary

New top-level `/playground` page that lets a logged-in operator send chat-style requests through the dashboard's own `/api/proxy/v1/chat/completions` route — the existing middleware injects the session bearer, so no new credential surface is introduced. Useful for quick smoke tests + verifying upstream provider auth without dropping to `curl`.

Closes #284.

## Scope decisions (per the issue)

- Non-streaming only. (Streaming follow-up.)
- Plain text assistant rendering (no Markdown).
- Plain HTML primitives (`<input type="range">`, `<textarea>`, `<select>`) + existing `Button` / `Card` UI primitives. No new third-party deps.

## Per-file changes

- `dashboard/src/app/playground/page.tsx` (new) — server component wrapper. Renders the heading + lead copy from the spec and embeds the client component. `export const dynamic = "force-dynamic"`.
- `dashboard/src/app/playground/_client.tsx` (new) — `"use client"` chat UI. State shape per the spec (`messages`, `draft`, `model`, `temperature`, `systemPrompt`, `pending`, `error`, `lastTraceId`) plus a `customModel` text input that overrides the dropdown selection when non-empty. Controls split into small sub-components, each function < 50 LOC. Cmd/Ctrl+Enter sends. `lastTraceId` is read from the `x-llmtrace-trace-id` response header and surfaces a `/traces/<id>` link.
- `dashboard/src/components/sidebar.tsx` — imports `MessageSquare` from `lucide-react` and inserts `{ href: "/playground", label: "Playground", icon: MessageSquare }` between `Audit` and `Costs` in the operator-action group.
- `dashboard/e2e/playground.spec.ts` (new) — Playwright tests:
  1. Authenticated GET `/playground` → 200 + `Playground` heading.
  2. Sidebar exposes a `Playground` link to `/playground`.
  3. Page renders model dropdown, temperature slider, system-prompt textarea, message input, send button.
  4. Sending a message renders the assistant reply, with `page.route` intercepting `/api/proxy/v1/chat/completions` to return a fake OpenAI-shaped body. The header comment documents why the upstream is mocked (CI proxy has no provider API key).

## Sidebar choices

- **Icon:** `MessageSquare` (the spec's first suggestion; `MessageCircle`/`Bot` not currently imported either, so chose the canonical one).
- **Position:** between `Audit` and `Costs`, matching the issue's request.

## Validation

`cd dashboard && npm run lint` — no new warnings; only the three pre-existing warnings remain (compliance/page, guide/page, traces/page):

```
> llmtrace-dashboard@0.1.0 lint
> next lint

./src/app/compliance/page.tsx
282:6  Warning: React Hook useEffect has a missing dependency: 'loadReports'...
./src/app/guide/page.tsx
112:13  Warning: Using `<img>` could result in slower LCP...
./src/app/traces/page.tsx
69:6  Warning: React Hook useEffect has a missing dependency: 'load'...
```

`cd dashboard && npm run build` — clean. `/playground` is emitted in the route table:

```
 ✓ Compiled successfully in 42s
 ✓ Generating static pages (18/18)

Route (app)                                 Size  First Load JS
...
├ ƒ /playground                          4.15 kB         117 kB
...
ƒ Middleware                             34.4 kB
```

`cd dashboard && npx tsc --noEmit -p tsconfig.json` — passes silently (strict mode, includes `e2e/**`).

## NOT validated (out of my reach)

- **Live OpenAI / Anthropic round-trip.** The CI proxy doesn't have an upstream provider API key configured (same constraint cited in the existing api-docs and auth-login specs), so the e2e test intercepts the upstream POST via `page.route` and asserts on a canned response. The live round-trip can only be exercised on a deployment that has a real provider key — maintainer territory.
- **Playwright execution locally.** I do not have a running proxy + dashboard stack in this worktree, so the new spec is being validated by the project's existing CI pipeline (which runs `npx playwright test --reporter=json` per `.github/workflows/ci.yml`). CI status will determine the final pass/fail signal.

## Test plan

- [x] `npm run lint` clean (no new warnings)
- [x] `npm run build` clean, `/playground` listed in route table
- [x] `npx tsc --noEmit` passes
- [ ] CI Playwright run is green
- [ ] Manual: maintainer hits a deployment with a real provider key and confirms an end-to-end chat round trip lands a trace in `/traces`