### PR TITLE
fix(dashboard): route /api/proxy/v1/* to proxy /v1/* (playground 404 fix)

### DIFF
--- a/dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/dashboard/src/app/api/proxy/[...path]/route.ts
@@ -29,6 +29,14 @@ function mapProxyPath(path: string[]): string {
   if (first === "health" || first === "metrics") {
     return "/" + path.join("/");
   }
+  // `/v1/*` is the OpenAI-compatible inference surface on the proxy (no
+  // `/api/v1/` prefix). Required so client code like the /playground panel
+  // can POST through `/api/proxy/v1/chat/completions` and have it land at
+  // the proxy's `/v1/chat/completions`. Without this branch the catch-all
+  // remapped to `/api/v1/v1/...` and produced 404.
+  if (first === "v1") {
+    return "/" + path.join("/");
+  }
   return "/api/v1/" + path.join("/");
 }
 


### PR DESCRIPTION
## Live-reproduced 404

After PR #285 (`/playground` page) merged + the corresponding dashboard image was deployed, posting a chat request through the playground returned **HTTP 404** with an empty body. Reproduce live with a logged-in session:

```bash
curl -X POST $DASH/api/proxy/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
# → HTTP 404
```

## Root cause

`dashboard/src/app/api/proxy/[...path]/route.ts::mapProxyPath` has explicit branches for `swagger-ui`, `api-doc`, `health`, `metrics`, and a fall-through that **unconditionally prepends `/api/v1/`**. For a path of `["v1", "chat", "completions"]`, the catch-all produces `"/api/v1/v1/chat/completions"` — a doubled `v1/` that the proxy doesn't route.

## Fix

Add the missing branch:

```ts
if (first === "v1") {
  return "/" + path.join("/");
}
```

`/api/proxy/v1/chat/completions` now lands at `/v1/chat/completions` on the proxy (and `/api/proxy/v1/embeddings` at `/v1/embeddings`, etc.), exactly mirroring the existing handling for `health` / `metrics` / `swagger-ui` / `api-doc`.

## Validation

- Read the diff: only one new branch, mirrors the existing pattern verbatim.
- The /playground page in PR #285 POSTs to `/api/proxy/v1/chat/completions` (verified via `grep` of `playground/_client.tsx`). After this fix, that POST will reach the proxy.
- No backend change. No auth-flow change.

## Not validated in this PR

- The live e2e (will be done by the maintainer with the local-CLI redeploy that follows merge).
- No new test added because the existing dashboard e2e suite (`auth-login.spec.ts`, `playground.spec.ts`) already covers the round-trip when the catch-all is correct; a regression that re-introduces the doubled-prefix would manifest as a 404 on every `/v1/*` proxied call. A future-proof unit test on `mapProxyPath` directly would be a small follow-up.