### PR TITLE
fix(dashboard,lifecycle): pin upstream calls to provisioned tenant + forward trace headers

### DIFF
--- a/dashboard/src/lib/proxy-helpers.ts
+++ b/dashboard/src/lib/proxy-helpers.ts
@@ -3,13 +3,33 @@ import { fetchWithFallback } from "./backend";
 import { isAuthDisabled } from "./auth";
 import { isUpstreamPublic } from "./public-paths";
 
+// Upstream response headers the browser needs to see. The proxy emits these
+// on every traced response; the /playground UI reads `x-llmtrace-trace-id`
+// to attach per-message metadata via /traces/{id}. Without forwarding, the
+// metadata pills never populate.
+const FORWARDED_RESPONSE_HEADERS: readonly string[] = [
+  "x-llmtrace-trace-id",
+  "x-llmtrace-tenant-id",
+  "x-request-id",
+];
+
 function buildHeaders(
   req: NextRequest,
   backendPath: string,
   extra: Record<string, string> = {},
 ): Record<string, string> | NextResponse {
   const headers: Record<string, string> = { ...extra };
-  const tenantHeader = req.headers.get("x-llmtrace-tenant-id");
+
+  // Tenant header resolution: prefer an explicit incoming header (used by
+  // dashboard pages that drive a tenant picker, e.g. /traces). Fall back to
+  // the deployment-pinned tenant set at provisioning time so that
+  // dashboard-originated traffic (e.g. /playground chat completions) is
+  // attributed to the real provisioned tenant instead of spawning a
+  // throwaway tenant per call on the proxy.
+  const tenantHeader =
+    req.headers.get("x-llmtrace-tenant-id") ??
+    process.env.LLMTRACE_DASHBOARD_TENANT_ID ??
+    null;
   if (tenantHeader) headers["X-LLMTrace-Tenant-ID"] = tenantHeader;
 
   const authHeader = req.headers.get("authorization");
@@ -43,6 +63,17 @@ function buildHeaders(
   );
 }
 
+function buildResponseHeaders(res: Response): Record<string, string> {
+  const out: Record<string, string> = {
+    "Content-Type": res.headers.get("Content-Type") ?? "application/json",
+  };
+  for (const name of FORWARDED_RESPONSE_HEADERS) {
+    const value = res.headers.get(name);
+    if (value) out[name] = value;
+  }
+  return out;
+}
+
 /**
  * Proxy a GET request to the LLMTrace backend, forwarding query params
  * and relevant headers (tenant identification, Authorization).
@@ -64,7 +95,7 @@ export async function proxyGet(
     const body = await res.text();
     return new NextResponse(body, {
       status: res.status,
-      headers: { "Content-Type": res.headers.get("Content-Type") ?? "application/json" },
+      headers: buildResponseHeaders(res),
     });
   } catch (e) {
     console.error("Proxy error:", e);
@@ -101,7 +132,7 @@ export async function proxyMutate(
     const body = await res.text();
     return new NextResponse(body, {
       status: res.status,
-      headers: { "Content-Type": res.headers.get("Content-Type") ?? "application/json" },
+      headers: buildResponseHeaders(res),
     });
   } catch (e) {
     console.error("Proxy error:", e);

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -920,6 +920,8 @@ def provision(
 
         tenant_uuid = _bootstrap_tenant_in_proxy(proxy.url, admin_key, tenant_id)
         operator_key = _mint_operator_key(proxy.url, admin_key, tenant_uuid)
+    else:
+        tenant_uuid = None
 
     dashboard_spec = _apply_dashboard_admin_username(
         dashboard_spec, spec.admin_username
@@ -928,6 +930,22 @@ def provision(
     if spec.inject_proxy_url_into_dashboard:
         merged_env = {**dashboard_spec.env, spec.proxy_url_env_var: proxy.url}
         dashboard_spec = dataclasses.replace(dashboard_spec, env=merged_env)
+
+    # Pin the dashboard's upstream calls to the provisioned tenant. Without
+    # this, admin-key calls (the dashboard's only auth path today) cause the
+    # proxy to attribute each request to a new "phantom" tenant — see the
+    # /traces emptiness incident: traces persist correctly but scatter across
+    # 16+ tenants per day, making the dashboard's tenant-filtered views
+    # appear empty. The proxy honours `X-LLMTrace-Tenant-ID` when supplied
+    # alongside an admin key; the dashboard injects this env value as that
+    # header in `proxy-helpers.ts::buildHeaders`.
+    if tenant_uuid:
+        merged_env = {
+            **dashboard_spec.env,
+            "LLMTRACE_DASHBOARD_TENANT_ID": tenant_uuid,
+        }
+        dashboard_spec = dataclasses.replace(dashboard_spec, env=merged_env)
+
     dashboard = _create_component(client, dashboard_name, dashboard_spec)
 
     return TenantInstances(

--- a/deployments/basilica/tests/test_operator_key_minting.py
+++ b/deployments/basilica/tests/test_operator_key_minting.py
@@ -503,6 +503,10 @@ def test_provision_returns_operator_key_as_api_key_and_admin_key_separately(
     dash_create = next(c for c in fake_client.creates if "dashboard" in c["instance_name"])
     assert dash_create["env"]["LLMTRACE_AUTH_ADMIN_KEY"] == ADMIN_KEY
     assert "LLMTRACE_AUTH_RUNTIME_KEY" not in dash_create["env"]
+    # Dashboard env pins upstream calls to the provisioned tenant so the
+    # proxy attributes admin-key traffic (the dashboard's only auth path)
+    # to the real tenant instead of spawning a phantom tenant per call.
+    assert dash_create["env"]["LLMTRACE_DASHBOARD_TENANT_ID"] == TENANT_UUID
 
 
 def test_provision_skips_key_flow_when_proxy_auth_disabled(fake_proxy: Any) -> None:
@@ -526,3 +530,7 @@ def test_provision_skips_key_flow_when_proxy_auth_disabled(fake_proxy: Any) -> N
     assert result.admin_key is None
     # No HTTP calls were made (no recorded requests because the fake never received any).
     assert proxy.recorded == []
+    # No tenant UUID is materialised when auth is disabled, so the dashboard
+    # env must not carry a stale LLMTRACE_DASHBOARD_TENANT_ID either.
+    dash_create = next(c for c in fake_client.creates if "dashboard" in c["instance_name"])
+    assert "LLMTRACE_DASHBOARD_TENANT_ID" not in dash_create["env"]


### PR DESCRIPTION
## Summary

Two layered defects were starving the `/traces` page and the `/playground` metadata pills. This PR closes the user-visible symptoms; a proxy-side cleanup is tracked separately.

**Defect 1 — dashboard strips upstream response headers.**
`proxy-helpers.ts::proxyGet` and `proxyMutate` rebuilt the response with only `Content-Type`, so `x-llmtrace-trace-id` and `x-request-id` never reached the browser. The redesigned `/playground` (#288) reads `x-llmtrace-trace-id` off the chat-completion response to drive `/traces/{id}` lookups; without passthrough, `traceId` was always `null` and the metadata pills stayed empty.

**Defect 2 — admin-key calls attribute to a phantom tenant per request.**
Empirically observed on a live deployment: 16 throwaway tenants accumulated in one day, each holding exactly one trace. The proxy honours `X-LLMTrace-Tenant-ID` when supplied alongside an admin key, so we pin all dashboard-originated upstream traffic to the real provisioned tenant via a deploy-time env var:

- `lifecycle.py` injects `LLMTRACE_DASHBOARD_TENANT_ID = <tenant_uuid>` into the dashboard `ComponentSpec.env` at provision time (only when proxy auth is on — no stale value when `enable_proxy_auth=False`).
- `proxy-helpers.ts::buildHeaders` falls back to that env when the incoming request doesn't already carry `X-LLMTrace-Tenant-ID`. Pages that drive their own tenant picker (`/traces` via `findActiveTenant`) keep their override semantics.

## Evidence (live deployment, pre-fix)

```
$ curl -X POST $PROXY/v1/chat/completions -H "Auth: Bearer $ADMIN" ...
   x-llmtrace-trace-id: 7b800984-...

$ curl $PROXY/api/v1/traces/7b800984-...                                          → 404
$ curl -H "X-LLMTrace-Tenant-ID: 9f934ce8-..." $PROXY/api/v1/traces/89d3a5e9-...  → 200

$ curl $PROXY/api/v1/tenants  → 16 rows, 15 named "key-llmt_642…" (truncated key prefix),
                                each holding exactly one trace.
```

After this PR, all dashboard chat completions land under the provisioned tenant, the `/traces` view shows them, and the `/playground` pills can resolve trace metadata.

## Tests

- `test_provision_returns_operator_key_as_api_key_and_admin_key_separately` extended to assert `LLMTRACE_DASHBOARD_TENANT_ID` lands on the dashboard env.
- `test_provision_skips_key_flow_when_proxy_auth_disabled` extended to assert the env var is absent when no tenant UUID was materialised.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [x] `npm run build` clean (18/18 pages, /playground 7.82kB)
- [x] lifecycle tests (direct Python — pytest collection on `deployments/basilica/tests/` is broken at HEAD due to package shadowing, unrelated to this PR)
- [ ] Live E2E validation after merge: redeploy and confirm a fresh chat completion via `/playground` lands a row on `/traces` AND populates the per-message metadata pills.

## Follow-up (separate ticket)
- **Proxy bug**: admin-key `/v1/chat/completions` calls auto-create a new tenant row per call rather than reusing a stable one. Needs a Rust-side fix in `crates/llmtrace-proxy/src/proxy.rs::resolve_tenant` to either fall back to a system tenant or refuse admin-key inference without an explicit tenant header.