### PR TITLE
fix(dashboard/playground): escalate bubble status to red when findings are Critical (even if action=allow)

### DIFF
--- a/dashboard/e2e/playground.spec.ts
+++ b/dashboard/e2e/playground.spec.ts
@@ -123,6 +123,51 @@ async function mockTraceAmberAllow(page: Page): Promise<void> {
   });
 }
 
+// Trace where the proxy returned action=allow (log-only enforcement
+// mode) but recorded Critical-severity findings on the span. The bubble
+// status overlay must escalate to red here — green would mislead the
+// user into thinking the request was safe when it wasn't.
+async function mockTraceCriticalAllow(page: Page): Promise<void> {
+  await page.route(`**/api/proxy/traces/${FIXTURE_TRACE_ID}`, async (route) => {
+    const trace = {
+      trace_id: FIXTURE_TRACE_ID,
+      tenant_id: "tenant-fixture",
+      created_at: new Date().toISOString(),
+      spans: [
+        {
+          span_id: "span-1",
+          trace_id: FIXTURE_TRACE_ID,
+          tenant_id: "tenant-fixture",
+          operation_name: "chat.completion",
+          provider: "openai",
+          model_name: "gpt-4o-mini",
+          duration_ms: 1234,
+          security_score: 80,
+          // No enforcement_action tag => deriveAction falls back to
+          // "allow" on a 2xx response. The Critical findings are
+          // independent of that decision.
+          security_findings: [
+            {
+              finding_type: "ml_prompt_injection",
+              severity: "Critical",
+              confidence: 0.91,
+            },
+            { finding_type: "pii_detected", severity: "Medium", confidence: 0.7 },
+            { finding_type: "data_exfiltration", severity: "Medium", confidence: 0.6 },
+          ],
+          agent_actions: [],
+          tags: {},
+        },
+      ],
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(trace),
+    });
+  });
+}
+
 test.describe("Playground page (issues #284, #287, #289)", () => {
   test.beforeAll(async ({ request }, testInfo) => {
     testInfo.setTimeout(120_000);
@@ -286,5 +331,52 @@ test.describe("Playground page (issues #284, #287, #289)", () => {
 
     // No assistant bubble must be appended when the request was blocked.
     await expect(page.getByTestId("playground-msg-assistant")).toHaveCount(0);
+  });
+
+  test("Critical findings escalate the bubble overlay to red even when action=allow", async ({
+    page,
+  }) => {
+    // Proxy returns 200 + action=allow (log-only enforcement) but the
+    // trace span carries Critical findings. The bubble must NOT show
+    // green — that would mislead the user into thinking the request
+    // was safe when LLMTrace flagged Critical risks.
+    await mockChatOk(page);
+    await mockTraceCriticalAllow(page);
+
+    await page.goto("/playground");
+    await page.getByTestId("playground-input").fill("payload with critical findings");
+    await page.getByTestId("playground-send").click();
+
+    await expect(page.getByTestId("playground-msg-assistant")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Wait for the trace fetch to resolve and the overlay to escalate.
+    const escalated = page.getByTestId("playground-status-critical-findings");
+    await expect(escalated.first()).toBeVisible({ timeout: 10_000 });
+    await expect(escalated).toHaveCount(2);
+
+    // Escalated overlay must carry the red tone.
+    const cls = (await escalated.first().getAttribute("class")) ?? "";
+    expect(cls).toContain("red");
+
+    // No green "allow" overlay should be present on either bubble — it
+    // would directly contradict the escalation.
+    await expect(page.getByTestId("playground-status-allow")).toHaveCount(0);
+
+    // The accessible label calls out the contradiction.
+    await expect(escalated.first()).toHaveAttribute(
+      "aria-label",
+      /Critical findings.*allowed by policy/,
+    );
+
+    // The Details drawer also exposes the warning next to the action.
+    await page
+      .getByTestId("playground-msg-user")
+      .getByTestId("playground-toggle-details")
+      .click();
+    await expect(
+      page.getByTestId("playground-details-action-warning").first(),
+    ).toBeVisible();
   });
 });

--- a/dashboard/src/app/playground/_client.tsx
+++ b/dashboard/src/app/playground/_client.tsx
@@ -309,9 +309,31 @@ function prettyJson(text: string | null): string {
   }
 }
 
-// Visual classifier for the status overlay on every bubble. Maps the
-// metadata's action + loading state to an icon, tone class for the
-// circular badge background, and an accessible label.
+// Severity rank used to escalate the bubble status overlay above the
+// proxy-reported action. The proxy can be configured in log-only
+// enforcement mode (`enforcement_mode: log`) in which case every
+// request returns action="allow" regardless of findings; without this
+// escalation the bubble would show a green tick despite Critical
+// findings (e.g. ml_prompt_injection, data_exfiltration) being detected
+// on the request. Higher number = more severe.
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  info: 0,
+};
+
+function findingsMaxRank(findings: readonly MsgFinding[]): number {
+  return findings.reduce(
+    (acc, f) => Math.max(acc, SEVERITY_RANK[f.severity.toLowerCase()] ?? 0),
+    0,
+  );
+}
+
+// Visual classifier for the status overlay on every bubble. Encodes the
+// WORST of (proxy enforcement action, finding severity) so the icon
+// never reads "safe" while elevated-severity findings exist.
 type StatusVisual = {
   icon: typeof ShieldCheck;
   tone: string;
@@ -334,6 +356,32 @@ function statusVisual(meta: MsgMetadata): StatusVisual {
       tone: "bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/40",
       label: "Blocked",
       testId: "block",
+    };
+  }
+  const sevRank = findingsMaxRank(meta.findings);
+  // Critical findings always escalate to a red warning even if the
+  // proxy allowed the request through (log-only enforcement mode).
+  // Labels reflect the truth: detected risks weren't enforced.
+  if (sevRank >= SEVERITY_RANK.critical) {
+    return {
+      icon: ShieldOff,
+      tone: "bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/40",
+      label:
+        meta.action === "allow"
+          ? "Critical findings (allowed by policy)"
+          : "Critical findings",
+      testId: "critical-findings",
+    };
+  }
+  if (sevRank >= SEVERITY_RANK.high) {
+    return {
+      icon: ShieldAlert,
+      tone: "bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/40",
+      label:
+        meta.action === "allow"
+          ? "High-severity findings (allowed by policy)"
+          : "High-severity findings",
+      testId: "high-findings",
     };
   }
   if (meta.action === "redact") {
@@ -905,6 +953,9 @@ function LabelingBlock(props: { meta: MsgMetadata }): ReactElement {
   const score = meta.securityScore;
   const pct = score == null ? null : Math.round(score * 100);
   const actionLabel = meta.blocked ? "block" : meta.action;
+  const sevRank = findingsMaxRank(meta.findings);
+  const isEscalated =
+    !meta.blocked && meta.action === "allow" && sevRank >= SEVERITY_RANK.high;
   return (
     <div className="space-y-1.5">
       <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -912,7 +963,17 @@ function LabelingBlock(props: { meta: MsgMetadata }): ReactElement {
       </div>
       <dl className="grid grid-cols-[max-content,1fr] gap-x-3 gap-y-1">
         <dt className="text-muted-foreground">Action</dt>
-        <dd data-testid="playground-details-action">{actionLabel}</dd>
+        <dd data-testid="playground-details-action">
+          {actionLabel}
+          {isEscalated && (
+            <span
+              data-testid="playground-details-action-warning"
+              className="ml-2 text-[10px] text-red-700 dark:text-red-300"
+            >
+              (allowed by policy — see Findings)
+            </span>
+          )}
+        </dd>
         <dt className="text-muted-foreground">Security score</dt>
         <dd data-testid="playground-details-score">{pct == null ? "—" : `${pct}/100`}</dd>
         <dt className="text-muted-foreground">Latency</dt>


### PR DESCRIPTION
## Reported

Sending a PII + injection payload through the proxy returned this trace:

- Action: `allow`
- Findings: `Medium · pii_detected (×4)`, `Medium · data_exfiltration`, **`Critical · ml_prompt_injection (×2)`**
- **Bubble overlay: green ShieldCheck "tick"**

The green tick directly contradicted the Critical findings the trace surfaced. The proxy is currently in `enforcement_mode: log` (action_router disabled), so it observes and tags but never returns action=block/redact — meaning the bubble overlay always read green regardless of severity.

## Fix

`statusVisual()` now derives the overlay from the **worst** of (proxy action, max finding severity):

| State | Icon | Tone | Label |
|---|---|---|---|
| Critical finding + action=allow | `ShieldOff` | **red** | "Critical findings (allowed by policy)" |
| High finding + action=allow | `ShieldAlert` | amber | "High-severity findings (allowed by policy)" |
| action=block | `ShieldOff` | red | "Blocked" (unchanged) |
| action=redact | `ShieldAlert` | amber | "Redacted" (unchanged) |
| action=allow, ≤Medium findings | `ShieldCheck` | green | "Allowed" (unchanged) |

The Details drawer also renders an inline warning next to the Action row whenever the escalation fires ("(allowed by policy — see Findings)"), so the verbatim trace metadata tells the same story as the icon.

## Test

New Playwright case `Critical findings escalate the bubble overlay to red even when action=allow` — mocks the chat with 200 and a trace span carrying Critical findings; asserts:
- `playground-status-critical-findings` present, red tone
- `playground-status-allow` count = 0 (no contradiction)
- aria-label contains "Critical findings...allowed by policy"
- Details drawer renders `playground-details-action-warning`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Live: redeploy + repeat the PII action chip; confirm overlay flips red and Action row shows the warning.

## Out of scope (separate)

The proxy is in **log-only** enforcement mode — that's a deployment config decision, not a UI bug. If actual redaction/blocking is desired, switch `enforcement_mode` to `enforce` (or `redact`) via env override on the proxy deployment. Filing as a separate concern; this PR fixes the misleading-UI symptom regardless.