### PR TITLE
fix(dashboard): forward all x-llmtrace-* response headers via prefix allow-list

### DIFF
--- a/dashboard/src/lib/proxy-helpers.ts
+++ b/dashboard/src/lib/proxy-helpers.ts
@@ -3,15 +3,16 @@ import { fetchWithFallback } from "./backend";
 import { isAuthDisabled } from "./auth";
 import { isUpstreamPublic } from "./public-paths";
 
-// Upstream response headers the browser needs to see. The proxy emits these
-// on every traced response; the /playground UI reads `x-llmtrace-trace-id`
-// to attach per-message metadata via /traces/{id}. Without forwarding, the
-// metadata pills never populate.
-const FORWARDED_RESPONSE_HEADERS: readonly string[] = [
-  "x-llmtrace-trace-id",
-  "x-llmtrace-tenant-id",
-  "x-request-id",
-];
+// Allow-list prefixes for upstream response headers that the browser
+// needs to see. The proxy emits `x-llmtrace-*` for every traced response
+// (trace-id, action, score, policy-mode, findings, etc.) plus
+// `x-request-id` for cross-system correlation. A prefix match means new
+// `x-llmtrace-*` headers added on the proxy side flow through without
+// further dashboard changes — see incident on 2026-05-27 where #297's
+// new x-llmtrace-action / x-llmtrace-score / x-llmtrace-policy-mode
+// headers were silently stripped by an earlier hardcoded name list.
+const FORWARDED_RESPONSE_HEADER_PREFIXES: readonly string[] = ["x-llmtrace-"];
+const FORWARDED_RESPONSE_HEADER_NAMES: readonly string[] = ["x-request-id"];
 
 function buildHeaders(
   req: NextRequest,
@@ -67,10 +68,19 @@ function buildResponseHeaders(res: Response): Record<string, string> {
   const out: Record<string, string> = {
     "Content-Type": res.headers.get("Content-Type") ?? "application/json",
   };
-  for (const name of FORWARDED_RESPONSE_HEADERS) {
-    const value = res.headers.get(name);
-    if (value) out[name] = value;
-  }
+  res.headers.forEach((value, name) => {
+    const lower = name.toLowerCase();
+    if (FORWARDED_RESPONSE_HEADER_NAMES.includes(lower)) {
+      out[lower] = value;
+      return;
+    }
+    for (const prefix of FORWARDED_RESPONSE_HEADER_PREFIXES) {
+      if (lower.startsWith(prefix)) {
+        out[lower] = value;
+        return;
+      }
+    }
+  });
   return out;
 }
 


### PR DESCRIPTION
PR #297 added new response headers on the proxy side (`x-llmtrace-action`, `x-llmtrace-score`, `x-llmtrace-policy-mode`). The dashboard's `proxy-helpers.ts` had a hardcoded three-name allow-list and silently dropped them.

Fix: switch to a prefix allow-list on `x-llmtrace-*` plus explicit `x-request-id`. Future `x-llmtrace-*` headers added on the proxy will flow through automatically.

## Evidence (live, before this PR)

```
$ curl $PROXY/v1/chat/completions ...
  x-llmtrace-trace-id: 2764d6c5-...
  x-llmtrace-action: allow
  x-llmtrace-policy-mode: log     ← proxy emits

$ curl $DASH/api/proxy/v1/chat/completions ...
  x-llmtrace-trace-id: ec39b1d7-...
  (no action, no policy-mode)     ← dashboard stripped
```

After this PR, all three flow through. Body envelope (`llmtrace` top-level field) was already passing through unmodified — that change isn't needed.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Live: redeploy, dashboard chat returns x-llmtrace-action / score / policy-mode headers