### PR TITLE
fix(proxy): skip null prompt/stream on advisory round-trip (closes #311)

### DIFF
--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -272,9 +272,13 @@ pub(crate) struct LLMRequestBody {
     pub model: String,
     #[serde(default)]
     pub messages: Vec<ChatMessage>,
-    #[serde(default)]
+    /// Legacy `/v1/completions` field. Skip on serialize when absent so
+    /// the proxy round-trip (advisory injection / envelope) does NOT
+    /// emit `"prompt": null` on chat-completions bodies — OpenAI rejects
+    /// unrecognized fields with HTTP 400.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
     /// Anthropic top-level system parameter (not in messages array).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3423,6 +3427,57 @@ mod tests {
         assert!(
             content.contains("Policy mode: log (the proxy did NOT modify this request"),
             "log-mode suffix must be present with leading space; got: {content}"
+        );
+    }
+
+    // Regression: advisory injection re-serializes through
+    // `LLMRequestBody`. When the original request omitted the legacy
+    // `prompt` field (any modern chat-completions call), the round-trip
+    // MUST NOT emit `"prompt": null` — OpenAI rejects unrecognized
+    // fields on `/v1/chat/completions` with HTTP 400. Same for `stream`.
+    #[test]
+    fn test_advisory_round_trip_omits_null_prompt_and_stream() {
+        let original = br#"{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}"#;
+        let advisory = ChatMessage {
+            role: "system".to_string(),
+            content: serde_json::Value::String("notice".to_string()),
+            extra: serde_json::Map::new(),
+        };
+        let rewritten = inject_advisory_into_body(original, advisory).expect("body must rewrite");
+        let v: serde_json::Value = serde_json::from_slice(&rewritten).expect("valid JSON");
+        let obj = v.as_object().expect("object");
+        assert!(
+            !obj.contains_key("prompt"),
+            "round-trip must NOT emit `prompt` key when input had none; got: {v}"
+        );
+        assert!(
+            !obj.contains_key("stream"),
+            "round-trip must NOT emit `stream` key when input had none; got: {v}"
+        );
+        assert_eq!(
+            v["messages"].as_array().map(|a| a.len()),
+            Some(2),
+            "messages must include advisory + original; got: {v}"
+        );
+    }
+
+    // Conversely: when the original request DID set `stream: true`,
+    // the round-trip must preserve it.
+    #[test]
+    fn test_advisory_round_trip_preserves_explicit_stream() {
+        let original =
+            br#"{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"hi"}]}"#;
+        let advisory = ChatMessage {
+            role: "system".to_string(),
+            content: serde_json::Value::String("notice".to_string()),
+            extra: serde_json::Map::new(),
+        };
+        let rewritten = inject_advisory_into_body(original, advisory).expect("body must rewrite");
+        let v: serde_json::Value = serde_json::from_slice(&rewritten).expect("valid JSON");
+        assert_eq!(
+            v["stream"].as_bool(),
+            Some(true),
+            "explicit stream:true must survive round-trip; got: {v}"
         );
     }
 }


### PR DESCRIPTION
Closes #311.

## Summary

PR #310 exposed a latent regression: when advisory injection fires, the proxy re-serializes the request body through \`LLMRequestBody\`, which emits \`\"prompt\": null\` and \`\"stream\": null\` because those \`Option<>\` fields lack \`skip_serializing_if = \"Option::is_none\"\`. OpenAI's \`/v1/chat/completions\` rejects unrecognized fields with HTTP 400. The bug is latent since #297 but only surfaced now because #310 made advisory injection actually fire on live traffic.

## Live evidence

\`\`\`
Direct proxy call, benign payload (\"hello\")          → 200 OK (no advisory, no re-serialize)
Direct proxy call, DAN injection payload             → 400 from upstream
  envelope.advisory_injected: true                  ← #310 working
  envelope.forwarded_request.messages[0]:
    <<LLMTRACE_SECURITY_NOTICE ...                  ← #310 working
  upstream error: \"Unrecognized request argument supplied: prompt\"
\`\`\`

## Fix

\`crates/llmtrace-proxy/src/proxy.rs\` — add \`skip_serializing_if = \"Option::is_none\"\` to \`LLMRequestBody.prompt\` and \`LLMRequestBody.stream\`. Matches the pattern already used on \`system\` in the same struct.

## Tests added

In \`mod tests\` (unit tests):

- \`test_advisory_round_trip_omits_null_prompt_and_stream\` — input \`{\"model\",\"messages\"}\`; after advisory injection, the rewritten body must NOT contain \`prompt\` or \`stream\` keys.
- \`test_advisory_round_trip_preserves_explicit_stream\` — input \`{\"stream\":true,...}\`; round-trip must preserve \`stream: true\`.

## Local verification

\`\`\`
cargo fmt --all --check                                   clean
cargo clippy --workspace -- -D warnings                   clean
cargo test -p llmtrace --lib                              622 passed; 0 failed
cargo test -p llmtrace --test integration_test            39 passed; 0 failed
\`\`\`

## Test plan

- [ ] CI green on this PR.
- [ ] After merge + redeploy: rerun the DAN payload through the proxy. Must return HTTP 200 from upstream WITH envelope intact (advisory_injected: true, findings populated, forwarded_request.messages[0] starts with \`<<LLMTRACE_SECURITY_NOTICE\`).