### PR TITLE
ci(e2e): pull pre-baked Playwright browsers from mcr.microsoft.com image (#303)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,11 +353,36 @@ jobs:
           cache: 'npm'
           cache-dependency-path: dashboard/package-lock.json
 
-      - name: Install Playwright
+      # Pull the official Playwright image and copy its pre-baked
+      # browser binaries to the runner's playwright cache instead of
+      # downloading from cdn.playwright.dev. The CDN has hung mid-
+      # install repeatedly (#303); the mcr.microsoft.com image is
+      # versioned with `@playwright/test` and reliably pull-able from
+      # GitHub Azure runners. apt-deps still come via
+      # `playwright install-deps` (system libs only, no CDN).
+      # Pin the image tag in lock-step with `@playwright/test` in
+      # dashboard/package.json — bump both together.
+      - name: Install npm dependencies
+        run: cd dashboard && npm ci
+
+      - name: Install Playwright browsers (from mcr image)
+        timeout-minutes: 8
+        env:
+          PW_IMAGE: mcr.microsoft.com/playwright:v1.58.2-noble
         run: |
-          cd dashboard
-          npm ci
-          npx playwright install --with-deps
+          set -euo pipefail
+          docker pull "$PW_IMAGE"
+          mkdir -p "$HOME/.cache/ms-playwright"
+          # Create a throwaway container to lift the browser directory
+          # off the image. `docker create` does NOT start it, so this
+          # costs only the fs-copy time.
+          cid=$(docker create "$PW_IMAGE")
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+          docker cp "$cid:/ms-playwright/." "$HOME/.cache/ms-playwright/"
+          # System deps (apt only, no CDN). Required so the host-side
+          # browser launch finds its shared libraries even though the
+          # binaries themselves came from the image.
+          cd dashboard && npx playwright install-deps
 
       - name: Build and Start Stack
         env:


### PR DESCRIPTION
Supersedes #308. Closes #303.

## Why

The Playwright CDN (\`cdn.playwright.dev\`) has been intermittently hanging mid-install (#303), and the cache + timeout approach in #308 only helps once a successful cold-cache install populates the cache. Today's runs prove the CDN is unreliable enough that we can't get that 'first good install' through.

The official Microsoft container image \`mcr.microsoft.com/playwright:v1.58.2-noble\` already contains pre-baked browser binaries at \`/ms-playwright\`. Docker pulls from \`ghcr.io\`/\`mcr.microsoft.com\` have been reliable on Azure runners. Pulling the image and copying its \`/ms-playwright\` to the runner's playwright cache removes the CDN dependency entirely.

## Change

\`.github/workflows/ci.yml\` — the \`Install Playwright\` step is replaced by:

1. \`npm ci\` (unchanged dep install).
2. \`docker pull mcr.microsoft.com/playwright:v1.58.2-noble\`, version-pinned to \`@playwright/test\` in \`dashboard/package.json\`.
3. \`docker create\` + \`docker cp\` to lift \`/ms-playwright/\` from the image into \`\$HOME/.cache/ms-playwright/\`. The container is never started, so the cost is just the fs-copy time (~5-15s).
4. \`npx playwright install-deps\` — apt-only system libs (libgbm, libnss, etc.) so the host-side browser launch finds shared libraries. No CDN involved.
5. \`timeout-minutes: 8\` on the step as a defense in depth.

Job stays on \`ubuntu-latest\` — \`docker compose up\` for the proxy + dashboard stack works unchanged on the host runner.

## Why not \`container: mcr.microsoft.com/playwright:...\`?

The e2e job uses \`docker compose up\` to bring up the proxy + dashboard stack. Running the whole job inside a container would require docker-in-docker or mounted host docker socket, neither of which is wired up in this workflow. Lifting just the browser binaries from the image keeps the change localized.

## Test plan

- [ ] CI on this PR. The \`Install Playwright browsers (from mcr image)\` step should complete in under 1 min on every run.
- [ ] Subsequent PRs after merge: no manual cancel + rerun on Playwright hangs.

## When upgrading \`@playwright/test\`

Bump \`PW_IMAGE\` in \`ci.yml\` in the same commit. The two must move together — the image tag is the contract.