### PR TITLE
fix(dashboard): use SecurityFinding.confidence_score field from trace API

### DIFF
--- a/dashboard/src/app/traces/[id]/page.tsx
+++ b/dashboard/src/app/traces/[id]/page.tsx
@@ -196,7 +196,7 @@ export default function TraceDetailPage(props: {
                         </Badge>
                         <span className="text-sm font-medium">{f.finding_type}</span>
                         <span className="ml-auto text-xs text-muted-foreground">
-                          Confidence: {(f.confidence * 100).toFixed(0)}%
+                          Confidence: {(f.confidence_score * 100).toFixed(0)}%
                         </span>
                       </div>
                       <Separator className="my-2" />

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -61,7 +61,7 @@ export interface SecurityFinding {
   severity: string;
   finding_type: string;
   description: string;
-  confidence: number;
+  confidence_score: number;
   detected_at: string;
 }
 


### PR DESCRIPTION
## Summary

Closes the \`Confidence: NaN%\` rendering on the traces detail page (\`/traces/:id\` → Security tab → each finding row). Backend \`SecurityFinding\` ships \`confidence_score: f64\` ([crates/llmtrace-core/src/lib.rs:240](https://github.com/techlab-innov/llmtrace/blob/main/crates/llmtrace-core/src/lib.rs)). The dashboard's TS interface declared \`confidence: number\`, so \`f.confidence\` was \`undefined\`, \`undefined * 100\` was \`NaN\`, and \`NaN.toFixed(0)\` rendered as \`"NaN"\`.

## Change

- \`dashboard/src/lib/api.ts\` — \`SecurityFinding.confidence\` → \`confidence_score\`.
- \`dashboard/src/app/traces/[id]/page.tsx\` — \`f.confidence\` → \`f.confidence_score\` (line ~199).

The playground (\`_client.tsx\`) is unchanged: it uses a separate \`RawFinding\`/\`MsgFinding\` shape that reads the envelope, which is \`confidence\` by design.

## Test plan

- [ ] CI green.
- [ ] Live: open any trace from /traces, expand the Security tab — Confidence column shows real percentages (was NaN%).