### PR TITLE
fix(proxy,dashboard): floor confidence display so <100 never renders as 100

### DIFF
--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -817,7 +817,7 @@ fn build_advisory_system_message(findings: &[SecurityFinding], policy_mode: &str
         .take(ADVISORY_MAX_UNIQUE_FINDING_TYPES)
         .map(|key| {
             let (sev, conf, count) = groups[&key].clone();
-            let pct = (conf.clamp(0.0, 1.0) * 100.0).round() as u32;
+            let pct = (conf.clamp(0.0, 1.0) * 100.0).floor() as u32;
             let (ftype, desc) = key;
             let suffix = if count > 1 {
                 format!(" [x{count}]")
@@ -3403,6 +3403,30 @@ mod tests {
         assert!(
             content.contains("<<END_LLMTRACE_SECURITY_NOTICE>>"),
             "advisory must include the end marker; got: {content}"
+        );
+    }
+
+    #[test]
+    fn test_advisory_template_floors_confidence_does_not_round_up_to_100() {
+        // 0.9962989687919617 * 100 = 99.62...; round() would yield 100, floor() must yield 99.
+        let findings = vec![finding(
+            "prompt_injection",
+            SecuritySeverity::High,
+            "near-certain injection",
+            0.996_298_968_791_961_7,
+        )];
+        let msg = build_advisory_system_message(&findings, "enforce");
+        let content = match &msg.content {
+            serde_json::Value::String(s) => s.clone(),
+            other => panic!("advisory content must be a string; got {other:?}"),
+        };
+        assert!(
+            content.contains("confidence 99%"),
+            "floor must yield 99%, not 100%; got: {content}"
+        );
+        assert!(
+            !content.contains("confidence 100%"),
+            "floor must not round up to 100%; got: {content}"
         );
     }
 

--- a/dashboard/src/app/traces/[id]/page.tsx
+++ b/dashboard/src/app/traces/[id]/page.tsx
@@ -196,7 +196,7 @@ export default function TraceDetailPage(props: {
                         </Badge>
                         <span className="text-sm font-medium">{f.finding_type}</span>
                         <span className="ml-auto text-xs text-muted-foreground">
-                          Confidence: {(f.confidence_score * 100).toFixed(0)}%
+                          Confidence: {Math.floor(f.confidence_score * 100)}%
                         </span>
                       </div>
                       <Separator className="my-2" />


### PR DESCRIPTION
## Summary

Confidence of 0.9962989687919617 was rendering as \`100%\` (via \`.round()\` in Rust and \`.toFixed(0)\` in JS). We don't want to overstate certainty — under 100 should display as < 100. Fixing both layers to floor.

## Changes

- \`crates/llmtrace-proxy/src/proxy.rs build_advisory_system_message\` — \`.round() as u32\` → \`.floor() as u32\` on the percentage rendering.
- \`dashboard/src/app/traces/[id]/page.tsx\` — change percent rendering to floor instead of \`.toFixed(0)\` (which banker-rounds).

The playground client's metadata rendering uses the envelope's confidence values; the same display logic applies. Branch only touches the two key rendering sites identified in the brief.

## Tests

New Rust unit test:

- \`test_advisory_template_floors_confidence_does_not_round_up_to_100\` — feed a finding with \`confidence_score = 0.9962989687919617\`; assert the rendered template contains \`"confidence 99%"\` and does NOT contain \`"confidence 100%"\`.

## Verification

\`cargo fmt --all --check\` clean. \`cargo clippy --workspace -- -D warnings\` clean. Targeted tests pass.

## Coordination note

This PR coexists with #317 (renames \`confidence\` → \`confidence_score\` in the dashboard's TS interface). If #317 merges first, this PR will still apply cleanly on rebase because it only changes the rendering expression, not the field name.

## Test plan

- [ ] CI green.
- [ ] Live: send a payload triggering 99.6% confidence → advisory bullets render as \"confidence 99%\" not \"100%\". Trace detail page same.