### PR TITLE
feat(dashboard): default to dark mode, add light toggle + semantic palette tokens

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -21,6 +21,7 @@
         "lodash": "^4.18.1",
         "lucide-react": "^0.468.0",
         "next": "^15.5.18",
+        "next-themes": "^0.4.6",
         "picomatch": "^4.0.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -5621,6 +5622,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-releases": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -24,6 +24,7 @@
     "lodash": "^4.18.1",
     "lucide-react": "^0.468.0",
     "next": "^15.5.18",
+    "next-themes": "^0.4.6",
     "picomatch": "^4.0.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -22,26 +22,64 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
+
+    --success: 142 71% 38%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 45%;
+    --warning-foreground: 0 0% 100%;
+    --info: 199 89% 42%;
+    --info-foreground: 0 0% 100%;
+
+    --severity-critical: 0 84% 50%;
+    --severity-critical-foreground: 0 0% 100%;
+    --severity-high: 25 95% 45%;
+    --severity-high-foreground: 0 0% 100%;
+    --severity-medium: 38 92% 45%;
+    --severity-medium-foreground: 0 0% 100%;
+    --severity-low: 199 89% 42%;
+    --severity-low-foreground: 0 0% 100%;
+    --severity-info: 220 9% 46%;
+    --severity-info-foreground: 0 0% 100%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --background: 220 13% 9%;
+    --foreground: 210 20% 98%;
+    --card: 220 13% 12%;
+    --card-foreground: 210 20% 98%;
+    --popover: 220 13% 12%;
+    --popover-foreground: 210 20% 98%;
+    --primary: 210 40% 96%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 220 13% 16%;
+    --secondary-foreground: 210 20% 98%;
+    --muted: 220 13% 16%;
+    --muted-foreground: 220 9% 65%;
+    --accent: 220 13% 18%;
+    --accent-foreground: 210 20% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 210 20% 98%;
+    --border: 220 13% 18%;
+    --input: 220 13% 18%;
+    --ring: 220 13% 30%;
+
+    --success: 142 71% 45%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 0%;
+    --info: 199 89% 48%;
+    --info-foreground: 0 0% 100%;
+
+    --severity-critical: 0 84% 60%;
+    --severity-critical-foreground: 0 0% 100%;
+    --severity-high: 25 95% 53%;
+    --severity-high-foreground: 0 0% 100%;
+    --severity-medium: 38 92% 50%;
+    --severity-medium-foreground: 0 0% 0%;
+    --severity-low: 199 89% 48%;
+    --severity-low-foreground: 0 0% 100%;
+    --severity-info: 220 9% 46%;
+    --severity-info-foreground: 0 0% 100%;
   }
 }
 

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { AppShell } from "@/components/app-shell";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,9 +17,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <AppShell>{children}</AppShell>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem={false}
+          disableTransitionOnChange
+        >
+          <AppShell>{children}</AppShell>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/dashboard/src/components/THEME_TOKENS.md
+++ b/dashboard/src/components/THEME_TOKENS.md
@@ -1,0 +1,29 @@
+# Theme tokens reference (Wave 2 / Wave 3)
+
+All tokens are defined in `src/app/globals.css` and exposed to Tailwind via `tailwind.config.ts`.
+
+## Status tokens
+
+| CSS variable | Tailwind class | Purpose |
+|---|---|---|
+| `--success` / `--success-foreground` | `bg-success text-success-foreground` | Positive / healthy state indicators |
+| `--warning` / `--warning-foreground` | `bg-warning text-warning-foreground` | Degraded / caution state |
+| `--info` / `--info-foreground` | `bg-info text-info-foreground` | Informational, neutral-positive |
+
+## Severity tokens
+
+| CSS variable | Tailwind class | Severity level |
+|---|---|---|
+| `--severity-critical` / `--severity-critical-foreground` | `bg-severity-critical text-severity-critical-foreground` | Critical |
+| `--severity-high` / `--severity-high-foreground` | `bg-severity-high text-severity-high-foreground` | High |
+| `--severity-medium` / `--severity-medium-foreground` | `bg-severity-medium text-severity-medium-foreground` | Medium |
+| `--severity-low` / `--severity-low-foreground` | `bg-severity-low text-severity-low-foreground` | Low |
+| `--severity-info` / `--severity-info-foreground` | `bg-severity-info text-severity-info-foreground` | Informational |
+
+## Color rules
+
+- Never use raw Tailwind palette classes like `bg-amber-500`, `text-red-600`, `bg-green-500` etc. for status or severity indication. Use the semantic tokens above.
+- For chips and badges, use the translucent chip pattern: `bg-severity-X/15 text-severity-X border border-severity-X/30`.
+  - Example: `<span className="bg-severity-critical/15 text-severity-critical border border-severity-critical/30 rounded px-2 py-0.5 text-xs">Critical</span>`
+- For filled backgrounds (alert banners, toasts): `bg-success text-success-foreground`.
+- Both `:root` (light) and `.dark` blocks define these tokens, so all classes adapt automatically on theme switch.

--- a/dashboard/src/components/app-shell.tsx
+++ b/dashboard/src/components/app-shell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { Sidebar } from "@/components/sidebar";
 import { LoadingOverlay } from "@/components/loading-overlay";
 import { ReconnectBanner } from "@/components/reconnect-banner";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const UNCHROMED_PATHS: readonly string[] = ["/login"];
 
@@ -228,7 +229,10 @@ function ChromedShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto">
+      <main className="flex flex-col flex-1 overflow-y-auto">
+        <header className="flex items-center justify-end px-4 py-2 border-b border-border">
+          <ThemeToggle />
+        </header>
         {showReconnectBanner && (
           <ReconnectBanner
             attempt={retryAttempt > 0 ? retryAttempt : undefined}

--- a/dashboard/src/components/theme-provider.tsx
+++ b/dashboard/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import type { ThemeProviderProps } from "next-themes";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps): React.ReactElement {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/dashboard/src/components/theme-toggle.tsx
+++ b/dashboard/src/components/theme-toggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle(): React.ReactElement {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = theme === "dark";
+
+  const toggle = () => setTheme(isDark ? "light" : "dark");
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label="Toggle theme"
+      data-testid="theme-toggle"
+    >
+      {mounted ? (
+        isDark ? (
+          <Sun className="h-4 w-4" />
+        ) : (
+          <Moon className="h-4 w-4" />
+        )
+      ) : (
+        <span className="h-4 w-4" aria-hidden="true" />
+      )}
+      <span className="sr-only">{mounted && isDark ? "Switch to light mode" : "Switch to dark mode"}</span>
+    </Button>
+  );
+}

--- a/dashboard/tailwind.config.ts
+++ b/dashboard/tailwind.config.ts
@@ -41,6 +41,38 @@ const config: Config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+        "severity-critical": {
+          DEFAULT: "hsl(var(--severity-critical))",
+          foreground: "hsl(var(--severity-critical-foreground))",
+        },
+        "severity-high": {
+          DEFAULT: "hsl(var(--severity-high))",
+          foreground: "hsl(var(--severity-high-foreground))",
+        },
+        "severity-medium": {
+          DEFAULT: "hsl(var(--severity-medium))",
+          foreground: "hsl(var(--severity-medium-foreground))",
+        },
+        "severity-low": {
+          DEFAULT: "hsl(var(--severity-low))",
+          foreground: "hsl(var(--severity-low-foreground))",
+        },
+        "severity-info": {
+          DEFAULT: "hsl(var(--severity-info))",
+          foreground: "hsl(var(--severity-info-foreground))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary

Wave 1 of 3 for the dark-mode-default rollout. Adds the infrastructure: the dashboard now defaults to dark mode, persists the user's choice across reloads via \`next-themes\`, and exposes a light-mode toggle (Sun/Moon icon) in the app header.

**Wave 2 (pages + shared components color audit) and Wave 3 (Playwright visual verification) follow this PR.** This PR deliberately does NOT replace any hardcoded \`bg-amber-500\` / \`text-red-600\` etc. in existing pages or components — that's Wave 2's scope. The semantic tokens added here are the contract Wave 2 will adopt.

## Changes (9 files)

- \`dashboard/package.json\` + \`package-lock.json\` — \`next-themes@0.4.6\` added.
- \`dashboard/src/components/theme-provider.tsx\` — thin client wrapper over \`NextThemesProvider\`.
- \`dashboard/src/components/theme-toggle.tsx\` — ghost icon button (\`Sun\`/\`Moon\` from \`lucide-react\`); \`mounted\` guard against SSR mismatch; \`data-testid=\"theme-toggle\"\`; \`aria-label\`; \`<span className=\"sr-only\">\` description.
- \`dashboard/src/app/layout.tsx\` — \`suppressHydrationWarning\` on \`<html>\`; wraps \`AppShell\` in \`<ThemeProvider attribute=\"class\" defaultTheme=\"dark\" enableSystem={false} disableTransitionOnChange>\`.
- \`dashboard/src/components/app-shell.tsx\` — \`<header>\` bar at top of \`<main>\` containing \`<ThemeToggle />\`. No layout restructure.
- \`dashboard/src/app/globals.css\` — refined \`.dark\` palette (slate/gunmetal base, raised card surface). Added new tokens to both \`:root\` and \`.dark\`:
  - Status: \`--success\`, \`--warning\`, \`--info\` + foregrounds
  - Severity: \`--severity-critical\` / \`-high\` / \`-medium\` / \`-low\` / \`-info\` + foregrounds
- \`dashboard/tailwind.config.ts\` — registers all new tokens under \`theme.extend.colors\` so Wave 2 can write \`bg-severity-critical/15 text-severity-critical\` etc.
- \`dashboard/src/components/THEME_TOKENS.md\` — Wave 2/3 reference (chip patterns, color rules).

## Notes from the agent

- Used \`next-themes@0.4.6\` — types come from the package root, not the \`dist/types\` path the brief originally referenced (which doesn't exist in 0.4.x). Adjusted the import accordingly.
- The dev server smoke test was not run (no display/port in the sub-agent env); \`npm run build\` succeeded with all 18 static pages generated, confirming type + import correctness.

## Verification

- \`npm run lint\` exit 0 (warnings pre-existing in unrelated files)
- \`npm run build\` exit 0 (18 static pages generated)

## Test plan

- [ ] CI green.
- [ ] After merge: dashboard loads in dark theme by default. Click the toggle in the top-right of the header → switches to light. Reload → comes back in chosen theme (persisted via localStorage).
- [ ] Wave 2 (separate PRs) replaces hardcoded color classes in the 10 existing files with the new semantic tokens or \`dark:\` variants.