### PR TITLE
feat(dashboard): pages dark-mode color audit + remediation

### DIFF
--- a/dashboard/e2e/feature-gaps.spec.ts
+++ b/dashboard/e2e/feature-gaps.spec.ts
@@ -100,7 +100,7 @@ test.describe("Dashboard Coverage Gaps", () => {
 
     await expect(page.locator("span.font-mono", { hasText: "Enabled" }).first()).toBeVisible();
     await expect(
-      page.locator("span.font-mono.text-amber-700", { hasText: "Redacted" }).first(),
+      page.locator("span.font-mono.text-warning", { hasText: "Redacted" }).first(),
     ).toBeVisible();
     await expect(page.locator("span.text-muted-foreground", { hasText: "None" }).first()).toBeVisible();
   });

--- a/dashboard/e2e/playground.spec.ts
+++ b/dashboard/e2e/playground.spec.ts
@@ -370,7 +370,9 @@ test.describe("Playground page (issues #284, #287, #289)", () => {
     const blockOverlay = userMsg.getByTestId("playground-status-block");
     await expect(blockOverlay).toBeVisible();
     const overlayCls = (await blockOverlay.getAttribute("class")) ?? "";
-    expect(overlayCls).toContain("red");
+    // After the dark-mode token migration the block tone uses the
+    // semantic severity-critical token (red-family in both themes).
+    expect(overlayCls).toContain("severity-critical");
 
     // Expanding details exposes the block reason.
     await userMsg.getByTestId("playground-toggle-details").click();
@@ -406,9 +408,10 @@ test.describe("Playground page (issues #284, #287, #289)", () => {
     await expect(escalated.first()).toBeVisible({ timeout: 10_000 });
     await expect(escalated).toHaveCount(2);
 
-    // Escalated overlay must carry the red tone.
+    // Escalated overlay must carry the critical (red-family) tone via
+    // the semantic severity-critical token.
     const cls = (await escalated.first().getAttribute("class")) ?? "";
-    expect(cls).toContain("red");
+    expect(cls).toContain("severity-critical");
 
     // No green "allow" overlay should be present on either bubble — it
     // would directly contradict the escalation.

--- a/dashboard/src/app/compliance/page.tsx
+++ b/dashboard/src/app/compliance/page.tsx
@@ -166,11 +166,11 @@ function ReportViewer({ report }: { report: ComplianceReport }) {
 
   return (
     <div className="print:p-0">
-      <Card className="border-green-600 bg-green-500/5 shadow-md print:border-none print:bg-white print:shadow-none">
+      <Card className="border-success/40 bg-success/5 shadow-md print:border-none print:bg-white print:shadow-none">
         <CardHeader className="flex flex-row items-center justify-between pb-4 border-b">
           <div className="space-y-1">
             <CardTitle className="flex items-center gap-2 text-2xl">
-              <CheckCircle className="h-6 w-6 text-green-600 print:text-black" />
+              <CheckCircle className="h-6 w-6 text-success print:text-foreground" />
               {report.report_type.toUpperCase()} Compliance Audit
             </CardTitle>
             <CardDescription className="text-sm font-medium">
@@ -225,10 +225,10 @@ function ReportViewer({ report }: { report: ComplianceReport }) {
                 </button>
                 
                 {showRaw && (
-                  <div className="mt-4 rounded-xl border bg-slate-950 p-4 shadow-inner">
+                  <div className="mt-4 rounded-xl border bg-card p-4 shadow-inner">
                     <pre
                       data-testid="report-raw-content"
-                      className="text-[10px] leading-relaxed text-slate-300 overflow-auto max-h-[300px] scrollbar-thin scrollbar-thumb-slate-700"
+                      className="text-[10px] leading-relaxed text-foreground overflow-auto max-h-[300px] scrollbar-thin scrollbar-thumb-muted"
                     >
                       {JSON.stringify(report.content, null, 2)}
                     </pre>
@@ -396,7 +396,7 @@ export default function CompliancePage() {
         <div className="space-y-4 animate-in fade-in slide-in-from-top-4 duration-300">
           <div className="flex items-center justify-between print:hidden">
             <h2 data-testid="active-report-viewer" className="text-xl font-bold flex items-center gap-2">
-              <div className="w-1.5 h-6 bg-green-600 rounded-full" />
+              <div className="w-1.5 h-6 bg-success rounded-full" />
               Active Viewer
             </h2>
             <Button

--- a/dashboard/src/app/costs/page.tsx
+++ b/dashboard/src/app/costs/page.tsx
@@ -149,7 +149,7 @@ export default function CostsPage() {
                         w.utilization_pct >= 80
                           ? "bg-destructive"
                           : w.utilization_pct >= 50
-                            ? "bg-yellow-500"
+                            ? "bg-warning"
                             : "bg-primary"
                       }`}
                       style={{ width: `${Math.min(100, w.utilization_pct)}%` }}
@@ -186,11 +186,11 @@ export default function CostsPage() {
                 <XAxis dataKey="name" className="text-xs" />
                 <YAxis className="text-xs" />
                 <Tooltip formatter={(value: number) => `$${value.toFixed(4)}`} />
-                <Bar dataKey="spent" name="Spent" fill="#ea580c" radius={[4, 4, 0, 0]} />
+                <Bar dataKey="spent" name="Spent" fill="hsl(var(--destructive))" radius={[4, 4, 0, 0]} />
                 <Bar
                   dataKey="remaining"
                   name="Remaining"
-                  fill="hsl(210 40% 96.1%)"
+                  fill="hsl(var(--muted))"
                   radius={[4, 4, 0, 0]}
                 />
               </BarChart>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -31,14 +31,20 @@ import {
 } from "@/lib/api";
 
 const SEVERITY_COLORS: Record<string, string> = {
-  Critical: "#dc2626",
-  High: "#ea580c",
-  Medium: "#ca8a04",
-  Low: "#2563eb",
-  Info: "#6b7280",
+  Critical: "hsl(var(--severity-critical))",
+  High: "hsl(var(--severity-high))",
+  Medium: "hsl(var(--severity-medium))",
+  Low: "hsl(var(--severity-low))",
+  Info: "hsl(var(--severity-info))",
 };
 
-const PIE_COLORS = ["#dc2626", "#ea580c", "#ca8a04", "#2563eb", "#6b7280"];
+const PIE_COLORS = [
+  "hsl(var(--severity-critical))",
+  "hsl(var(--severity-high))",
+  "hsl(var(--severity-medium))",
+  "hsl(var(--severity-low))",
+  "hsl(var(--severity-info))",
+];
 
 export default function OverviewPage() {
   const [stats, setStats] = useState<StorageStats | null>(null);
@@ -210,7 +216,7 @@ export default function OverviewPage() {
                 <XAxis dataKey="hour" className="text-xs" />
                 <YAxis className="text-xs" />
                 <Tooltip />
-                <Bar dataKey="traces" fill="hsl(222.2 47.4% 11.2%)" radius={[4, 4, 0, 0]} />
+                <Bar dataKey="traces" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>

--- a/dashboard/src/app/playground/_client.tsx
+++ b/dashboard/src/app/playground/_client.tsx
@@ -594,7 +594,7 @@ function statusVisual(meta: MsgMetadata): StatusVisual {
   if (meta.blocked || meta.action === "block") {
     return {
       icon: ShieldOff,
-      tone: "bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/40",
+      tone: "bg-severity-critical/15 text-severity-critical border-severity-critical/40",
       label: "Blocked",
       testId: "block",
     };
@@ -606,7 +606,7 @@ function statusVisual(meta: MsgMetadata): StatusVisual {
   if (sevRank >= SEVERITY_RANK.critical) {
     return {
       icon: ShieldOff,
-      tone: "bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/40",
+      tone: "bg-severity-critical/15 text-severity-critical border-severity-critical/40",
       label:
         meta.action === "allow"
           ? "Critical findings (allowed by policy)"
@@ -617,7 +617,7 @@ function statusVisual(meta: MsgMetadata): StatusVisual {
   if (sevRank >= SEVERITY_RANK.high) {
     return {
       icon: ShieldAlert,
-      tone: "bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/40",
+      tone: "bg-severity-high/15 text-severity-high border-severity-high/40",
       label:
         meta.action === "allow"
           ? "High-severity findings (allowed by policy)"
@@ -628,7 +628,7 @@ function statusVisual(meta: MsgMetadata): StatusVisual {
   if (meta.action === "redact") {
     return {
       icon: ShieldAlert,
-      tone: "bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/40",
+      tone: "bg-warning/15 text-warning border-warning/40",
       label: "Redacted",
       testId: "redact",
     };
@@ -636,7 +636,7 @@ function statusVisual(meta: MsgMetadata): StatusVisual {
   if (meta.action === "allow") {
     return {
       icon: ShieldCheck,
-      tone: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/40",
+      tone: "bg-success/15 text-success border-success/40",
       label: "Allowed",
       testId: "allow",
     };
@@ -1302,7 +1302,7 @@ function LabelingBlock(props: { meta: MsgMetadata }): ReactElement {
           {isEscalated && (
             <span
               data-testid="playground-details-action-warning"
-              className="ml-2 text-[10px] text-red-700 dark:text-red-300"
+              className="ml-2 text-[10px] text-severity-critical"
             >
               (allowed by policy — see Findings)
             </span>
@@ -1321,7 +1321,7 @@ function LabelingBlock(props: { meta: MsgMetadata }): ReactElement {
         {meta.blockedReason && (
           <>
             <dt className="text-muted-foreground">Reason</dt>
-            <dd className="text-red-700 dark:text-red-300">{meta.blockedReason}</dd>
+            <dd className="text-severity-critical">{meta.blockedReason}</dd>
           </>
         )}
         <dt className="text-muted-foreground" title="Analyzers run on the whole conversation each turn, not just the latest user message. A finding here may correspond to an earlier turn's content.">
@@ -1392,7 +1392,7 @@ function RawBlock(props: {
       </div>
       <pre
         data-testid={props.testId}
-        className="max-h-64 overflow-auto rounded-md border bg-background px-2 py-1.5 text-[10px] leading-snug"
+        className="max-h-64 overflow-auto rounded-md border border-border bg-card text-foreground px-2 py-1.5 text-[10px] leading-snug"
       >
         {prettyJson(props.body)}
       </pre>

--- a/dashboard/src/app/security/page.tsx
+++ b/dashboard/src/app/security/page.tsx
@@ -27,11 +27,19 @@ import {
 } from "@/lib/api";
 
 const SEVERITY_COLORS: Record<string, string> = {
-  Critical: "#dc2626",
-  High: "#ea580c",
-  Medium: "#ca8a04",
-  Low: "#2563eb",
-  Info: "#6b7280",
+  Critical: "hsl(var(--severity-critical))",
+  High: "hsl(var(--severity-high))",
+  Medium: "hsl(var(--severity-medium))",
+  Low: "hsl(var(--severity-low))",
+  Info: "hsl(var(--severity-info))",
+};
+
+const SEVERITY_CHIP_CLASSES: Record<string, string> = {
+  critical: "bg-severity-critical/15 text-severity-critical border-severity-critical/30",
+  high: "bg-severity-high/15 text-severity-high border-severity-high/30",
+  medium: "bg-severity-medium/15 text-severity-medium border-severity-medium/30",
+  low: "bg-severity-low/15 text-severity-low border-severity-low/30",
+  info: "bg-severity-info/15 text-severity-info border-severity-info/30",
 };
 
 export default function SecurityPage() {
@@ -94,11 +102,17 @@ export default function SecurityPage() {
     {
       header: "Findings",
       accessor: (s: TraceSpan) =>
-        s.security_findings?.map((f) => (
-          <Badge key={f.id} variant="outline" className="mr-1">
-            {f.severity}: {f.finding_type}
-          </Badge>
-        )),
+        s.security_findings?.map((f) => {
+          const chipClass = SEVERITY_CHIP_CLASSES[f.severity.toLowerCase()] ?? SEVERITY_CHIP_CLASSES.info;
+          return (
+            <span
+              key={f.id}
+              className={`mr-1 inline-flex items-center rounded border px-2 py-0.5 text-[10px] ${chipClass}`}
+            >
+              {f.severity}: {f.finding_type}
+            </span>
+          );
+        }),
     },
     {
       header: "Description",
@@ -186,7 +200,7 @@ export default function SecurityPage() {
                   <XAxis type="number" className="text-xs" />
                   <YAxis dataKey="name" type="category" width={150} className="text-xs" />
                   <Tooltip />
-                  <Bar dataKey="count" fill="#ea580c" radius={[0, 4, 4, 0]} />
+                  <Bar dataKey="count" fill="hsl(var(--severity-high))" radius={[0, 4, 4, 0]} />
                 </BarChart>
               </ResponsiveContainer>
             ) : (

--- a/dashboard/src/app/settings/settings-client.tsx
+++ b/dashboard/src/app/settings/settings-client.tsx
@@ -51,7 +51,7 @@ function renderConfigValue(value: unknown, depth = 0) {
     const text = formatPrimitive(value);
     const isRedacted = text === "***redacted***";
     return (
-      <span className={isRedacted ? "font-mono text-amber-700" : "font-mono"}>
+      <span className={isRedacted ? "font-mono text-warning" : "font-mono"}>
         {isRedacted ? "Redacted" : text}
       </span>
     );
@@ -152,7 +152,7 @@ interface UrlRowProps {
 function UrlRow({ label, value, emptyLabel, emptyTone, note, testId, copyable }: UrlRowProps) {
   const hasValue = value !== null && value.trim().length > 0;
   const emptyClass =
-    emptyTone === "warning" ? "text-amber-700 font-medium" : "text-muted-foreground";
+    emptyTone === "warning" ? "text-warning font-medium" : "text-muted-foreground";
 
   return (
     <div className="flex items-start gap-3" data-testid={testId}>
@@ -189,8 +189,8 @@ function ConnectionStatusBadge({ health, loading, onCheck }: ConnectionStatusBad
         <div className="flex items-center gap-2">
           {isHealthy ? (
             <>
-              <CheckCircle className="h-4 w-4 text-green-500" />
-              <Badge variant="secondary" className="bg-green-100 text-green-800">
+              <CheckCircle className="h-4 w-4 text-success" />
+              <Badge variant="secondary" className="bg-success/15 text-success border border-success/30">
                 Connected
               </Badge>
             </>

--- a/dashboard/src/app/status/page.tsx
+++ b/dashboard/src/app/status/page.tsx
@@ -30,7 +30,7 @@ const ENDPOINTS: Array<Pick<EndpointCheck, "path" | "label">> = [
 
 function statusBadge(item: EndpointCheck) {
   if (item.status === "ok") {
-    return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Healthy</Badge>;
+    return <Badge className="bg-success/15 text-success border border-success/30 hover:bg-success/20">Healthy</Badge>;
   }
   if (item.status === "error") {
     return <Badge variant="destructive">Error</Badge>;
@@ -80,7 +80,7 @@ function parseMetricSamples(preview: string): MetricSample[] {
 function renderEndpointBody(item: EndpointCheck) {
   if (item.error) {
     return (
-      <pre className="max-h-56 overflow-auto rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-800">
+      <pre className="max-h-56 overflow-auto rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
         {item.error}
       </pre>
     );

--- a/dashboard/src/app/tenants/_client.tsx
+++ b/dashboard/src/app/tenants/_client.tsx
@@ -298,7 +298,7 @@ export default function TenantsClient() {
             </CardHeader>
             <CardContent className="space-y-6 pt-6">
               {configSuccess && (
-                <div className="bg-green-500/10 border border-green-500/20 text-green-600 p-3 rounded-md text-sm">
+                <div className="bg-success/10 border border-success/30 text-success p-3 rounded-md text-sm">
                   Configuration saved successfully
                 </div>
               )}
@@ -415,11 +415,11 @@ export default function TenantsClient() {
                     data-testid="copy-proxy-token-button"
                     onClick={() => copyToClipboard(activeTenantKeys.apiToken ?? "")}
                   >
-                    {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                    {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
                   </Button>
                 </div>
               ) : (
-                <div className="text-sm text-yellow-600 bg-yellow-500/10 p-2 rounded-md border border-yellow-500/20 flex items-center gap-2">
+                <div className="text-sm text-warning bg-warning/10 p-2 rounded-md border border-warning/30 flex items-center gap-2">
                   <AlertTriangle className="h-4 w-4" />
                   No proxy token set. Click Reset to generate one.
                 </div>
@@ -473,9 +473,9 @@ export default function TenantsClient() {
       )}
 
       {generatedKey && (
-        <Card className="border-green-600 bg-green-500/5">
+        <Card className="border-success/40 bg-success/5">
           <CardHeader>
-            <CardTitle className="text-base text-green-600 flex items-center gap-2" data-testid="new-token-title">
+            <CardTitle className="text-base text-success flex items-center gap-2" data-testid="new-token-title">
               <Check className="h-4 w-4" /> New Token Generated
             </CardTitle>
           </CardHeader>
@@ -492,7 +492,7 @@ export default function TenantsClient() {
                 variant="ghost"
                 onClick={() => copyToClipboard(generatedKey.key ?? "")}
               >
-                {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
               </Button>
             </div>
             <Button variant="outline" size="sm" onClick={() => setGeneratedKey(null)}>

--- a/dashboard/src/app/tenants/config/page.tsx
+++ b/dashboard/src/app/tenants/config/page.tsx
@@ -100,7 +100,7 @@ function ConfigContent() {
       </div>
 
       {success && (
-        <div className="bg-green-500/10 border border-green-500/20 text-green-600 p-3 rounded-md text-sm">
+        <div className="bg-success/10 border border-success/30 text-success p-3 rounded-md text-sm">
           Configuration saved successfully
         </div>
       )}


### PR DESCRIPTION
## Summary

Wave 2A of 3. Migrates hardcoded Tailwind color classes + hex literals across page-level components to the semantic tokens introduced in Wave 1 (#323), so every page reads coherently in BOTH dark (default) and light themes.

## Files (9)

| File | Changes |
|---|---|
| \`app/compliance/page.tsx\` | \`border-green-600 bg-green-500/5\` → \`border-success/40 bg-success/5\`; \`text-green-600\` → \`text-success\`; JSON pre block \`bg-slate-950 text-slate-300\` → \`bg-card text-foreground\` |
| \`app/costs/page.tsx\` | Progress bar \`bg-yellow-500\` → \`bg-warning\`; recharts bar fills hex → \`hsl(var(--destructive))\` / \`hsl(var(--muted))\` |
| \`app/page.tsx\` | \`SEVERITY_COLORS\` + \`PIE_COLORS\` hex literals → \`hsl(var(--severity-*))\` tokens; bar chart fill \`hsl(222.2…)\` → \`hsl(var(--primary))\` |
| \`app/playground/_client.tsx\` | \`statusVisual\` tones \`red-*/amber-*/emerald-*\` → \`severity-critical/high\`, \`warning\`, \`success\` tokens; blocked reason / action-warning text → \`text-severity-critical\`; \`RawBlock <pre>\` background \`bg-background\` → \`bg-card border-border text-foreground\` |
| \`app/security/page.tsx\` | \`SEVERITY_COLORS\` hex → CSS var form; added static \`SEVERITY_CHIP_CLASSES\` map; Findings column uses chip pattern; bar fill \`#ea580c\` → \`hsl(var(--severity-high))\` |
| \`app/settings/settings-client.tsx\` | \`text-amber-700\` → \`text-warning\`; \`bg-green-100 text-green-800\` connected badge → success chip; \`text-green-500\` → \`text-success\` |
| \`app/status/page.tsx\` | \`bg-green-100 text-green-800\` healthy badge → success chip; \`border-red-200 bg-red-50 text-red-800\` error pre → destructive tokens |
| \`app/tenants/_client.tsx\` | \`border-green-600 bg-green-500/5\` cards → success tokens; copy icon \`text-green-500\` → \`text-success\`; yellow warning banner → warning tokens |
| \`app/tenants/config/page.tsx\` | \`bg-green-500/10 border-green-500/20 text-green-600\` success banner → success tokens |

## Pages with no changes needed

\`api-docs\` (iframe), \`audit\`, \`guide\`, \`login\`, \`playground/page\` (server wrapper), \`settings/page\` (server wrapper), \`tenants/page\` (server wrapper), \`traces/page\`, \`traces/[id]/page\` — all already token-driven.

## Verification

- \`npm run lint\` exit 0 (warnings pre-existing, none introduced)
- \`npm run build\` exit 0 — 18 static pages compiled

## Coordination

Strictly confined to \`dashboard/src/app/\`. No shared-component changes needed. Wave 2B (#324) adds severity variants to the Badge primitive — this PR uses the chip pattern inline (not the variant) so the two PRs are independent and can land in either order. A follow-up cleanup could migrate the inline chip classes here to \`<Badge variant=\"critical\">\` once 2B is in.

## Test plan

- [ ] CI green.
- [ ] After merge: smoke-test every page in both themes via the toggle from Wave 1.
- [ ] Wave 3 (Playwright visual verification) runs after both 2A + 2B merge.