### PR TITLE
fix(dashboard): theme recharts gridlines, playground scrim, compliance print text (#326 leftovers)

### DIFF
--- a/dashboard/src/app/compliance/page.tsx
+++ b/dashboard/src/app/compliance/page.tsx
@@ -166,7 +166,7 @@ function ReportViewer({ report }: { report: ComplianceReport }) {
 
   return (
     <div className="print:p-0">
-      <Card className="border-success/40 bg-success/5 shadow-md print:border-none print:bg-white print:shadow-none">
+      <Card className="border-success/40 bg-success/5 shadow-md print:border-none print:bg-white print:text-black print:shadow-none">
         <CardHeader className="flex flex-row items-center justify-between pb-4 border-b">
           <div className="space-y-1">
             <CardTitle className="flex items-center gap-2 text-2xl">

--- a/dashboard/src/app/costs/page.tsx
+++ b/dashboard/src/app/costs/page.tsx
@@ -182,7 +182,7 @@ export default function CostsPage() {
           <CardContent>
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={budgetData}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" className="stroke-muted" />
                 <XAxis dataKey="name" className="text-xs" />
                 <YAxis className="text-xs" />
                 <Tooltip formatter={(value: number) => `$${value.toFixed(4)}`} />

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -212,7 +212,7 @@ export default function OverviewPage() {
           <CardContent>
             <ResponsiveContainer width="100%" height={260}>
               <BarChart data={activityData}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" className="stroke-muted" />
                 <XAxis dataKey="hour" className="text-xs" />
                 <YAxis className="text-xs" />
                 <Tooltip />

--- a/dashboard/src/app/playground/_client.tsx
+++ b/dashboard/src/app/playground/_client.tsx
@@ -1468,7 +1468,7 @@ function SettingsDrawer(props: {
         aria-hidden={!visible}
         tabIndex={-1}
         onClick={props.onClose}
-        className={`fixed inset-0 z-40 bg-black/40 transition-opacity ${
+        className={`fixed inset-0 z-40 bg-background/80 backdrop-blur-sm transition-opacity ${
           visible ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
       />

--- a/dashboard/src/app/security/page.tsx
+++ b/dashboard/src/app/security/page.tsx
@@ -196,7 +196,7 @@ export default function SecurityPage() {
             {attackPatterns.length > 0 ? (
               <ResponsiveContainer width="100%" height={260}>
                 <BarChart data={attackPatterns} layout="vertical">
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" className="stroke-muted" />
                   <XAxis type="number" className="text-xs" />
                   <YAxis dataKey="name" type="category" width={150} className="text-xs" />
                   <Tooltip />


### PR DESCRIPTION
Resolves the three deferred items from the dark-mode visual audit (docs/research/dashboard-dark-mode-visual-audit-2026-05-29.md).

## Changes
- **recharts gridlines** — add explicit `stroke="hsl(var(--border))"` on the home, security, and costs `CartesianGrid` charts. recharts v2 does not reliably apply the Tailwind `stroke-muted` class to the inner SVG `<line>` elements, so gridlines rendered as browser-default (near-black) and were invisible in dark mode. `strokeDasharray` and `className` preserved.
- **playground settings drawer scrim** — replace `bg-black/40` with `bg-background/80 backdrop-blur-sm`, matching the existing `loading-overlay` pattern, so the backdrop reads correctly in both themes. Opacity transition logic untouched.
- **compliance print** — add `print:text-black` so foreground text stays legible on the forced-white print background. On-screen (dark/light) appearance unchanged.

## Verification
- `npm run lint` exit 0 (only 3 pre-existing warnings, none introduced)
- `npm run build` exit 0 (all 18 pages compiled)
- No e2e selectors affected.

5 files changed, +5/-5.