### PR TITLE
test(storage,proxy): make ttl_expiry and webhook delivery tests deterministic

### DIFF
--- a/crates/llmtrace-proxy/src/action_router.rs
+++ b/crates/llmtrace-proxy/src/action_router.rs
@@ -935,28 +935,45 @@ mod tests {
         }
     }
 
-    async fn simple_mock(path: &str) -> (String, Arc<AsyncMutex<Vec<serde_json::Value>>>) {
+    /// Mock webhook server.
+    ///
+    /// Returns the URL, the shared store of received payloads, and an mpsc
+    /// receiver that the handler signals on each received payload so callers
+    /// can synchronize on delivery instead of sleeping.
+    async fn simple_mock(
+        path: &str,
+    ) -> (
+        String,
+        Arc<AsyncMutex<Vec<serde_json::Value>>>,
+        mpsc::Receiver<()>,
+    ) {
         let received: Arc<AsyncMutex<Vec<serde_json::Value>>> =
             Arc::new(AsyncMutex::new(Vec::new()));
         let store = Arc::clone(&received);
+        let (tx, rx) = mpsc::channel::<()>(8);
         let app = Router::new().route(
             path,
             post(move |axum::Json(body): axum::Json<serde_json::Value>| {
                 let store = Arc::clone(&store);
+                let tx = tx.clone();
                 async move {
                     store.lock().await.push(body);
+                    // Signal delivery; ignore if the receiver is gone.
+                    let _ = tx.send(()).await;
                     axum::http::StatusCode::OK
                 }
             }),
         );
 
+        // Bind synchronously before spawning serve so the socket is already
+        // accepting connections by the time the URL is handed back.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
 
-        (format!("http://{addr}{path}"), received)
+        (format!("http://{addr}{path}"), received, rx)
     }
 
     #[tokio::test]
@@ -1205,7 +1222,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_webhook_action_delivers_payload() {
-        let (url, received) = simple_mock("/action-webhook").await;
+        let (url, received, mut delivered) = simple_mock("/action-webhook").await;
         let action = WebhookAction {
             url,
             timeout_ms: 500,
@@ -1217,7 +1234,12 @@ mod tests {
         let outcome = action.execute(&ctx).await.unwrap();
         assert!(matches!(outcome, ActionOutcome::Completed { .. }));
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for the mock handler to signal it received the payload, with a
+        // bounded timeout that fails loudly rather than racing on a sleep.
+        tokio::time::timeout(Duration::from_secs(5), delivered.recv())
+            .await
+            .expect("webhook payload was not delivered within 5s")
+            .expect("mock handler signal channel closed before delivery");
         let payloads = received.lock().await;
         assert_eq!(payloads.len(), 1);
         assert_eq!(payloads[0]["tenant_id"], ctx.tenant_id.0.to_string());

--- a/crates/llmtrace-storage/src/cache.rs
+++ b/crates/llmtrace-storage/src/cache.rs
@@ -101,20 +101,30 @@ mod tests {
 
     #[tokio::test]
     async fn test_ttl_expiry() {
+        // Expiry uses `std::time::Instant` (wall clock), which tokio's paused
+        // clock cannot control. Use a short TTL plus a bounded poll loop so the
+        // assertion is race-free regardless of CI scheduling jitter.
         let cache = InMemoryCacheLayer::new();
         cache
             .set("ephemeral", b"data", Duration::from_millis(10))
             .await
             .unwrap();
 
-        // Should exist immediately
+        // Should exist immediately.
         assert!(cache.get("ephemeral").await.unwrap().is_some());
 
-        // Wait for expiry
-        tokio::time::sleep(Duration::from_millis(20)).await;
-
-        // Should be gone
-        assert!(cache.get("ephemeral").await.unwrap().is_none());
+        // Poll for expiry with a generous, bounded retry loop (up to ~2s).
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if cache.get("ephemeral").await.unwrap().is_none() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "entry did not expire within 2s of its 10ms TTL"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Removes timing/sleep races from two pre-existing flaky tests. No production code changed; all assertions preserved.

## cache::tests::test_ttl_expiry
The cache expiry uses `std::time::Instant` (wall clock), which tokio's paused clock cannot control — so fake timers do not apply. Replaced the single fixed `sleep(20ms)` with a bounded poll loop (poll every 5ms, hard 2s deadline that fails loudly) after the 10ms TTL. Immediate-presence assertion kept.

## action_router::tests::test_webhook_action_delivers_payload
Replaced the post-request `sleep(100ms)` with real synchronization: `simple_mock` now returns an `mpsc::Receiver`, the handler signals on each received payload, and the test awaits delivery via `tokio::time::timeout(5s, …)` that fails loudly on timeout. Listener still binds + reads `local_addr()` synchronously before `serve` is spawned. Mirrors the sibling `test_judge_route_enqueue_succeeds_and_receiver_gets_request`. All assertions (count, tenant_id, finding_type) kept.

## Verification
- `cargo fmt --all` exit 0
- target tests run 6x each, all pass
- `cargo build -p llmtrace-storage -p llmtrace` exit 0

2 files changed, +42/-10.