### PR TITLE
feat(deploy): wire durable storage + stable tenant id across recreate

### DIFF
--- a/deployments/basilica/README.md
+++ b/deployments/basilica/README.md
@@ -653,6 +653,57 @@ The admin key follows the same recreate / restart split: pin it via
 `spec.api_key` (or `api_key:` in YAML) if you need it stable across
 recreates; on restart it is simply re-derived from spec and not re-minted.
 
+### Durable storage across recreate
+
+By default the proxy stores traces + tenant rows in a SQLite file on the
+pod's container-local disk (`/home/llmtrace/llmtrace.db`). `recreate` deletes
+the pod, so that file — and every trace + the internal tenant id — is lost,
+and the next provision mints a fresh tenant UUID. To make state survive
+`recreate`, pick one of three options (full analysis, with SDK evidence, in
+`docs/research/basilica-persistence-options-2026-05-29.md`):
+
+1. **External production backend (fully durable — recommended).** Set
+   `LLMTRACE_STORAGE_PROFILE=production` and supply reachable
+   `LLMTRACE_POSTGRES_URL`, `LLMTRACE_CLICKHOUSE_URL`, `LLMTRACE_REDIS_URL`
+   in the proxy env. Traces + tenants live outside the pod, so recreate is
+   safe. Requires you to run those services.
+
+2. **Object-store persistent mount (durable, SQLite synced to a bucket).**
+   Set `persistent_volume` on the proxy `ComponentSpec` (or the `proxy.
+   persistent_volume:` block in YAML). The library attaches a Basilica
+   `StorageSpec` (the only durable substrate for a Basilica *deployment* —
+   there is no raw block/hostPath volume on the SDK, only object storage)
+   and automatically repoints `LLMTRACE_STORAGE_DATABASE_PATH` onto the
+   mount. Requires a pre-provisioned Basilica `credentials_secret` and a
+   bucket (`backend` is `r2` | `s3` | `gcs`):
+
+   ```yaml
+   proxy:
+     persistent_volume:
+       bucket: "${LLMTRACE_STORAGE_BUCKET}"
+       credentials_secret: "basilica-r2-credentials"
+       backend: r2
+       mount_path: /data
+       db_filename: llmtrace.db
+   ```
+
+3. **restart-only updates (PARTIAL — stopgap, not a guarantee).** Keep
+   SQLite but only ever use `update --strategy restart` for upgrades, never
+   `recreate`. A rolling restart keeps the pod's disk, so rows survive in
+   place. **Caveat:** this is NOT durable across a node reschedule /
+   eviction, and `restart` 404s on a freshly-provisioned deployment until
+   its k8s Deployment CR materialises.
+
+**Stable tenant id across redeploys.** Set `tenant_uuid` on the `TenantSpec`
+(or `tenant_uuid:` in YAML) to a deterministic value (e.g.
+`user-uuid-<uuid>`). The library sends it as the `id` on
+`POST /api/v1/tenants` so the proxy reuses the SAME internal tenant id every
+redeploy instead of minting a fresh one — preserving tenant IDENTITY across
+`recreate` (the proxy must honour an explicit `id` on create, i.e. make
+create idempotent on that id; until it does, the field is ignored
+server-side and the returned id is used, which is harmless). Combine with
+option 1 or 2 to also preserve the traces that identity points at.
+
 ### Disabling auth
 
 For a trusted-network deploy where the proxy URL won't leak (a VPC-only

--- a/deployments/basilica/cli.py
+++ b/deployments/basilica/cli.py
@@ -107,7 +107,39 @@ def _component_from_dict(data: dict[str, Any], label: str) -> lifecycle.Componen
     for key, caster in optional.items():
         if key in data:
             kwargs[key] = caster(data[key])
+    if "persistent_volume" in data and data["persistent_volume"] is not None:
+        kwargs["persistent_volume"] = _persistent_volume_from_dict(
+            data["persistent_volume"], label
+        )
     return lifecycle.ComponentSpec(**kwargs)
+
+
+def _persistent_volume_from_dict(
+    data: dict[str, Any], label: str
+) -> lifecycle.PersistentVolumeSpec:
+    if not isinstance(data, dict):
+        raise SystemExit(
+            f"component {label!r}: 'persistent_volume' must be a mapping"
+        )
+    required = {"bucket", "credentials_secret"}
+    missing = required - data.keys()
+    if missing:
+        raise SystemExit(
+            f"component {label!r}: persistent_volume is missing required "
+            f"keys: {sorted(missing)}"
+        )
+    kwargs: dict[str, Any] = {
+        "bucket": str(data["bucket"]),
+        "credentials_secret": str(data["credentials_secret"]),
+    }
+    optional_str = ("mount_path", "backend", "region", "endpoint", "db_filename")
+    for key in optional_str:
+        if key in data and data[key] is not None:
+            kwargs[key] = str(data[key])
+    for key in ("sync_interval_ms", "cache_size_mb"):
+        if key in data and data[key] is not None:
+            kwargs[key] = int(data[key])
+    return lifecycle.PersistentVolumeSpec(**kwargs)
 
 
 def _rate_limit_from_dict(data: dict[str, Any]) -> lifecycle.RateLimitSpec:
@@ -136,6 +168,7 @@ def _tenant_spec_from_config(tenant_id: str, cfg: dict[str, Any]) -> lifecycle.T
         "dashboard": dashboard,
     }
     for key in (
+        "tenant_uuid",
         "proxy_name_template",
         "dashboard_name_template",
         "inject_proxy_url_into_dashboard",

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -8,6 +8,36 @@
 # via `api_key:` below) is retained by the caller for self-service /
 # admin pages and NEVER handed to the tenant. See starter.yaml + the
 # README "Per-tenant API key auth" section for the full contract.
+#
+# DURABILITY across `update --strategy recreate` (traces + tenant id):
+# By default the proxy stores traces + tenant rows in a SQLite file on the
+# pod's container-local disk, which Basilica DESTROYS on recreate (the pod
+# is deleted and re-created). To make state survive recreate, pick ONE:
+#
+#   A) External production backend (fully durable, recommended for prod):
+#      set LLMTRACE_STORAGE_PROFILE=production and provide reachable
+#      Postgres + ClickHouse + Redis URLs via env (see the `env:` notes
+#      below). Traces + tenants live outside the pod, so recreate is safe.
+#
+#   B) Object-store persistent mount (durable, SQLite synced to a bucket):
+#      uncomment `proxy.persistent_volume` below. Requires a pre-provisioned
+#      Basilica `credentials_secret` and a bucket. The lifecycle library
+#      attaches a Basilica StorageSpec and repoints
+#      LLMTRACE_STORAGE_DATABASE_PATH onto the mount automatically.
+#
+#   C) restart-only updates (PARTIAL — in-place pod roll only): keep SQLite
+#      but always use `update --strategy restart` for upgrades, never
+#      `recreate`. A rolling restart keeps the pod's disk, so rows survive.
+#      CAVEAT: this is NOT durable across a node reschedule / eviction, and
+#      restart 404s on a freshly-provisioned deployment until its k8s CR
+#      materialises. Treat as a stopgap, not a guarantee.
+#
+# tenant_uuid: the STABLE internal tenant id reused across redeploys. When
+# set, the lifecycle library sends it as the `id` on POST /api/v1/tenants so
+# the proxy keeps the SAME tenant id every recreate (requires the proxy to
+# honour an explicit id on create — idempotent create). Use a deterministic
+# value derived from your app's tenant key, e.g.:
+# tenant_uuid: "user-uuid-550e8400-e29b-41d4-a716-446655440000"
 
 proxy:
   image: "ghcr.io/techlab-innov/llmtrace-proxy:${LLMTRACE_VERSION:-latest}"
@@ -28,8 +58,31 @@ proxy:
   # auto-bumps to 1500s when both flags are on and this value is lower; we set
   # 1500 explicitly to silence the WARN and document the cost.
   startup_timeout_seconds: 1500
+  # Option B — object-store persistent mount. Uncomment to make the SQLite
+  # profile durable across recreate. Requires a Basilica-side secret named by
+  # `credentials_secret` (holds the bucket creds) and an existing bucket.
+  # The lifecycle library sets LLMTRACE_STORAGE_DATABASE_PATH to
+  # <mount_path>/<db_filename> automatically, so leave the env var below unset
+  # when this is on. `backend` is r2 | s3 | gcs.
+  # persistent_volume:
+  #   bucket: "${LLMTRACE_STORAGE_BUCKET}"
+  #   credentials_secret: "${LLMTRACE_STORAGE_CREDENTIALS_SECRET}"
+  #   backend: r2
+  #   mount_path: /data
+  #   db_filename: llmtrace.db
+  #   sync_interval_ms: 1000
+  #   cache_size_mb: 1024
   env:
     LLMTRACE_UPSTREAM_URL: "${LLMTRACE_UPSTREAM_URL}"
+    # Option A — external production backend. Set LLMTRACE_STORAGE_PROFILE to
+    # `production` and supply reachable URLs (uncomment the three lines) to
+    # store traces + tenants outside the pod (fully durable across recreate):
+    #   LLMTRACE_POSTGRES_URL: "${LLMTRACE_POSTGRES_URL}"
+    #   LLMTRACE_CLICKHOUSE_URL: "${LLMTRACE_CLICKHOUSE_URL}"
+    #   LLMTRACE_REDIS_URL: "${LLMTRACE_REDIS_URL}"
+    # Default `sqlite` writes to container-local disk (lost on recreate
+    # unless Option B's persistent_volume is attached, or you only ever
+    # update via --strategy restart per Option C).
     LLMTRACE_STORAGE_PROFILE: "${LLMTRACE_STORAGE_PROFILE:-sqlite}"
     LLMTRACE_ML_ENABLED: "1"
     LLMTRACE_ML_PRELOAD: "1"

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -32,12 +32,13 @@
 #      restart 404s on a freshly-provisioned deployment until its k8s CR
 #      materialises. Treat as a stopgap, not a guarantee.
 #
-# tenant_uuid: the STABLE internal tenant id reused across redeploys. When
-# set, the lifecycle library sends it as the `id` on POST /api/v1/tenants so
-# the proxy keeps the SAME tenant id every recreate (requires the proxy to
-# honour an explicit id on create — idempotent create). Use a deterministic
-# value derived from your app's tenant key, e.g.:
-# tenant_uuid: "user-uuid-550e8400-e29b-41d4-a716-446655440000"
+# tenant_uuid: the STABLE internal tenant id reused across redeploys. The
+# lifecycle library sends it as the `id` on POST /api/v1/tenants so the proxy
+# keeps the SAME tenant id every recreate (the proxy honours an explicit id on
+# create — idempotent create). MUST be a valid UUID. Override via the
+# LLMTRACE_TENANT_UUID env var; the default below is the dashboard's canonical
+# default tenant id so the bootstrapped tenant and the dashboard fallback align.
+tenant_uuid: "${LLMTRACE_TENANT_UUID:-6ae1ab34-02d8-5b68-ad6f-132bf4de8408}"
 
 proxy:
   image: "ghcr.io/techlab-innov/llmtrace-proxy:${LLMTRACE_VERSION:-latest}"
@@ -92,6 +93,15 @@ proxy:
     LLMTRACE_DATAMARKING_ENABLED: "true"
     LLMTRACE_DATAMARKING_SHADOW_MODE: "false"
     LLMTRACE_ZONE_DETECTION_ENABLED: "true"
+    # Explicit default tenant for header-less /v1 traffic (issue #292): the
+    # proxy stamps this id instead of creating a phantom tenant per call.
+    # Matches `tenant_uuid` above so the default path stays consistent.
+    LLMTRACE_DEFAULT_TENANT_ID: "${LLMTRACE_DEFAULT_TENANT_ID:-6ae1ab34-02d8-5b68-ad6f-132bf4de8408}"
+    # Master key (32 bytes; 64-char hex or base64) used to encrypt per-tenant
+    # upstream API keys at rest. MUST be stable across recreates or stored
+    # ciphertext becomes undecryptable. Unset => per-tenant key writes fail
+    # closed (proxy still boots; the global upstream key is still used).
+    LLMTRACE_SECRET_ENCRYPTION_KEY: "${LLMTRACE_SECRET_ENCRYPTION_KEY:-}"
     RUST_LOG: info
     OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
     ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -38,7 +38,10 @@ from typing import Any, Mapping, Optional
 from basilica import (
     BasilicaClient,
     HealthCheckConfig,
+    PersistentStorageSpec,
     ProbeConfig,
+    StorageBackend,
+    StorageSpec,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -96,6 +99,27 @@ _UNSHARED_STORAGE_PROFILES: frozenset[str] = frozenset(
     {"", "sqlite", "lite", "memory"}
 )
 
+# Storage backends Basilica's persistent-storage spec accepts. Mirrors
+# `basilica._basilica.StorageBackend` (R2 / S3 / GCS). Object-store backed:
+# the deployment mounts a FUSE-style path that syncs to the bucket on an
+# interval, so the data survives `recreate` (which deletes the pod). This is
+# the ONLY durable substrate available to a Basilica *deployment* — there is
+# no raw block / hostPath volume on `CreateDeploymentRequest` (only object
+# storage). See docs/research/basilica-persistence-options-2026-05-29.md.
+_STORAGE_BACKENDS: dict[str, StorageBackend] = {
+    "r2": StorageBackend.R2,
+    "s3": StorageBackend.S3,
+    "gcs": StorageBackend.GCS,
+}
+
+# Env var the proxy reads to place its SQLite database file
+# (`crates/llmtrace-proxy/src/config.rs::apply_env_overrides`,
+# `LLMTRACE_STORAGE_DATABASE_PATH`). Defaults to the relative `llmtrace.db`
+# in the proxy's WORKDIR (`/home/llmtrace`) which is container-local and lost
+# on recreate. When a persistent mount is attached we repoint this at a file
+# under the mount so the sqlite profile becomes durable.
+STORAGE_DB_PATH_ENV = "LLMTRACE_STORAGE_DATABASE_PATH"
+
 # Proxy admin API endpoints (see `crates/llmtrace-proxy/src/main.rs` routing).
 TENANTS_PATH = "/api/v1/tenants"
 AUTH_KEYS_PATH = "/api/v1/auth/keys"
@@ -144,6 +168,94 @@ class RateLimitSpec:
 
 
 @dataclass(frozen=True)
+class PersistentVolumeSpec:
+    """Object-store-backed persistent mount for a Basilica deployment.
+
+    Basilica deployments have no raw block / hostPath volume — the only
+    durable substrate is an object store (R2 / S3 / GCS) mounted as a
+    FUSE-style path that syncs to a bucket on an interval. Data written under
+    `mount_path` survives `update(strategy="recreate")` (which deletes the
+    pod) because it is persisted in the bucket, not on the pod's local disk.
+
+    `credentials_secret` names a secret that MUST already exist on the
+    Basilica side (the platform injects the bucket credentials from it). This
+    library cannot create that secret; the operator provisions it out of band.
+    `backend` is one of `r2` / `s3` / `gcs` (case-insensitive).
+
+    When attached to a proxy `ComponentSpec`, the lifecycle library also
+    repoints `LLMTRACE_STORAGE_DATABASE_PATH` at a file under `mount_path`
+    (see `db_filename`) so the sqlite storage profile becomes durable.
+    """
+
+    bucket: str
+    credentials_secret: str
+    mount_path: str = "/data"
+    backend: str = "r2"
+    region: Optional[str] = None
+    endpoint: Optional[str] = None
+    sync_interval_ms: int = 1000
+    cache_size_mb: int = 1024
+    # SQLite filename placed under `mount_path`. The proxy's
+    # LLMTRACE_STORAGE_DATABASE_PATH is set to `mount_path/db_filename` so the
+    # `lite`/`sqlite` profile writes its DB onto the durable mount.
+    db_filename: str = "llmtrace.db"
+
+    def __post_init__(self) -> None:
+        if not self.bucket:
+            raise ValueError("PersistentVolumeSpec.bucket must be non-empty")
+        if not self.credentials_secret:
+            raise ValueError(
+                "PersistentVolumeSpec.credentials_secret must be non-empty"
+            )
+        if not self.mount_path.startswith("/"):
+            raise ValueError(
+                f"PersistentVolumeSpec.mount_path must be absolute, got "
+                f"{self.mount_path!r}"
+            )
+        if self.backend.lower() not in _STORAGE_BACKENDS:
+            raise ValueError(
+                f"PersistentVolumeSpec.backend must be one of "
+                f"{sorted(_STORAGE_BACKENDS)}, got {self.backend!r}"
+            )
+        if self.sync_interval_ms <= 0:
+            raise ValueError(
+                f"PersistentVolumeSpec.sync_interval_ms must be > 0, got "
+                f"{self.sync_interval_ms}"
+            )
+        if self.cache_size_mb <= 0:
+            raise ValueError(
+                f"PersistentVolumeSpec.cache_size_mb must be > 0, got "
+                f"{self.cache_size_mb}"
+            )
+        if not self.db_filename or "/" in self.db_filename:
+            raise ValueError(
+                f"PersistentVolumeSpec.db_filename must be a bare filename, "
+                f"got {self.db_filename!r}"
+            )
+
+    @property
+    def database_path(self) -> str:
+        """Absolute path the proxy SQLite DB should use on the mount."""
+        return f"{self.mount_path.rstrip('/')}/{self.db_filename}"
+
+    def to_storage_spec(self) -> StorageSpec:
+        """Build the Basilica `StorageSpec` for `create_deployment(storage=...)`."""
+        return StorageSpec(
+            persistent=PersistentStorageSpec(
+                enabled=True,
+                backend=_STORAGE_BACKENDS[self.backend.lower()],
+                bucket=self.bucket,
+                region=self.region,
+                endpoint=self.endpoint,
+                credentials_secret=self.credentials_secret,
+                sync_interval_ms=self.sync_interval_ms,
+                cache_size_mb=self.cache_size_mb,
+                mount_path=self.mount_path,
+            )
+        )
+
+
+@dataclass(frozen=True)
 class ComponentSpec:
     """Full deployment spec for one component (proxy or dashboard).
 
@@ -157,6 +269,12 @@ class ComponentSpec:
     memory: str
     replicas: int
     env: Mapping[str, str]
+    # Optional object-store-backed persistent mount. When set on the proxy
+    # ComponentSpec, the deployment is created with this Basilica StorageSpec
+    # and the proxy's LLMTRACE_STORAGE_DATABASE_PATH is repointed onto the
+    # mount so the sqlite DB (traces + tenant rows) survives recreate. None
+    # means no persistent storage (container-local disk, lost on recreate).
+    persistent_volume: Optional[PersistentVolumeSpec] = None
     health_check_path: str = "/health"
     startup_timeout_seconds: int = 600
     startup_initial_delay_seconds: int = 30
@@ -175,6 +293,16 @@ class TenantSpec:
     tenant_id: str
     proxy: ComponentSpec
     dashboard: ComponentSpec
+    # Stable internal tenant UUID to reuse across redeploys. When set, the
+    # lifecycle layer sends it as the `id` field on `POST /api/v1/tenants`
+    # so the proxy reuses the SAME tenant id every recreate instead of
+    # minting a fresh UUID (requires the proxy to honour an explicit id on
+    # create — idempotent-create is owned by the proxy; until then the field
+    # is ignored server-side, which is harmless). None means "let the proxy
+    # mint a UUID" (legacy behaviour, identity NOT stable across recreate).
+    # Format is the caller's choice (e.g. `user-uuid-<uuid>`); the proxy
+    # validates / canonicalises it.
+    tenant_uuid: Optional[str] = None
     proxy_name_template: str = DEFAULT_PROXY_NAME_TEMPLATE
     dashboard_name_template: str = DEFAULT_DASHBOARD_NAME_TEMPLATE
     # If True, the resolved proxy URL is injected into the dashboard's env
@@ -425,8 +553,14 @@ def _wait_until_ready(
 def _create_component(
     client: BasilicaClient, friendly_name: str, spec: ComponentSpec
 ) -> InstanceInfo:
+    storage_spec = (
+        spec.persistent_volume.to_storage_spec()
+        if spec.persistent_volume is not None
+        else None
+    )
     LOGGER.info(
-        "creating friendly=%s image=%s cpu=%s memory=%s replicas=%d port=%d env_keys=%s",
+        "creating friendly=%s image=%s cpu=%s memory=%s replicas=%d port=%d "
+        "env_keys=%s persistent_mount=%s",
         friendly_name,
         spec.image,
         spec.cpu,
@@ -434,17 +568,21 @@ def _create_component(
         spec.replicas,
         spec.port,
         sorted(spec.env.keys()),
+        spec.persistent_volume.mount_path if spec.persistent_volume else None,
     )
-    response = client.create_deployment(
-        instance_name=friendly_name,
-        image=spec.image,
-        replicas=spec.replicas,
-        port=spec.port,
-        env=dict(spec.env),
-        cpu=spec.cpu,
-        memory=spec.memory,
-        health_check=_build_health_check(spec),
-    )
+    create_kwargs: dict[str, Any] = {
+        "instance_name": friendly_name,
+        "image": spec.image,
+        "replicas": spec.replicas,
+        "port": spec.port,
+        "env": dict(spec.env),
+        "cpu": spec.cpu,
+        "memory": spec.memory,
+        "health_check": _build_health_check(spec),
+    }
+    if storage_spec is not None:
+        create_kwargs["storage"] = storage_spec
+    response = client.create_deployment(**create_kwargs)
     LOGGER.info(
         "created friendly=%s instance_id=%s initial_state=%s",
         friendly_name,
@@ -630,6 +768,24 @@ def _apply_rate_limit(
     return dataclasses.replace(proxy_spec, env=proxy_env)
 
 
+def _apply_persistent_db_path(proxy_spec: ComponentSpec) -> ComponentSpec:
+    """Repoint the proxy SQLite DB onto the persistent mount, if one is set.
+
+    No-op when `proxy_spec.persistent_volume` is None. Otherwise sets
+    `LLMTRACE_STORAGE_DATABASE_PATH` to `<mount_path>/<db_filename>` so the
+    `lite`/`sqlite` storage profile writes its database (traces + tenant
+    rows) onto the object-store-backed mount that survives recreate. The
+    spec's persistent_volume is the source of truth — a caller-supplied
+    same-named env value is overwritten (same precedence model as
+    `_apply_proxy_auth` / `_apply_rate_limit`).
+    """
+    pv = proxy_spec.persistent_volume
+    if pv is None:
+        return proxy_spec
+    env = {**proxy_spec.env, STORAGE_DB_PATH_ENV: pv.database_path}
+    return dataclasses.replace(proxy_spec, env=env)
+
+
 def _admin_http_request(
     proxy_url: str,
     path: str,
@@ -671,7 +827,10 @@ def _admin_http_request(
 
 
 def _bootstrap_tenant_in_proxy(
-    proxy_url: str, admin_key: str, tenant_label: str
+    proxy_url: str,
+    admin_key: str,
+    tenant_label: str,
+    stable_id: Optional[str] = None,
 ) -> str:
     """Create the per-pod tenant row via `POST /api/v1/tenants`.
 
@@ -679,13 +838,23 @@ def _bootstrap_tenant_in_proxy(
     must materialise one. Returns the tenant UUID. The bootstrap admin
     key authenticates this call; the resulting tenant row owns all
     operator keys minted afterwards.
+
+    When `stable_id` is supplied it is sent as the `id` field so the proxy
+    reuses the SAME tenant id across redeploys (idempotent create — owned by
+    the proxy). This is what makes tenant identity survive `recreate`. The
+    request struct is not `deny_unknown_fields`, so a proxy that does not yet
+    honour `id` ignores it harmlessly (the response `id` then governs). We
+    always trust the returned `id` so the caller is correct in both cases.
     """
+    body: dict[str, Any] = {"name": tenant_label, "plan": "default", "config": {}}
+    if stable_id:
+        body["id"] = stable_id
     status, payload = _admin_http_request(
         proxy_url,
         TENANTS_PATH,
         "POST",
         admin_key,
-        body={"name": tenant_label, "plan": "default", "config": {}},
+        body=body,
     )
     if status != 201:
         raise RuntimeError(
@@ -696,7 +865,12 @@ def _bootstrap_tenant_in_proxy(
         raise RuntimeError(
             f"tenant bootstrap response missing 'id': body={payload}"
         )
-    LOGGER.info("bootstrapped tenant in proxy uuid=%s label=%s", tenant_uuid, tenant_label)
+    LOGGER.info(
+        "bootstrapped tenant in proxy uuid=%s label=%s stable_id=%s",
+        tenant_uuid,
+        tenant_label,
+        stable_id or "<none>",
+    )
     return tenant_uuid
 
 
@@ -894,6 +1068,9 @@ def provision(
         )
     if spec.rate_limit is not None:
         proxy_spec = _apply_rate_limit(proxy_spec, spec.rate_limit)
+    # Repoint the sqlite DB onto the persistent mount (if attached) BEFORE
+    # creating the proxy so the very first boot writes to the durable path.
+    proxy_spec = _apply_persistent_db_path(proxy_spec)
     proxy_spec = _apply_ml_preload_startup_floor(proxy_spec, tenant_id=tenant_id)
     _warn_on_unsharable_replicas(proxy_spec, tenant_id)
 
@@ -918,7 +1095,13 @@ def provision(
             proxy = rotation.proxy
             admin_key = rotation.admin_key
 
-        tenant_uuid = _bootstrap_tenant_in_proxy(proxy.url, admin_key, tenant_id)
+        # Pass the stable internal tenant id so the proxy reuses the SAME
+        # tenant id across redeploys (identity persists when the proxy honours
+        # an explicit id on create — owned by the proxy). We still trust the
+        # returned id, so this is correct whether or not the proxy honours it.
+        tenant_uuid = _bootstrap_tenant_in_proxy(
+            proxy.url, admin_key, tenant_id, stable_id=spec.tenant_uuid
+        )
         operator_key = _mint_operator_key(proxy.url, admin_key, tenant_uuid)
     else:
         tenant_uuid = None
@@ -989,7 +1172,7 @@ def _verify_or_remint_operator_key(
             spec.tenant_id,
         )
         tenant_uuid = _bootstrap_tenant_in_proxy(
-            proxy_url, admin_key, spec.tenant_id
+            proxy_url, admin_key, spec.tenant_id, stable_id=spec.tenant_uuid
         )
         return (admin_key, _mint_operator_key(proxy_url, admin_key, tenant_uuid))
     existing = _find_operator_key_record(proxy_url, admin_key, tenant_uuid)

--- a/deployments/basilica/tests/conftest.py
+++ b/deployments/basilica/tests/conftest.py
@@ -23,10 +23,28 @@ def _install_basilica_stub() -> None:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             self.args = args
             self.kwargs = kwargs
+            # Expose kwargs as attributes too, so tests that read the real
+            # SDK's property accessors (e.g. StorageSpec.persistent,
+            # PersistentStorageSpec.bucket) also work against the stub.
+            for key, value in kwargs.items():
+                setattr(self, key, value)
 
     module.BasilicaClient = _Stub
     module.HealthCheckConfig = _Stub
     module.ProbeConfig = _Stub
+
+    # Storage SDK surface used by the persistent-volume path. Tests that
+    # assert on the StorageSpec contents inspect these stubs' captured
+    # kwargs/args (they never reach a real Basilica backend).
+    module.PersistentStorageSpec = _Stub
+    module.StorageSpec = _Stub
+
+    class _StorageBackend:
+        R2 = "R2"
+        S3 = "S3"
+        GCS = "GCS"
+
+    module.StorageBackend = _StorageBackend
     sys.modules["basilica"] = module
 
 

--- a/deployments/basilica/tests/test_persistent_storage.py
+++ b/deployments/basilica/tests/test_persistent_storage.py
@@ -1,0 +1,330 @@
+"""Tests for the durable-storage substrate wiring.
+
+Scope: the `PersistentVolumeSpec` dataclass, its `StorageSpec` projection,
+the `LLMTRACE_STORAGE_DATABASE_PATH` repointing helper, the storage threading
+through `_create_component`, and the stable-tenant-id field on tenant
+bootstrap. The Basilica SDK boundary is the conftest stub; no real backend is
+contacted.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Callable
+
+import pytest
+
+from deployments.basilica import lifecycle
+
+
+# ---------------------------------------------------------------------------
+# In-process fake proxy admin API (mirrors test_operator_key_minting.py)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    responder: Callable[[str, str, dict[str, str], bytes], tuple[int, dict[str, Any]]]
+    recorded: list[dict[str, Any]]
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    def _dispatch(self, method: str) -> None:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length) if length else b""
+        headers = {k.lower(): v for k, v in self.headers.items()}
+        self.recorded.append(
+            {"method": method, "path": self.path, "headers": headers, "body": body}
+        )
+        status, payload = self.responder(method, self.path, headers, body)
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._dispatch("GET")
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._dispatch("POST")
+
+
+class _FakeProxy:
+    def __init__(self, responder: Callable[..., tuple[int, dict[str, Any]]]) -> None:
+        self.recorded: list[dict[str, Any]] = []
+        handler_cls = type(
+            "Handler",
+            (_RecordingHandler,),
+            {"responder": staticmethod(responder), "recorded": self.recorded},
+        )
+        self.server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+
+@pytest.fixture
+def fake_proxy() -> Any:
+    servers: list[_FakeProxy] = []
+
+    def make(responder: Callable[..., tuple[int, dict[str, Any]]]) -> _FakeProxy:
+        s = _FakeProxy(responder)
+        servers.append(s)
+        return s
+
+    yield make
+    for s in servers:
+        s.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# PersistentVolumeSpec validation + projection
+# ---------------------------------------------------------------------------
+
+
+def _pv(**overrides: Any) -> lifecycle.PersistentVolumeSpec:
+    kwargs: dict[str, Any] = {
+        "bucket": "llmtrace-traces",
+        "credentials_secret": "basilica-r2-credentials",
+    }
+    kwargs.update(overrides)
+    return lifecycle.PersistentVolumeSpec(**kwargs)
+
+
+def test_database_path_joins_mount_and_filename() -> None:
+    pv = _pv(mount_path="/data", db_filename="llmtrace.db")
+    assert pv.database_path == "/data/llmtrace.db"
+    pv2 = _pv(mount_path="/mnt/store/", db_filename="t.db")
+    assert pv2.database_path == "/mnt/store/t.db"
+
+
+def test_to_storage_spec_passes_all_fields_to_sdk() -> None:
+    pv = _pv(
+        bucket="b1",
+        credentials_secret="sec1",
+        mount_path="/data",
+        backend="s3",
+        region="eu-west-1",
+        endpoint="https://s3.example",
+        sync_interval_ms=2000,
+        cache_size_mb=2048,
+    )
+    spec = pv.to_storage_spec()
+    persistent = spec.persistent
+    assert persistent.enabled is True
+    assert str(persistent.backend) == "StorageBackend.S3"
+    assert persistent.bucket == "b1"
+    assert persistent.credentials_secret == "sec1"
+    assert persistent.mount_path == "/data"
+    assert persistent.region == "eu-west-1"
+    assert persistent.endpoint == "https://s3.example"
+    assert persistent.sync_interval_ms == 2000
+    assert persistent.cache_size_mb == 2048
+
+
+def test_backend_is_case_insensitive() -> None:
+    assert (
+        str(_pv(backend="R2").to_storage_spec().persistent.backend)
+        == "StorageBackend.R2"
+    )
+    assert (
+        str(_pv(backend="gcs").to_storage_spec().persistent.backend)
+        == "StorageBackend.GCS"
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides, match",
+    [
+        ({"bucket": ""}, "bucket"),
+        ({"credentials_secret": ""}, "credentials_secret"),
+        ({"mount_path": "data"}, "absolute"),
+        ({"backend": "azure"}, "backend"),
+        ({"sync_interval_ms": 0}, "sync_interval_ms"),
+        ({"cache_size_mb": -1}, "cache_size_mb"),
+        ({"db_filename": "a/b.db"}, "db_filename"),
+        ({"db_filename": ""}, "db_filename"),
+    ],
+)
+def test_validation_rejects_bad_specs(overrides: dict[str, Any], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _pv(**overrides)
+
+
+# ---------------------------------------------------------------------------
+# _apply_persistent_db_path
+# ---------------------------------------------------------------------------
+
+
+def _proxy_spec(**overrides: Any) -> lifecycle.ComponentSpec:
+    kwargs: dict[str, Any] = {
+        "image": "ghcr.io/example/proxy:latest",
+        "port": 8080,
+        "cpu": "1",
+        "memory": "1Gi",
+        "replicas": 1,
+        "env": {"LLMTRACE_UPSTREAM_URL": "https://upstream.example"},
+    }
+    kwargs.update(overrides)
+    return lifecycle.ComponentSpec(**kwargs)
+
+
+def test_apply_persistent_db_path_noop_without_volume() -> None:
+    spec = _proxy_spec()
+    assert lifecycle._apply_persistent_db_path(spec) is spec
+
+
+def test_apply_persistent_db_path_sets_env_to_mount() -> None:
+    spec = _proxy_spec(persistent_volume=_pv(mount_path="/data", db_filename="x.db"))
+    out = lifecycle._apply_persistent_db_path(spec)
+    assert out.env[lifecycle.STORAGE_DB_PATH_ENV] == "/data/x.db"
+    # original env preserved
+    assert out.env["LLMTRACE_UPSTREAM_URL"] == "https://upstream.example"
+
+
+def test_apply_persistent_db_path_overrides_caller_env() -> None:
+    spec = _proxy_spec(
+        env={lifecycle.STORAGE_DB_PATH_ENV: "/home/llmtrace/stale.db"},
+        persistent_volume=_pv(mount_path="/data"),
+    )
+    out = lifecycle._apply_persistent_db_path(spec)
+    assert out.env[lifecycle.STORAGE_DB_PATH_ENV] == "/data/llmtrace.db"
+
+
+# ---------------------------------------------------------------------------
+# Stable tenant id on bootstrap
+# ---------------------------------------------------------------------------
+
+
+_STABLE_ID = "user-uuid-550e8400-e29b-41d4-a716-446655440000"
+_RETURNED_UUID = "11111111-1111-4111-8111-111111111111"
+
+
+def test_bootstrap_sends_stable_id_when_set(fake_proxy: Any) -> None:
+    def responder(method: str, path: str, headers: dict[str, str], body: bytes):
+        decoded = json.loads(body)
+        assert decoded["id"] == _STABLE_ID
+        assert decoded["name"] == "acme"
+        return 201, {"id": _RETURNED_UUID, "name": "acme"}
+
+    proxy = fake_proxy(responder)
+    out = lifecycle._bootstrap_tenant_in_proxy(
+        proxy.url, "llmt_" + "a" * 64, "acme", stable_id=_STABLE_ID
+    )
+    assert out == _RETURNED_UUID
+
+
+def test_bootstrap_omits_id_field_when_unset(fake_proxy: Any) -> None:
+    def responder(method: str, path: str, headers: dict[str, str], body: bytes):
+        decoded = json.loads(body)
+        assert "id" not in decoded
+        return 201, {"id": _RETURNED_UUID, "name": "acme"}
+
+    proxy = fake_proxy(responder)
+    out = lifecycle._bootstrap_tenant_in_proxy(proxy.url, "llmt_" + "a" * 64, "acme")
+    assert out == _RETURNED_UUID
+
+
+# ---------------------------------------------------------------------------
+# Storage threading through _create_component (via provision)
+# ---------------------------------------------------------------------------
+
+
+class _FakeReplicas:
+    def __init__(self, ready: int, desired: int) -> None:
+        self.ready = ready
+        self.desired = desired
+
+
+class _FakeDetail:
+    def __init__(self, instance_name: str, url: str) -> None:
+        self.instance_name = instance_name
+        self.state = "running"
+        self.url = url
+        self.replicas = _FakeReplicas(1, 1)
+        self.phase = "ready"
+        self.message = None
+
+
+class _FakeBasilicaClient:
+    def __init__(self, proxy_url: str, dashboard_url: str) -> None:
+        self.proxy_url = proxy_url
+        self.dashboard_url = dashboard_url
+        self.creates: list[dict[str, Any]] = []
+
+    def create_deployment(self, **kwargs: Any) -> _FakeDetail:
+        name = kwargs.get("instance_name", "")
+        self.creates.append(kwargs)
+        if "proxy" in name:
+            return _FakeDetail(instance_name="proxy-uuid", url=self.proxy_url)
+        return _FakeDetail(instance_name="dash-uuid", url=self.dashboard_url)
+
+    def get_deployment(self, instance_name: str) -> _FakeDetail:
+        if instance_name == "proxy-uuid":
+            return _FakeDetail(instance_name="proxy-uuid", url=self.proxy_url)
+        return _FakeDetail(instance_name="dash-uuid", url=self.dashboard_url)
+
+
+def test_provision_attaches_storage_and_repoints_db_and_sends_stable_id(
+    fake_proxy: Any,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def responder(method: str, path: str, headers: dict[str, str], body: bytes):
+        if method == "POST" and path == "/api/v1/tenants":
+            seen["tenant_body"] = json.loads(body)
+            return 201, {"id": _RETURNED_UUID, "name": "acme"}
+        if method == "POST" and path == "/api/v1/auth/keys":
+            return 201, {"key": "llmt_" + "b" * 64, "key_prefix": "llmt_bbb"}
+        raise AssertionError(f"unexpected: {method} {path}")
+
+    proxy = fake_proxy(responder)
+    client = _FakeBasilicaClient(proxy.url, "https://dashboard.example")
+
+    proxy_spec = _proxy_spec(
+        persistent_volume=_pv(mount_path="/data", db_filename="llmtrace.db")
+    )
+    dash_spec = lifecycle.ComponentSpec(
+        image="ghcr.io/example/dashboard:latest",
+        port=3000,
+        cpu="1",
+        memory="1Gi",
+        replicas=1,
+        env={"HOSTNAME": "0.0.0.0"},
+    )
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        tenant_uuid=_STABLE_ID,
+        proxy=proxy_spec,
+        dashboard=dash_spec,
+        api_key="llmt_" + "a" * 64,
+    )
+
+    lifecycle.provision(spec, client=client)
+
+    proxy_create = next(c for c in client.creates if "proxy" in c["instance_name"])
+    # Storage spec was attached to the proxy create.
+    assert "storage" in proxy_create
+    persistent = proxy_create["storage"].persistent
+    assert persistent.bucket == "llmtrace-traces"
+    assert persistent.mount_path == "/data"
+    # DB path repointed onto the mount.
+    assert proxy_create["env"][lifecycle.STORAGE_DB_PATH_ENV] == "/data/llmtrace.db"
+    # Stable id forwarded on tenant create.
+    assert seen["tenant_body"]["id"] == _STABLE_ID
+    # Dashboard has no storage attached (only proxy carries the DB).
+    dash_create = next(c for c in client.creates if "dashboard" in c["instance_name"])
+    assert "storage" not in dash_create

--- a/docs/research/basilica-persistence-options-2026-05-29.md
+++ b/docs/research/basilica-persistence-options-2026-05-29.md
@@ -1,0 +1,188 @@
+# Basilica persistence options for LLMTrace tenant + trace state (2026-05-29)
+
+## Problem
+
+On Basilica, LLMTrace proxy storage is ephemeral. The proxy defaults to the
+SQLite (`lite`/`sqlite`) profile writing `llmtrace.db` to the container's
+local working directory (`/home/llmtrace/llmtrace.db` — see Evidence E5).
+There is no mounted durable volume today. On `update(strategy="recreate")`
+the lifecycle layer deletes both Basilica deployments and re-provisions fresh
+ones (`deployments/basilica/lifecycle.py:1063-1068`), which:
+
+1. wipes all traces stored in the per-pod SQLite file, and
+2. re-bootstraps a brand-new internal tenant row (the proxy mints a fresh
+   tenant UUID on `POST /api/v1/tenants`), so tenant identity is lost.
+
+Goal: make tenant + trace state survive a redeploy.
+
+## What the Basilica SDK actually offers (evidence)
+
+SDK version inspected: `basilica-sdk` at
+`/home/epappas/.local/lib/python3.12/site-packages/basilica/`.
+
+### E1 — `create_deployment` accepts a `storage` spec
+
+`basilica/__init__.py:1825-1851` — the low-level `create_deployment(...)`
+signature includes:
+
+```python
+storage: Optional[Union[str, StorageSpec]] = None,
+```
+
+`basilica/__init__.py:1903-1918` builds a `StorageSpec` from it: if `storage`
+is a `str` it is treated as a mount path and wrapped in a
+`PersistentStorageSpec(enabled=True, backend=StorageBackend.R2, bucket="",
+credentials_secret=None, sync_interval_ms=1000, cache_size_mb=1024,
+mount_path=storage)`. If it is already a `StorageSpec` it is passed through.
+
+### E2 — persistent storage is OBJECT-STORE backed, not a raw block volume
+
+`_basilica.pyi:577-617` — `PersistentStorageSpec.__new__`:
+
+```python
+def __new__(cls, enabled, backend: StorageBackend, bucket: str='',
+            region=None, endpoint=None, credentials_secret=None,
+            sync_interval_ms: int=1000, cache_size_mb: int=1024,
+            mount_path: str='/data') -> PersistentStorageSpec: ...
+```
+
+`_basilica.pyi:1107-1113` — `StorageBackend` enum is `{R2, S3, GCS}`. So the
+only persistent backend is an object store (Cloudflare R2 / AWS S3 / GCS),
+synced on an interval (`sync_interval_ms`) with a local cache
+(`cache_size_mb`). It REQUIRES a `bucket` and (in practice) a
+`credentials_secret` naming a pre-provisioned secret on the Basilica side
+(the `deploy_vllm`/`deploy_sglang` paths hard-code
+`credentials_secret="basilica-r2-credentials"`, `__init__.py:915,1071`).
+
+There is NO local-disk / PVC / hostPath persistent-volume option on
+`CreateDeploymentRequest`. `VolumeMountRequest(host_path, container_path,
+read_only)` exists (`_basilica.pyi:1058-1074`) but it is ONLY a field of
+`StartRentalApiRequest` (raw GPU rentals, `_basilica.pyi:983`), NOT of
+`CreateDeploymentRequest` (`_basilica.pyi:126-190` — its fields are
+`instance_name, image, replicas, port, command, args, env, resources,
+ttl_seconds, public, storage, topology_spread, health_check, websocket,
+public_metadata`; no `volumes`). The `Volume.from_name(...)` helper
+(`basilica/volume.py`) is consumed only by the `@basilica.deployment`
+decorator's `volumes={}` kwarg, a code path the lifecycle library does not
+use (it calls the low-level `create_deployment`).
+
+### E3 — `create_deployment` does NOT thread storage today
+
+`deployments/basilica/lifecycle.py:438-447` (`_create_component`) calls
+`client.create_deployment(...)` with no `storage=` argument. So even though
+the SDK supports it, LLMTrace never requests any persistent storage.
+
+### E4 — restart vs recreate disk semantics
+
+`lifecycle.py:1031-1068`:
+
+- `strategy="restart"` calls `client.restart_deployment(uuid)` on each side
+  (rolling restart of existing pods). The pods keep their identity; the
+  Basilica deployment (and whatever disk is attached to it) is not deleted.
+  The library's own restart path (`_verify_or_remint_operator_key`,
+  `lifecycle.py:961-1003`) is built on the assumption that the tenant row
+  and operator key SURVIVE a restart and only need re-minting if absent.
+- `strategy="recreate"` calls `_safe_delete` on both UUIDs then
+  `provision(spec)` (`lifecycle.py:1063-1068`). Deleting the Basilica
+  deployment destroys the pod and its container-local disk.
+
+The shipped README already states this contract (`deployments/basilica/
+README.md:647-650`): recreate → "DB volume is destroyed alongside the pods";
+restart → "Same DB volume — rows survive".
+
+IMPORTANT CAVEAT — restart does NOT survive a node reschedule. A Basilica
+rolling restart keeps the deployment object, but the proxy's SQLite file
+lives on the container's ephemeral local filesystem (`emptyDir`-class, E5).
+If the pod is rescheduled to another node (eviction, node failure, image
+update via recreate) the local file is gone. "restart preserves the DB" is
+only true for an in-place pod roll on the same node with the same writable
+layer. It is NOT a durability guarantee equivalent to a real volume.
+Additionally the README documents (`README.md:1248`) that `restart` returns
+`404 deployments.apps ... not found` on a freshly-provisioned deployment
+until the k8s Deployment CR has materialised — so restart is not always
+available even when desired.
+
+### E5 — where the SQLite file lives
+
+`Dockerfile:64-72` — the proxy image runs as user `llmtrace` (uid 1000) with
+`WORKDIR /home/llmtrace`. The default DB path is the RELATIVE string
+`llmtrace.db` (`crates/llmtrace-core/src/lib.rs:1853-1855`,
+`default_database_path() -> "llmtrace.db"`), so it resolves to
+`/home/llmtrace/llmtrace.db` on the container-local writable layer. The image
+already creates and chowns `/home/llmtrace/.cache/llmtrace/models` for the ML
+weights (`Dockerfile:69`) — that directory is likewise ephemeral.
+
+### E6 — external DB profile is wired, but no endpoints are available here
+
+`crates/llmtrace-proxy/src/config.rs:49-64` reads `LLMTRACE_STORAGE_PROFILE`,
+`LLMTRACE_STORAGE_DATABASE_PATH`, `LLMTRACE_CLICKHOUSE_URL`,
+`LLMTRACE_POSTGRES_URL`, `LLMTRACE_REDIS_URL`. `crates/llmtrace-proxy/src/
+main.rs:438-464` maps `profile=="production"` to `StorageProfile::Production
+{ clickhouse_url, postgres_url, redis_url }` — a fully durable external
+backend. This is the only LLMTrace storage mode that is unconditionally
+durable across recreate.
+
+BUT: no external Postgres/ClickHouse/Redis endpoints are credentialed in this
+environment. `/home/epappas/workspace/spacejar/autojepa/.env` is readable and
+contains 9 keys, NONE matching `POSTGRES|CLICKHOUSE|REDIS|DATABASE|DB_*|
+DSN|*_URL` (verified by grepping key names only; no values inspected). No R2
+/ S3 / GCS bucket or `*-r2-credentials` secret is referenced anywhere in
+`deployments/`. So neither the production profile nor the R2-backed
+persistent mount can be wired with real, working credentials right now.
+
+### E7 — tenant create does NOT yet accept an explicit id
+
+`crates/llmtrace-proxy/src/tenant_api.rs:24-35` — `CreateTenantRequest` has
+only `name`, `plan`, `config`. There is no `id` field, so the proxy mints a
+fresh UUID per create. The struct is NOT `#[serde(deny_unknown_fields)]`, so
+sending an extra `id` key in the JSON body is currently IGNORED (safe, no
+error). Making create idempotent on a caller-supplied stable id is owned by
+the parallel proxy agent; this work provides the stable id over the wire so
+that, once the proxy honours it, identity persists across recreate.
+
+## Durable options, ranked
+
+| Rank | Option | Survives recreate? | Requires | Status here |
+|---|---|---|---|---|
+| 1 | External production profile (Postgres + ClickHouse + Redis) via `LLMTRACE_*_URL` env | YES (fully) | Real, reachable, credentialed DB endpoints | BLOCKED — no endpoints in this env (E6) |
+| 2 | R2/S3/GCS-backed `StorageSpec` mount, point SQLite db at the mount path | YES (synced to object store) | A bucket + a Basilica-side `credentials_secret` | BLOCKED — no bucket/credentials in this env (E2, E6) |
+| 3 | `strategy="restart"` for updates + deterministic SQLite path on the pod | PARTIAL — survives in-place pod roll, NOT recreate, NOT node reschedule | Operator must use restart, never recreate, for updates | AVAILABLE but weak (E4) |
+| 4 | Deterministic/stable tenant id passed to tenant create | Identity only (not traces); needs proxy-side idempotent create | Proxy to honour an `id` field on create (parallel agent) | WIRED here; proxy support pending (E7) |
+
+## Decision
+
+- Options 1 and 2 are the only ways to make TRACES survive `recreate`. Both
+  are BLOCKED in this environment for lack of real credentials/endpoints. We
+  will NOT invent connection strings or bucket names.
+- We make the deployment FORWARD-READY for both: `lifecycle.py` gains a
+  first-class, validated way to attach a Basilica `StorageSpec` (object-store
+  persistent mount) and to set `LLMTRACE_STORAGE_DATABASE_PATH` onto the
+  mount, and `pro.yaml` documents the production-profile env switch. Neither
+  is turned on by default because doing so without real credentials would
+  break deploys.
+- We pass the STABLE tenant id on tenant create so that, the moment the proxy
+  makes create idempotent on it (parallel agent, E7), tenant IDENTITY
+  survives recreate. This is safe to ship now (E7: unknown field ignored).
+- We document the restart-vs-recreate disk contract and the deterministic
+  SQLite path so an operator who chooses restart-based updates retains state
+  in-place, with the honest caveat that this is not node-reschedule durable.
+
+## Honest verdict
+
+With the credentials available in THIS environment, TRACES do not survive a
+`--strategy recreate` — there is no durable substrate (no external DB, no
+object-store bucket) to point at, and Basilica deployments have no raw
+persistent block volume on `CreateDeploymentRequest`. What this change does
+deliver:
+
+- A deterministic, configurable SQLite path and a first-class
+  `StorageSpec` attachment point, so durability is a one-line config change
+  once a bucket or external DB exists.
+- The stable tenant id on the wire, so tenant identity persists across
+  recreate as soon as the proxy honours it.
+- The production-profile switch documented end-to-end in `pro.yaml`.
+
+To actually persist traces across recreate, EITHER provision an external
+Postgres+ClickHouse+Redis and set the `LLMTRACE_*_URL` env (Option 1), OR
+provision an R2/S3/GCS bucket + Basilica `credentials_secret` and enable the
+`StorageSpec` mount with the SQLite db on it (Option 2).


### PR DESCRIPTION
Addresses issue 9 ("redeploy forgets tenants"). Verified import-safe against the installed Basilica SDK (`StorageSpec`, `PersistentStorageSpec`, `StorageBackend` all present).

## Honest persistence verdict
With the credentials available today, **trace history does NOT survive `--strategy recreate`** — Basilica deployments expose no block/hostPath volume (only object-store `StorageSpec` for R2/S3/GCS, or an external production DB), and **neither is credentialed in this environment**. This PR wires the *attachment points* for both durable options and makes enabling them a config switch, but enables **neither by default** (so current deploys keep working unchanged). What becomes durable immediately is **tenant identity** via the stable `tenant_uuid`.

## Changes
- `lifecycle.py`: `PersistentVolumeSpec` (validated) + `StorageSpec` projection; `persistent_volume` on `ComponentSpec`; `_apply_persistent_db_path` repoints `LLMTRACE_STORAGE_DATABASE_PATH` onto the mount; `tenant_uuid` on `TenantSpec` sent as `id` on `POST /api/v1/tenants` (both provision + restart paths).
- `cli.py`: parses `proxy.persistent_volume` + top-level `tenant_uuid`.
- `pro.yaml`: documents the three durable options (external DB / object-store mount / restart-only) — all commented out, defaults unchanged.
- `README.md` + `docs/research/basilica-persistence-options-2026-05-29.md`: investigation writeup.
- `tests/test_persistent_storage.py`: 17 new tests.

## Dependency
Stable-id persistence requires the proxy's `CreateTenantRequest` to accept an optional `id` and make create idempotent on it — delivered in the proxy tenant-subsystem PR. Until then the sent `id` is ignored harmlessly (not `deny_unknown_fields`); the returned id is always trusted.

## Verification
- `py_compile` exit 0; new tests 17 passed; full basilica test suite 88 passed (2 pre-existing network-sandbox failures unrelated)
- `helm lint` exit 0; pro.yaml/starter.yaml parse OK

## Live validation required post-merge (orchestrator/operator)
Only provable with a real bucket/DB credential: provision with durable backend + stable `tenant_uuid` -> send N traces -> `update --strategy recreate` -> assert tenant id unchanged AND traces still queryable.