### PR TITLE
fix(dashboard): P0 tenant isolation end-to-end + admin all-tenants view + per-tenant upstream creds + sidebar auto-refresh

### DIFF
--- a/dashboard/e2e/dashboard.spec.ts
+++ b/dashboard/e2e/dashboard.spec.ts
@@ -310,20 +310,25 @@ test.describe('LLMTrace Dashboard', () => {
 
       await page.reload();
       await page.waitForLoadState('domcontentloaded');
-      // Wait for 2 real tenant options (ignore placeholder/empty option).
+      // Wait for 2 real tenant options. Ignore the placeholder/empty option
+      // AND the "__all__" all-tenants sentinel (admin scope, not a tenant).
       await page.waitForFunction(() => {
         const opts = Array.from(document.querySelectorAll('aside select option'));
-        const real = opts.filter((o) => (o as HTMLOptionElement).value && (o as HTMLOptionElement).value.trim() !== '');
+        const real = opts.filter((o) => {
+          const v = (o as HTMLOptionElement).value;
+          return v && v.trim() !== '' && v !== '__all__';
+        });
         return real.length >= 2;
       });
     }
 
-    // 2. Select the second real tenant option (ignore placeholder option with empty value).
+    // 2. Select the second real tenant option (ignore the empty placeholder
+    // and the "__all__" all-tenants sentinel).
     const optionValues = await selector.evaluate((el) => {
       const opts = Array.from((el as HTMLSelectElement).querySelectorAll('option'));
       return opts
         .map((o) => (o as HTMLOptionElement).value)
-        .filter((v) => v && v.trim() !== '');
+        .filter((v) => v && v.trim() !== '' && v !== '__all__');
     });
 
     if (optionValues.length < 2) {
@@ -334,15 +339,35 @@ test.describe('LLMTrace Dashboard', () => {
     if (!targetId) {
       throw new Error('Second tenant option had no value attribute');
     }
-    
+
     // 3. Select the second tenant and wait until it is persisted in localStorage
     await selector.selectOption(targetId);
     await page.waitForFunction((id) => localStorage.getItem("llmtrace_tenant_id") === id, targetId);
-    
+
     // 4. Verify it persists after a hard reload (sidebar must re-read localStorage).
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('aside select')).toHaveValue(targetId, { timeout: 15000 });
+  });
+
+  test('Sidebar: "All tenants" selection persists the all-tenants scope', async ({ page }) => {
+    // Selecting the admin "All tenants" option must store the "__all__"
+    // sentinel so user-scoped reads send X-LLMTrace-Tenant-Scope: all
+    // (CONTRACT 2) instead of a concrete tenant id.
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const selector = page.getByTestId('tenant-selector');
+    await expect(selector).toBeVisible();
+
+    await selector.selectOption('__all__');
+    await page.waitForFunction(
+      () => localStorage.getItem('llmtrace_tenant_id') === '__all__',
+    );
+
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.getByTestId('tenant-selector')).toHaveValue('__all__', { timeout: 15000 });
   });
 
 });

--- a/dashboard/src/app/playground/_client.tsx
+++ b/dashboard/src/app/playground/_client.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { STORED_TENANT_KEY, ALL_TENANTS_SCOPE } from "@/lib/api";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -157,6 +158,33 @@ const ACTION_CHIPS: readonly ActionChip[] = [
 
 const TEXTAREA_LINE_PX = 24;
 const TEXTAREA_MAX_LINES = 6;
+
+// ---------------------------------------------------------------------------
+// Tenant scoping — playground traffic must carry the operator's sidebar
+// selection so generated traces are attributed to the selected tenant and
+// reads stay consistently scoped. Without this, the raw proxy fetch sends
+// no tenant header and the proxy mis-attributes every trace to its default
+// tenant (the reported cross-tenant contamination P0).
+// ---------------------------------------------------------------------------
+
+/** Read the operator's current sidebar tenant selection from localStorage. */
+function selectedTenant(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(STORED_TENANT_KEY);
+}
+
+/**
+ * Tenant-scoping headers for READS. "All tenants" is a valid read scope:
+ *  - "all tenants"     -> { "X-LLMTrace-Tenant-Scope": "all" }
+ *  - concrete tenant   -> { "X-LLMTrace-Tenant-ID": <id> }
+ *  - nothing selected  -> {} (proxy applies its own default)
+ */
+function tenantReadHeaders(): Record<string, string> {
+  const sel = selectedTenant();
+  if (sel === ALL_TENANTS_SCOPE) return { "X-LLMTrace-Tenant-Scope": "all" };
+  if (sel) return { "X-LLMTrace-Tenant-ID": sel };
+  return {};
+}
 
 // ---------------------------------------------------------------------------
 // Backend shapes (subset we touch). The real TraceEvent lives in `lib/api.ts`
@@ -680,9 +708,26 @@ type SendResult =
   | { kind: "err"; error: string; traceId: string | null; raw: string };
 
 async function postChat(requestBody: string): Promise<SendResult> {
+  const sel = selectedTenant();
+  // WRITE GUARD: "all tenants" is a read-only aggregate scope — there is no
+  // single tenant to write the generated trace to. Refuse to send. This is
+  // the authoritative backstop for the composer's disabled affordance.
+  if (sel === ALL_TENANTS_SCOPE) {
+    return {
+      kind: "err",
+      error: "Select a specific tenant to send traffic — the playground cannot send to 'All tenants'.",
+      traceId: null,
+      raw: "",
+    };
+  }
   const res = await fetch("/api/proxy/v1/chat/completions", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // Concrete selection -> attribute the trace to that tenant. No
+      // selection -> send no header and let the proxy apply its default.
+      ...(sel ? { "X-LLMTrace-Tenant-ID": sel } : {}),
+    },
     body: requestBody,
   });
   const traceId = res.headers.get("x-llmtrace-trace-id");
@@ -718,7 +763,10 @@ const TRACE_FETCH_RETRIES: readonly number[] = [250, 500, 1000, 2000];
 async function fetchTrace(traceId: string): Promise<RawTrace | null> {
   for (let attempt = 0; attempt <= TRACE_FETCH_RETRIES.length; attempt++) {
     try {
-      const res = await fetch(`/api/proxy/traces/${traceId}`, { cache: "no-store" });
+      const res = await fetch(`/api/proxy/traces/${traceId}`, {
+        cache: "no-store",
+        headers: tenantReadHeaders(),
+      });
       if (res.ok) {
         return (await res.json()) as RawTrace;
       }
@@ -762,6 +810,15 @@ export default function PlaygroundClient(): ReactElement {
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState<boolean>(false);
   const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set());
+  // Whether the "All tenants" aggregate scope is the active selection. Reads
+  // are allowed in that scope, but writes (sending traffic) are not — there is
+  // no single tenant to attribute the generated trace to. Read once on mount;
+  // the sidebar reloads the page on any selection change, so this stays
+  // authoritative for the session. SSR-safe (localStorage is client-only).
+  const [allTenantsScope, setAllTenantsScope] = useState<boolean>(false);
+  useEffect(() => {
+    setAllTenantsScope(selectedTenant() === ALL_TENANTS_SCOPE);
+  }, []);
   const [settings, setSettings] = useState<Settings>({
     model: "gpt-4o-mini",
     customModel: "",
@@ -965,7 +1022,7 @@ export default function PlaygroundClient(): ReactElement {
       <div className="flex-1 overflow-y-auto" data-testid="playground-scroll">
         <div className="mx-auto w-full max-w-3xl px-4 py-6">
           {messages.length === 0 ? (
-            <EmptyState onPick={onActionChip} disabled={pending} />
+            <EmptyState onPick={onActionChip} disabled={pending || allTenantsScope} />
           ) : (
             <Transcript
               messages={messages}
@@ -989,6 +1046,7 @@ export default function PlaygroundClient(): ReactElement {
         onKeyDown={onKeyDown}
         onSend={() => void send()}
         pending={pending}
+        allTenantsScope={allTenantsScope}
       />
       <SettingsDrawer
         open={settingsOpen}
@@ -1410,11 +1468,24 @@ function Composer(props: {
   onKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
   onSend: () => void;
   pending: boolean;
+  allTenantsScope: boolean;
 }): ReactElement {
   const ref = useAutoGrow(props.draft);
-  const disabled = props.pending || props.draft.trim() === "";
+  // Sending writes a trace, which "All tenants" cannot do — block it here so
+  // the user gets immediate feedback; postChat enforces the same guard.
+  const disabled =
+    props.pending || props.allTenantsScope || props.draft.trim() === "";
   return (
     <div className="border-t bg-background/80 px-4 py-3 backdrop-blur">
+      {props.allTenantsScope && (
+        <p
+          className="mx-auto mb-2 w-full max-w-3xl text-xs text-muted-foreground"
+          data-testid="playground-all-tenants-hint"
+        >
+          Select a specific tenant to send — the playground cannot send to
+          &ldquo;All tenants&rdquo;.
+        </p>
+      )}
       <div className="mx-auto flex w-full max-w-3xl items-end gap-2 rounded-2xl border bg-card px-3 py-2 focus-within:ring-2 focus-within:ring-primary/30">
         <textarea
           ref={ref}
@@ -1422,7 +1493,7 @@ function Composer(props: {
           value={props.draft}
           onChange={(e) => props.setDraft(e.target.value)}
           onKeyDown={props.onKeyDown}
-          disabled={props.pending}
+          disabled={props.pending || props.allTenantsScope}
           rows={1}
           placeholder="Send a message. Cmd/Ctrl+Enter to send, Enter for newline."
           className="flex-1 resize-none border-0 bg-transparent px-1 py-1.5 text-sm leading-6 focus:outline-none disabled:cursor-not-allowed"

--- a/dashboard/src/app/tenants/_client.tsx
+++ b/dashboard/src/app/tenants/_client.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Trash2, Users, Key, Copy, Check, AlertTriangle, Settings, Shield, Activity, DollarSign, Save, X } from "lucide-react";
+import { Plus, Trash2, Users, Key, Copy, Check, AlertTriangle, Settings, Shield, Activity, DollarSign, Save, X, Server, KeyRound } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -11,6 +11,7 @@ import {
   type Tenant,
   type MonitoringScope,
   type TenantConfig,
+  type UpstreamCredsInput,
   listTenants,
   getTenant,
   createTenant,
@@ -20,8 +21,24 @@ import {
   listApiKeys,
   revokeApiKey,
   updateTenant,
+  notifyTenantsChanged,
   type ApiKey,
 } from "@/lib/api";
+
+/**
+ * Build the optional per-tenant upstream override fields for a create/update
+ * request (CONTRACT 1). Both fields are write-only on the wire:
+ *  - `url`: a blank string clears the override (`null` => inherit global);
+ *    a non-blank value sets it.
+ *  - `key`: only sent when the operator entered a new value. A blank field
+ *    means "leave unchanged" (the existing secret is never echoed back, so
+ *    we must not send null and accidentally wipe a configured key on edit).
+ */
+function upstreamCredsPayload(url: string, key: string): UpstreamCredsInput {
+  const payload: UpstreamCredsInput = { upstream_url: url.trim() === "" ? null : url.trim() };
+  if (key.trim() !== "") payload.upstream_api_key = key.trim();
+  return payload;
+}
 
 export default function TenantsClient() {
   const router = useRouter();
@@ -31,6 +48,8 @@ export default function TenantsClient() {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
   const [newPlan, setNewPlan] = useState("default");
+  const [newUpstreamUrl, setNewUpstreamUrl] = useState("");
+  const [newUpstreamKey, setNewUpstreamKey] = useState("");
   const [newKeyRole, setNewKeyRole] = useState<"admin" | "operator" | "viewer">("operator");
   const [generatedKey, setGeneratedKey] = useState<ApiKey | null>(null);
   const [activeTenantKeys, setActiveTenantKeys] = useState<{tenantId: string, tenantName: string, keys: ApiKey[], apiToken?: string} | null>(null);
@@ -43,6 +62,9 @@ export default function TenantsClient() {
   const [configScope, setConfigScope] = useState<MonitoringScope>("hybrid");
   const [configRateLimit, setConfigRateLimit] = useState("");
   const [configBudget, setConfigBudget] = useState("");
+  const [configUpstreamUrl, setConfigUpstreamUrl] = useState("");
+  const [configUpstreamKey, setConfigUpstreamKey] = useState("");
+  const [configUpstreamKeySet, setConfigUpstreamKeySet] = useState(false);
   const [configSaving, setConfigSaving] = useState(false);
   const [configSuccess, setConfigSuccess] = useState(false);
 
@@ -68,7 +90,11 @@ export default function TenantsClient() {
   async function handleCreate() {
     if (!newName.trim()) return;
     try {
-      const res = await createTenant({ name: newName, plan: newPlan });
+      const res = await createTenant({
+        name: newName,
+        plan: newPlan,
+        ...upstreamCredsPayload(newUpstreamUrl, newUpstreamKey),
+      });
       if (res.api_key) {
         setGeneratedKey({
           id: "new",
@@ -83,8 +109,13 @@ export default function TenantsClient() {
       }
       setNewName("");
       setNewPlan("default");
+      setNewUpstreamUrl("");
+      setNewUpstreamKey("");
       setShowCreate(false);
       await loadTenants();
+      // Refresh the sidebar selector so the new tenant is immediately
+      // selectable without a full page reload (issue 7).
+      notifyTenantsChanged();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create tenant");
     }
@@ -161,7 +192,20 @@ export default function TenantsClient() {
     setConfigScope(tenant.config.monitoring_scope || "hybrid");
     setConfigRateLimit(tenant.config.rate_limit_rpm?.toString() || "");
     setConfigBudget(tenant.config.monthly_budget?.toString() || "");
+    setConfigUpstreamUrl(tenant.upstream_url ?? "");
+    setConfigUpstreamKey("");
+    setConfigUpstreamKeySet(tenant.upstream_api_key_set ?? false);
     setConfigSuccess(false);
+    // The list payload may omit the upstream fields — fetch the full tenant
+    // for the authoritative URL + "key set" flag (the secret is never
+    // returned, only `upstream_api_key_set`).
+    try {
+      const full = await getTenant(tenant.id);
+      setConfigUpstreamUrl(full.upstream_url ?? "");
+      setConfigUpstreamKeySet(full.upstream_api_key_set ?? false);
+    } catch {
+      // Keep the list-derived values; the GET is a best-effort enrichment.
+    }
   }
 
   async function handleSaveConfig() {
@@ -176,8 +220,13 @@ export default function TenantsClient() {
       await updateTenant(editingConfig.id, {
         name: configName,
         plan: configPlan,
-        config: update
+        config: update,
+        ...upstreamCredsPayload(configUpstreamUrl, configUpstreamKey),
       });
+      // Reflect a freshly entered key in the "key set" indicator without a
+      // round-trip; the secret itself is intentionally never read back.
+      if (configUpstreamKey.trim() !== "") setConfigUpstreamKeySet(true);
+      setConfigUpstreamKey("");
       setConfigSuccess(true);
       setTimeout(() => {
         setConfigSuccess(false);
@@ -285,7 +334,7 @@ export default function TenantsClient() {
       </div>
 
       {editingConfig && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
           <Card className="w-full max-w-2xl max-h-[90vh] overflow-y-auto">
             <CardHeader className="flex flex-row items-center justify-between border-b pb-4">
               <div>
@@ -360,6 +409,53 @@ export default function TenantsClient() {
                       onChange={(e) => setConfigBudget(e.target.value)}
                       className="w-full rounded-md border bg-background px-3 py-2 text-sm"
                     />
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-4 border-t pt-6">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <Server className="h-3 w-3" /> Upstream Provider
+                </h3>
+                <p className="text-xs text-muted-foreground">
+                  Optional per-tenant upstream override. Leave blank to inherit the global default.
+                </p>
+                <div className="grid gap-6 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium flex items-center gap-2">
+                      <Server className="h-3 w-3" /> Upstream URL
+                    </label>
+                    <input
+                      type="text"
+                      name="upstream_url"
+                      placeholder="Inherit global default"
+                      value={configUpstreamUrl}
+                      onChange={(e) => setConfigUpstreamUrl(e.target.value)}
+                      className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium flex items-center gap-2">
+                      <KeyRound className="h-3 w-3" /> Upstream API Key
+                      <span
+                        data-testid="upstream-key-status"
+                        className={`ml-auto text-[10px] font-normal ${configUpstreamKeySet ? "text-success" : "text-muted-foreground"}`}
+                      >
+                        {configUpstreamKeySet ? "key set" : "no key"}
+                      </span>
+                    </label>
+                    <input
+                      type="password"
+                      name="upstream_api_key"
+                      autoComplete="new-password"
+                      placeholder={configUpstreamKeySet ? "Enter a new key to replace" : "Inherit global default"}
+                      value={configUpstreamKey}
+                      onChange={(e) => setConfigUpstreamKey(e.target.value)}
+                      className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                    />
+                    <p className="text-[11px] text-muted-foreground">
+                      Write-only. The stored secret is never displayed. Leave blank to keep the current key.
+                    </p>
                   </div>
                 </div>
               </div>
@@ -507,7 +603,7 @@ export default function TenantsClient() {
           <CardHeader>
             <CardTitle className="text-base">Create Tenant</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <div className="flex gap-4">
               <input
                 type="text"
@@ -528,6 +624,38 @@ export default function TenantsClient() {
               </select>
               <Button onClick={handleCreate}>Create</Button>
             </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1">
+                <label className="text-xs font-medium flex items-center gap-2 text-muted-foreground">
+                  <Server className="h-3 w-3" /> Upstream URL (optional)
+                </label>
+                <input
+                  type="text"
+                  name="upstream_url"
+                  placeholder="Inherit global default"
+                  value={newUpstreamUrl}
+                  onChange={(e) => setNewUpstreamUrl(e.target.value)}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium flex items-center gap-2 text-muted-foreground">
+                  <KeyRound className="h-3 w-3" /> Upstream API Key (optional)
+                </label>
+                <input
+                  type="password"
+                  name="upstream_api_key"
+                  autoComplete="new-password"
+                  placeholder="Inherit global default"
+                  value={newUpstreamKey}
+                  onChange={(e) => setNewUpstreamKey(e.target.value)}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                />
+              </div>
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              Leave both blank to inherit the global upstream provider. The API key is write-only and never displayed after saving.
+            </p>
           </CardContent>
         </Card>
       )}

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   LayoutDashboard,
   FileSearch,
@@ -20,7 +20,15 @@ import {
   LogOut,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { listTenants, setStoredTenant, type Tenant, DEFAULT_TENANT_ID } from "@/lib/api";
+import {
+  listTenants,
+  setStoredTenant,
+  type Tenant,
+  DEFAULT_TENANT_ID,
+  ALL_TENANTS_SCOPE,
+  STORED_TENANT_KEY,
+  TENANTS_CHANGED_EVENT,
+} from "@/lib/api";
 
 const navItems = [
   { href: "/", label: "Overview", icon: LayoutDashboard },
@@ -42,36 +50,49 @@ export function Sidebar() {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [selectedTenant, setSelectedTenant] = useState<string>(DEFAULT_TENANT_ID);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const data = await listTenants();
-        setTenants(data);
-        const stored = localStorage.getItem("llmtrace_tenant_id");
+  const loadTenants = useCallback(async () => {
+    try {
+      const data = await listTenants();
+      setTenants(data);
+      const stored = localStorage.getItem(STORED_TENANT_KEY);
 
-        if (stored && (stored === DEFAULT_TENANT_ID || data.some((t) => t.id === stored))) {
-          setSelectedTenant(stored);
-        } else if (data.length > 0) {
-          // If we have tenants but none stored, pick the first one from DB
-          setSelectedTenant(data[0].id);
-          if (!stored) setStoredTenant(data[0].id);
-        } else {
-          // Fallback to nil tenant if no tenants exist in DB
-          setSelectedTenant(DEFAULT_TENANT_ID);
-          if (!stored) setStoredTenant(DEFAULT_TENANT_ID);
-        }
-      } catch (e) {
-        console.error("Failed to load tenants in sidebar", e);
+      if (
+        stored &&
+        (stored === ALL_TENANTS_SCOPE ||
+          stored === DEFAULT_TENANT_ID ||
+          data.some((t) => t.id === stored))
+      ) {
+        setSelectedTenant(stored);
+      } else if (data.length > 0) {
+        // If we have tenants but none stored, pick the first one from DB
+        setSelectedTenant(data[0].id);
+        if (!stored) setStoredTenant(data[0].id);
+      } else {
+        // Fallback to nil tenant if no tenants exist in DB
         setSelectedTenant(DEFAULT_TENANT_ID);
+        if (!stored) setStoredTenant(DEFAULT_TENANT_ID);
       }
+    } catch (e) {
+      console.error("Failed to load tenants in sidebar", e);
+      setSelectedTenant(DEFAULT_TENANT_ID);
     }
-    load();
   }, []);
+
+  useEffect(() => {
+    void loadTenants();
+    // Re-run when the tenant registry changes (e.g. a tenant was created on
+    // the /tenants page) so the selector picks up new tenants without a full
+    // page reload. See issue 7.
+    const onChanged = () => void loadTenants();
+    window.addEventListener(TENANTS_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(TENANTS_CHANGED_EVENT, onChanged);
+  }, [loadTenants]);
 
   const handleTenantChange = (id: string) => {
     setSelectedTenant(id);
     setStoredTenant(id);
-    // Refresh the page to update all components with the new tenant ID
+    // Refresh the page so every page re-resolves its tenant/scope from the
+    // new selection (read pages call findActiveTenant on mount).
     window.location.reload();
   };
 
@@ -102,8 +123,11 @@ export function Sidebar() {
           <select
             value={selectedTenant}
             onChange={(e) => handleTenantChange(e.target.value)}
+            data-testid="tenant-selector"
             className="w-full bg-background border rounded-md px-3 py-2 text-sm appearance-none cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary"
           >
+            {/* Admin-only aggregate view: reads scope to every tenant. */}
+            <option value={ALL_TENANTS_SCOPE}>All tenants</option>
             {/* Always include the Default/Nil tenant if it's the only one or currently selected */}
             {(tenants.length === 0 || selectedTenant === DEFAULT_TENANT_ID) && (
               <option value={DEFAULT_TENANT_ID}>Default Tenant</option>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -11,6 +11,45 @@ const API_BASE = "";
 /** Default tenant ID used as a fallback for the "default" tenant. */
 export const DEFAULT_TENANT_ID = "6ae1ab34-02d8-5b68-ad6f-132bf4de8408";
 
+/** localStorage key holding the operator's current tenant selection. */
+export const STORED_TENANT_KEY = "llmtrace_tenant_id";
+
+/**
+ * Sentinel selection value meaning "all tenants" (admin-only read scope).
+ * Distinct from any real tenant UUID. When this is the stored selection,
+ * user-scoped reads send `X-LLMTrace-Tenant-Scope: all` and OMIT the
+ * tenant-id header (see CONTRACT 2 / proxy enforcement).
+ */
+export const ALL_TENANTS_SCOPE = "__all__";
+
+/** Request header names the proxy uses to scope a tenant-aware call. */
+const TENANT_ID_HEADER = "X-LLMTrace-Tenant-ID";
+const TENANT_SCOPE_HEADER = "X-LLMTrace-Tenant-Scope";
+
+/**
+ * Resolve the tenant-scoping request headers for a user-driven call from
+ * the stored sidebar selection. CONTRACT 2:
+ *  - specific tenant id  -> { "X-LLMTrace-Tenant-ID": <id> }
+ *  - "all tenants"       -> { "X-LLMTrace-Tenant-Scope": "all" }
+ *  - nothing stored      -> {} (caller / proxy decide)
+ *
+ * An explicit `tenantId` argument always wins and forces the id header,
+ * letting callers (e.g. per-tenant token/stat fan-out) target a concrete
+ * tenant regardless of the sidebar selection.
+ */
+function tenantScopeHeaders(tenantId?: string): Record<string, string> {
+  if (tenantId === ALL_TENANTS_SCOPE) return { [TENANT_SCOPE_HEADER]: "all" };
+  if (tenantId) return { [TENANT_ID_HEADER]: tenantId };
+  // Browser-side default: read the operator's stored sidebar selection so
+  // every user-scoped call carries the authoritative tenant/scope without
+  // each caller having to thread it through explicitly.
+  if (typeof window === "undefined") return {};
+  const stored = localStorage.getItem(STORED_TENANT_KEY);
+  if (stored === ALL_TENANTS_SCOPE) return { [TENANT_SCOPE_HEADER]: "all" };
+  if (stored) return { [TENANT_ID_HEADER]: stored };
+  return {};
+}
+
 // ---------------------------------------------------------------------------
 // Core types (mirror Rust API responses)
 // ---------------------------------------------------------------------------
@@ -109,6 +148,11 @@ export interface Tenant {
   created_at: string;
   config: TenantConfig;
   api_key?: string; // Present only immediately after creation
+  // Per-tenant upstream override (CONTRACT 1). `upstream_url` echoes the
+  // configured URL (null => inherit the global default). The secret is
+  // never returned — only a boolean flag indicating whether one is set.
+  upstream_url?: string | null;
+  upstream_api_key_set?: boolean;
 }
 
 export interface ApiKey {
@@ -184,11 +228,16 @@ async function apiFetch<T>(
   tenantId?: string,
 ): Promise<T> {
   const url = `${API_BASE}${path}`;
-  console.log(`[API] Fetching: ${url}${tenantId ? ` (Tenant: ${tenantId})` : ""}`);
+  const scopeHeaders = tenantScopeHeaders(tenantId);
+  console.log(
+    `[API] Fetching: ${url}${
+      Object.keys(scopeHeaders).length > 0 ? ` (${JSON.stringify(scopeHeaders)})` : ""
+    }`,
+  );
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...(tenantId ? { "X-LLMTrace-Tenant-ID": tenantId } : {}),
+    ...scopeHeaders,
   };
 
   // Local-dev escape hatch only: when explicitly disabled, fall back to the
@@ -293,10 +342,18 @@ export async function getStats(tenantId?: string): Promise<StorageStats> {
   return apiFetch("/api/v1/stats", undefined, tenantId);
 }
 
-/** Get global storage stats across all tenants. */
+/**
+ * Get global storage stats across ALL tenants. This is an admin aggregate
+ * (Overview page) so it always sends `X-LLMTrace-Tenant-Scope: all` rather
+ * than scoping to the current sidebar selection — the proxy returns 400 on
+ * a tenant-scoped read that carries neither a tenant-id nor a scope header.
+ */
 export async function getGlobalStats(): Promise<StorageStats> {
   try {
-    const res = await fetch("/api/v1/stats", { cache: "no-store" });
+    const res = await fetch("/api/v1/stats", {
+      cache: "no-store",
+      headers: { [TENANT_SCOPE_HEADER]: "all" },
+    });
     if (!res.ok) {
       return { total_traces: 0, total_spans: 0, total_cost_usd: 0 };
     }
@@ -324,7 +381,7 @@ export async function getCurrentCosts(
   const url = `/api/v1/costs/current${q}`;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...(tenantId ? { "X-LLMTrace-Tenant-ID": tenantId } : {}),
+    ...tenantScopeHeaders(tenantId),
   };
 
   if (
@@ -384,9 +441,25 @@ export async function resetTenantToken(tenantId: string): Promise<{ api_token: s
   return apiFetch(`/api/v1/tenants/${tenantId}/token/reset`, { method: "POST" });
 }
 
+/**
+ * Per-tenant upstream override fields (CONTRACT 1). Both optional and
+ * write-only on the wire: `upstream_api_key` is sent on create/update but
+ * never returned (the GET response exposes `upstream_api_key_set` instead).
+ * A `null` (or omitted) value clears the override so the tenant inherits
+ * the global default.
+ */
+export interface UpstreamCredsInput {
+  upstream_url?: string | null;
+  upstream_api_key?: string | null;
+}
+
 /** Create a new tenant. */
 export async function createTenant(
-  body: { name: string; plan?: string; config?: Record<string, unknown> },
+  body: {
+    name: string;
+    plan?: string;
+    config?: Record<string, unknown>;
+  } & UpstreamCredsInput,
 ): Promise<Tenant> {
   return apiFetch("/api/v1/tenants", {
     method: "POST",
@@ -397,7 +470,11 @@ export async function createTenant(
 /** Update tenant. */
 export async function updateTenant(
   id: string,
-  body: { name?: string; plan?: string; config?: Partial<TenantConfig> },
+  body: {
+    name?: string;
+    plan?: string;
+    config?: Partial<TenantConfig>;
+  } & UpstreamCredsInput,
 ): Promise<Tenant> {
   return apiFetch(`/api/v1/tenants/${id}`, {
     method: "PUT",
@@ -440,9 +517,16 @@ export async function healthCheck(): Promise<{ status: string }> {
 /** Helper: Find the tenant with the most recent activity. */
 export async function findActiveTenant(): Promise<string | undefined> {
   try {
+    // An explicit "all tenants" selection is authoritative — honour it
+    // before touching the tenant list so read pages can scope=all.
+    if (typeof window !== "undefined" &&
+        localStorage.getItem(STORED_TENANT_KEY) === ALL_TENANTS_SCOPE) {
+      return ALL_TENANTS_SCOPE;
+    }
+
     const tenants = await listTenants();
     console.log(`[API] findActiveTenant: Found ${tenants.length} tenants`);
-    
+
     if (tenants.length === 0) {
       console.warn("[API] No tenants found in the database.");
       setStoredTenant(undefined);
@@ -451,7 +535,7 @@ export async function findActiveTenant(): Promise<string | undefined> {
 
     // Check localStorage first and verify it still exists
     if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("llmtrace_tenant_id");
+      const stored = localStorage.getItem(STORED_TENANT_KEY);
       if (stored && tenants.some(t => t.id === stored)) {
         console.log(`[API] Using stored tenant ID: ${stored}`);
         return stored;
@@ -478,7 +562,7 @@ export async function findActiveTenant(): Promise<string | undefined> {
     console.log(`[API] Identified most active tenant: ${activeId}`);
 
     // Only set stored tenant if none is currently selected
-    if (activeId && typeof window !== "undefined" && !localStorage.getItem("llmtrace_tenant_id")) {
+    if (activeId && typeof window !== "undefined" && !localStorage.getItem(STORED_TENANT_KEY)) {
       setStoredTenant(activeId);
     }
     return activeId;
@@ -488,14 +572,37 @@ export async function findActiveTenant(): Promise<string | undefined> {
   }
 }
 
-/** Helper: Store the selected tenant ID in localStorage. */
+/** Helper: read the stored tenant selection (id or the all-tenants sentinel). */
+export function getStoredTenant(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(STORED_TENANT_KEY);
+}
+
+/**
+ * Helper: Store the selected tenant ID (or the "all tenants" sentinel) in
+ * localStorage. Pass `undefined` to clear the selection.
+ */
 export function setStoredTenant(tenantId: string | undefined): void {
   if (typeof window === "undefined") return;
   if (tenantId) {
-    localStorage.setItem("llmtrace_tenant_id", tenantId);
+    localStorage.setItem(STORED_TENANT_KEY, tenantId);
   } else {
-    localStorage.removeItem("llmtrace_tenant_id");
+    localStorage.removeItem(STORED_TENANT_KEY);
   }
+}
+
+/** Event name dispatched on the window when the tenant registry changes. */
+export const TENANTS_CHANGED_EVENT = "llmtrace:tenants-changed";
+
+/**
+ * Notify listeners (e.g. the sidebar selector) that the tenant registry
+ * changed so they can refresh without a full page reload. No-op on the
+ * server. See issue 7 — the sidebar previously loaded tenants once on
+ * mount and went stale after a create on the /tenants page.
+ */
+export function notifyTenantsChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(TENANTS_CHANGED_EVENT));
 }
 
 // -- Compliance reporting ---------------------------------------------------

--- a/dashboard/src/lib/proxy-helpers.ts
+++ b/dashboard/src/lib/proxy-helpers.ts
@@ -21,17 +21,28 @@ function buildHeaders(
 ): Record<string, string> | NextResponse {
   const headers: Record<string, string> = { ...extra };
 
-  // Tenant header resolution: prefer an explicit incoming header (used by
-  // dashboard pages that drive a tenant picker, e.g. /traces). Fall back to
-  // the deployment-pinned tenant set at provisioning time so that
-  // dashboard-originated traffic (e.g. /playground chat completions) is
-  // attributed to the real provisioned tenant instead of spawning a
-  // throwaway tenant per call on the proxy.
-  const tenantHeader =
-    req.headers.get("x-llmtrace-tenant-id") ??
-    process.env.LLMTRACE_DASHBOARD_TENANT_ID ??
-    null;
-  if (tenantHeader) headers["X-LLMTrace-Tenant-ID"] = tenantHeader;
+  // Tenant scoping. The browser is authoritative: the dashboard attaches the
+  // operator's sidebar selection to every user-driven call as either
+  //   - X-LLMTrace-Tenant-ID: <uuid>      (a specific tenant), or
+  //   - X-LLMTrace-Tenant-Scope: all      (admin "all tenants" reads).
+  // We forward whichever the browser sent, UNCHANGED, and never let the two
+  // coexist (CONTRACT 2: scope=all must omit the tenant-id header).
+  //
+  // The provisioned-tenant env fallback (LLMTRACE_DASHBOARD_TENANT_ID) is a
+  // last resort for genuinely tenant-agnostic system calls that arrive with
+  // NEITHER header. It must NOT override a header the browser sent — doing
+  // so silently mis-attributed user traffic (notably /playground chat
+  // completions that generate traces) to the single provisioned tenant,
+  // ignoring the sidebar selection (PR #291 regression).
+  const incomingScope = req.headers.get("x-llmtrace-tenant-scope");
+  const incomingTenant = req.headers.get("x-llmtrace-tenant-id");
+  if (incomingScope) {
+    headers["X-LLMTrace-Tenant-Scope"] = incomingScope;
+  } else if (incomingTenant) {
+    headers["X-LLMTrace-Tenant-ID"] = incomingTenant;
+  } else if (process.env.LLMTRACE_DASHBOARD_TENANT_ID) {
+    headers["X-LLMTrace-Tenant-ID"] = process.env.LLMTRACE_DASHBOARD_TENANT_ID;
+  }
 
   const authHeader = req.headers.get("authorization");
   if (authHeader) {


### PR DESCRIPTION
Fixes the P0 cross-tenant contamination / trace-loss-on-switch (issues 5+6), the sidebar not refreshing after tenant create (7), and adds the dashboard side of admin all-tenants view + per-tenant upstream creds (issue 8). Pairs with the proxy tenant-subsystem PR which enforces the contracts server-side.

## Root cause (P0)
PR #291's pin in `proxy-helpers.ts` substituted `LLMTRACE_DASHBOARD_TENANT_ID` for any dashboard call lacking a tenant header. Playground chat completions (raw `fetch`, no header) therefore generated traces under the provisioned tenant regardless of the sidebar selection -> selecting tenant A showed nothing (loss); the shared bucket looked like contamination.

## Changes
- **proxy-helpers.ts**: forward the browser's `X-LLMTrace-Tenant-ID` / `X-LLMTrace-Tenant-Scope` UNCHANGED; the env fallback is now last-resort (only when neither header is present) and never overrides a browser header.
- **api.ts**: centralized `tenantScopeHeaders()` reads the operator's stored sidebar selection and attaches it to every user-scoped call via `apiFetch`; `ALL_TENANTS_SCOPE="__all__"` sentinel; `getGlobalStats` always sends scope=all; per-tenant creds types (CONTRACT 1).
- **playground/_client.tsx**: the raw chat-completions `fetch` now carries the selected tenant; reads carry the scope; **sending is blocked + the composer disabled with an inline hint when 'All tenants' is selected** (you cannot write to all tenants).
- **sidebar.tsx**: 'All tenants' option; **auto-refresh** via a `llmtrace:tenants-changed` CustomEvent so a newly created tenant appears without a page reload (issue 7).
- **tenants/_client.tsx**: per-tenant Upstream URL + Upstream API key fields on create/edit (write-only key; GET exposes `upstream_url` + `upstream_api_key_set` only); dispatches the refresh event; modal backdrop moved to a token scrim.
- **e2e/dashboard.spec.ts**: updated + added assertions for tenant-scoped selection and the all-tenants scope (not weakened).

## Contracts (must match the proxy PR)
- CONTRACT 1 (per-tenant creds): create/update accept `upstream_url: string|null`, `upstream_api_key: string|null` (write-only); get/list return `upstream_url` + `upstream_api_key_set: boolean`; null => inherit global.
- CONTRACT 2 (scope): `X-LLMTrace-Tenant-ID` single; `X-LLMTrace-Tenant-Scope: all` admin reads only; non-admin+all => 403; admin+neither on a scoped read => 400.

## Verification
- `npm run lint` exit 0, `npm run build` exit 0, `npx tsc --noEmit` exit 0.
- e2e require the live stack -> run in CI.