### PR TITLE
feat(proxy): per-tenant upstream routing (encrypted), admin tenant scoping, phantom-tenant guard, idempotent bootstrap, datamarking/zone env overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +641,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cityhash-rs"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,7 +975,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1738,6 +1793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,11 +2439,13 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 name = "llmtrace"
 version = "0.2.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "arc-swap",
  "async-stream",
  "async-trait",
  "axum 0.7.9",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "clap",
@@ -2969,6 +3045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3258,18 @@ checksum = "ec242d7eccbb2fd8b3b5b6e3cf89f94a91a800f469005b44d154359609f8af72"
 dependencies = [
  "higher-kinded-types",
  "never-say-never",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5039,6 +5133,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -132,6 +132,37 @@ pub struct AuthContext {
     pub key_id: Option<Uuid>,
 }
 
+/// Tenant scope for an authenticated request, derived from headers.
+///
+/// Inserted into request extensions alongside [`AuthContext`] by the auth
+/// middleware. Read-only cross-tenant access is represented by [`TenantScope::All`]
+/// and is only ever granted to admin callers. Most requests resolve to
+/// [`TenantScope::Single`] which restricts reads to a single tenant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TenantScope {
+    /// Restrict the request to a single tenant.
+    Single(TenantId),
+    /// Cross-tenant (all-tenants) scope — admin reads only.
+    All,
+}
+
+impl TenantScope {
+    /// Returns the single tenant id when scoped to one tenant, else `None`.
+    #[must_use]
+    pub fn single(self) -> Option<TenantId> {
+        match self {
+            Self::Single(id) => Some(id),
+            Self::All => None,
+        }
+    }
+
+    /// Returns `true` when this scope spans all tenants.
+    #[must_use]
+    pub fn is_all(self) -> bool {
+        matches!(self, Self::All)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Security types
 // ---------------------------------------------------------------------------
@@ -934,6 +965,16 @@ pub struct Tenant {
     /// Arbitrary tenant-level configuration.
     #[schema(value_type = Object)]
     pub config: serde_json::Value,
+    /// Per-tenant upstream base URL override. When `None`, the proxy falls
+    /// back to the global `upstream_url`.
+    #[serde(default)]
+    pub upstream_url: Option<String>,
+    /// Encrypted (AEAD) per-tenant upstream provider API key, base64-encoded
+    /// `nonce || ciphertext`. NEVER serialized to API clients (write-only at
+    /// rest). When `None`, the proxy falls back to the global env-based key.
+    #[serde(default, skip_serializing)]
+    #[schema(value_type = Option<String>)]
+    pub upstream_api_key_ciphertext: Option<String>,
 }
 
 /// Per-tenant configuration for security thresholds and feature flags.
@@ -1256,6 +1297,13 @@ pub struct ProxyConfig {
     /// left bytes-exact.
     #[serde(default = "default_true")]
     pub llm_advisory_injection_enabled: bool,
+    /// Explicit tenant id stamped on header-less traffic. When set, requests
+    /// that cannot resolve a tenant from a header or derivable key are
+    /// attributed to this tenant instead of inventing a phantom one. When
+    /// `None` and auth is enabled, header-less traffic is rejected (401).
+    /// Tunable via `LLMTRACE_DEFAULT_TENANT_ID`.
+    #[serde(default)]
+    pub default_tenant_id: Option<TenantId>,
 }
 
 impl Default for ProxyConfig {
@@ -1300,6 +1348,7 @@ impl Default for ProxyConfig {
             server: ServerConfig::default(),
             ml_pipeline: MlPipelineConfig::default(),
             llm_advisory_injection_enabled: true,
+            default_tenant_id: None,
         }
     }
 }
@@ -3351,6 +3400,28 @@ pub trait TraceRepository: Send + Sync {
     /// Query spans with filters.
     async fn query_spans(&self, query: &TraceQuery) -> Result<Vec<TraceSpan>>;
 
+    /// Query traces across ALL tenants (admin cross-tenant scope, reads only).
+    ///
+    /// The `tenant_id` on the supplied [`TraceQuery`] is ignored; every other
+    /// filter still applies. Backends that do not implement cross-tenant
+    /// queries return an unsupported error so callers fail closed rather than
+    /// silently leaking or losing data.
+    async fn query_traces_all_tenants(&self, _query: &TraceQuery) -> Result<Vec<TraceEvent>> {
+        Err(crate::LLMTraceError::Storage(
+            "cross-tenant trace query is not supported by this storage backend".to_string(),
+        ))
+    }
+
+    /// Get a specific trace by ID without a tenant filter (admin cross-tenant).
+    ///
+    /// Returns the trace regardless of which tenant owns it. Backends that do
+    /// not implement cross-tenant lookups return an unsupported error.
+    async fn get_trace_any_tenant(&self, _trace_id: Uuid) -> Result<Option<TraceEvent>> {
+        Err(crate::LLMTraceError::Storage(
+            "cross-tenant trace lookup is not supported by this storage backend".to_string(),
+        ))
+    }
+
     /// Get a specific trace by ID.
     async fn get_trace(&self, tenant_id: TenantId, trace_id: Uuid) -> Result<Option<TraceEvent>>;
 
@@ -4216,6 +4287,7 @@ mod tests {
             server: ServerConfig::default(),
             ml_pipeline: MlPipelineConfig::default(),
             llm_advisory_injection_enabled: true,
+            default_tenant_id: None,
         };
 
         let serialized = serde_json::to_string(&config).unwrap();
@@ -4289,6 +4361,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({"max_traces_per_day": 10000}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
 
         let serialized = serde_json::to_string(&tenant).unwrap();
@@ -5111,7 +5185,7 @@ mod tests {
     #[test]
     fn test_truncate_2byte_utf8_at_boundary() {
         let s = "h\u{00E9}llo"; // h(1) + e-acute(2) + l(1) + l(1) + o(1) = 6 bytes
-        assert_eq!(s.as_bytes().len(), 6);
+        assert_eq!(s.len(), 6);
         // Truncating at 2 would split the e-acute - backs up to 1
         assert_eq!(truncate_to_byte_limit(s, 2), "h");
         // Truncating at 3 includes "h" + e-acute exactly
@@ -5122,8 +5196,8 @@ mod tests {
     fn test_truncate_4byte_utf8_at_boundary() {
         // U+1F600 (grinning face) is 4 bytes: F0 9F 98 80
         let s = "a\u{1F600}b";
-        assert_eq!(s.as_bytes().len(), 6); // a=1, emoji=4, b=1
-                                           // Truncating at 2, 3, or 4 should all back up to byte 1 ("a")
+        assert_eq!(s.len(), 6); // a=1, emoji=4, b=1
+                                // Truncating at 2, 3, or 4 should all back up to byte 1 ("a")
         assert_eq!(truncate_to_byte_limit(s, 2), "a");
         assert_eq!(truncate_to_byte_limit(s, 3), "a");
         assert_eq!(truncate_to_byte_limit(s, 4), "a");

--- a/crates/llmtrace-proxy/Cargo.toml
+++ b/crates/llmtrace-proxy/Cargo.toml
@@ -41,6 +41,8 @@ prost = "0.14"
 hex = "0.4"
 sha2 = "0.10"
 rand = "0.8"
+aes-gcm = "0.10"
+base64 = "0.22"
 axum = "0.7"
 tower-http = { version = "0.6", features = ["cors", "limit"] }
 hyper = { version = "1", features = ["full"] }

--- a/crates/llmtrace-proxy/src/api.rs
+++ b/crates/llmtrace-proxy/src/api.rs
@@ -12,7 +12,8 @@ use axum::Extension;
 use axum::Json;
 use chrono::{DateTime, Utc};
 use llmtrace_core::{
-    AgentAction, AgentActionType, ApiKeyRole, AuthContext, LLMProvider, MonitoringScope, TraceQuery,
+    AgentAction, AgentActionType, ApiKeyRole, AuthContext, LLMProvider, MonitoringScope,
+    TenantScope, TraceQuery,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -202,6 +203,15 @@ fn require_role_operator(auth: &AuthContext) -> Option<Response> {
     }
 }
 
+/// The `400` response for a tenant-scoped read when an admin supplied neither a
+/// tenant id nor `scope=all` (CONTRACT 2).
+fn scope_required_error() -> Response {
+    api_error(
+        StatusCode::BAD_REQUEST,
+        "Missing tenant scope: provide X-LLMTrace-Tenant-ID or X-LLMTrace-Tenant-Scope: all",
+    )
+}
+
 /// Build a JSON error response.
 fn api_error(status: StatusCode, message: &str) -> Response {
     let body = ApiError {
@@ -287,16 +297,22 @@ fn is_sensitive_config_key(key: &str) -> bool {
 pub async fn list_traces(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthContext>,
+    extensions: axum::http::Extensions,
     Query(params): Query<ListTracesParams>,
 ) -> Response {
     if let Some(err) = require_role_viewer(&auth) {
         return err;
     }
-    let tenant_id = auth.tenant_id;
+    let scope = match crate::auth::resolve_request_scope(&extensions) {
+        Some(s) => s,
+        None => return scope_required_error(),
+    };
     let limit = clamp_limit(params.limit);
     let offset = params.offset.unwrap_or(0);
 
-    let mut query = TraceQuery::new(tenant_id);
+    // Tenant id only matters for single-tenant scope; the all-tenants path
+    // ignores it but `TraceQuery` still requires a value.
+    let mut query = TraceQuery::new(scope.single().unwrap_or(auth.tenant_id));
     query.start_time = params.start_time;
     query.end_time = params.end_time;
     if let Some(ref provider_str) = params.provider {
@@ -304,8 +320,13 @@ pub async fn list_traces(
     }
     query.model_name = params.model;
 
+    let traces_result = match scope {
+        TenantScope::All => state.storage.traces.query_traces_all_tenants(&query).await,
+        TenantScope::Single(_) => state.storage.traces.query_traces(&query).await,
+    };
+
     // Query without pagination to get total count, then paginate here.
-    match state.storage.traces.query_traces(&query).await {
+    match traces_result {
         Ok(all) => {
             let total = all.len() as u64;
             let data: Vec<_> = all
@@ -345,14 +366,23 @@ pub async fn list_traces(
 pub async fn get_trace(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthContext>,
+    extensions: axum::http::Extensions,
     Path(trace_id): Path<Uuid>,
 ) -> Response {
     if let Some(err) = require_role_viewer(&auth) {
         return err;
     }
-    let tenant_id = auth.tenant_id;
+    let scope = match crate::auth::resolve_request_scope(&extensions) {
+        Some(s) => s,
+        None => return scope_required_error(),
+    };
 
-    match state.storage.traces.get_trace(tenant_id, trace_id).await {
+    let trace_result = match scope {
+        TenantScope::All => state.storage.traces.get_trace_any_tenant(trace_id).await,
+        TenantScope::Single(id) => state.storage.traces.get_trace(id, trace_id).await,
+    };
+
+    match trace_result {
         Ok(Some(trace)) => Json(trace).into_response(),
         Ok(None) => api_error(StatusCode::NOT_FOUND, "Trace not found"),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
@@ -499,13 +529,22 @@ pub async fn get_span(
 pub async fn get_stats(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthContext>,
+    extensions: axum::http::Extensions,
 ) -> Response {
     if let Some(err) = require_role_viewer(&auth) {
         return err;
     }
-    let tenant_id = auth.tenant_id;
+    let scope = match crate::auth::resolve_request_scope(&extensions) {
+        Some(s) => s,
+        None => return scope_required_error(),
+    };
 
-    match state.storage.traces.get_stats(tenant_id).await {
+    let stats_result = match scope {
+        TenantScope::All => state.storage.traces.get_global_stats().await,
+        TenantScope::Single(id) => state.storage.traces.get_stats(id).await,
+    };
+
+    match stats_result {
         Ok(stats) => Json(stats).into_response(),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     }

--- a/crates/llmtrace-proxy/src/audit_api.rs
+++ b/crates/llmtrace-proxy/src/audit_api.rs
@@ -266,6 +266,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 

--- a/crates/llmtrace-proxy/src/auth.rs
+++ b/crates/llmtrace-proxy/src/auth.rs
@@ -12,7 +12,7 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use chrono::Utc;
-use llmtrace_core::{ApiKeyRecord, ApiKeyRole, AuthContext, TenantId};
+use llmtrace_core::{ApiKeyRecord, ApiKeyRole, AuthContext, TenantId, TenantScope};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -97,13 +97,22 @@ pub async fn auth_middleware(
     // When auth is disabled, inject a permissive AuthContext using the legacy
     // tenant resolution so downstream handlers can always rely on extensions.
     if !cfg.auth.enabled {
+        // Auth disabled grants a permissive Admin context. Honour an explicit
+        // `X-LLMTrace-Tenant-Scope: all` for cross-tenant reads; otherwise scope
+        // to the resolved single tenant.
         let tenant_id = crate::proxy::resolve_tenant(req.headers()).unwrap_or_default();
+        let scope = if wants_all_tenants(req.headers()) {
+            TenantScope::All
+        } else {
+            TenantScope::Single(tenant_id)
+        };
         let ctx = AuthContext {
             tenant_id,
             role: ApiKeyRole::Admin,
             key_id: None,
         };
         req.extensions_mut().insert(ctx);
+        req.extensions_mut().insert(scope);
         return next.run(req).await;
     }
 
@@ -125,12 +134,21 @@ pub async fn auth_middleware(
     {
         match state.metadata().get_tenant_by_token(token).await {
             Ok(Some(tenant)) => {
+                // Operator tokens are single-tenant only; an explicit
+                // cross-tenant scope request is forbidden for non-admins.
+                if wants_all_tenants(req.headers()) {
+                    return auth_error(
+                        StatusCode::FORBIDDEN,
+                        "Cross-tenant scope (X-LLMTrace-Tenant-Scope: all) requires admin role",
+                    );
+                }
                 let ctx = AuthContext {
                     tenant_id: tenant.id,
                     role: ApiKeyRole::Operator, // Token grants operator access for traffic
                     key_id: None,
                 };
                 req.extensions_mut().insert(ctx);
+                req.extensions_mut().insert(TenantScope::Single(tenant.id));
                 return next.run(req).await;
             }
             Ok(None) => {
@@ -154,14 +172,31 @@ pub async fn auth_middleware(
         // Check bootstrap admin key first
         if let Some(ref admin_key) = cfg.auth.admin_key {
             if token == admin_key.as_str() {
-                // Admin key uses tenant from X-LLMTrace-Tenant-ID header, or a default
-                let tenant_id = resolve_tenant_from_header(headers).unwrap_or_default();
+                // CONTRACT 2 scope resolution for the bootstrap admin key:
+                //   * X-LLMTrace-Tenant-ID present       => Single(that id)
+                //   * X-LLMTrace-Tenant-Scope: all       => All (cross-tenant)
+                //   * neither                            => no scope inserted;
+                //     tenant_id stays nil and tenant-scoped reads reject 400.
+                let header_tenant = resolve_tenant_from_header(headers);
+                // No header => explicit NIL tenant (NOT a random default) so
+                // tenant-scoped reads detect the "admin, no scope" case and
+                // reject 400 rather than silently using a phantom tenant.
+                let tenant_id = header_tenant.unwrap_or(TenantId(Uuid::nil()));
+                // Compute the scope (owned) BEFORE taking a mutable borrow of req.
+                let scope = match header_tenant {
+                    Some(id) => Some(TenantScope::Single(id)),
+                    None if wants_all_tenants(headers) => Some(TenantScope::All),
+                    None => None,
+                };
                 let ctx = AuthContext {
                     tenant_id,
                     role: ApiKeyRole::Admin,
                     key_id: None,
                 };
                 req.extensions_mut().insert(ctx);
+                if let Some(scope) = scope {
+                    req.extensions_mut().insert(scope);
+                }
                 return next.run(req).await;
             }
         }
@@ -170,12 +205,26 @@ pub async fn auth_middleware(
         let key_hash = hash_api_key(token);
         match state.metadata().get_api_key_by_hash(&key_hash).await {
             Ok(Some(record)) => {
+                let asked_all = wants_all_tenants(req.headers());
+                let is_admin = record.role.has_permission(ApiKeyRole::Admin);
+                if asked_all && !is_admin {
+                    return auth_error(
+                        StatusCode::FORBIDDEN,
+                        "Cross-tenant scope (X-LLMTrace-Tenant-Scope: all) requires admin role",
+                    );
+                }
+                let scope = if asked_all && is_admin {
+                    TenantScope::All
+                } else {
+                    TenantScope::Single(record.tenant_id)
+                };
                 let ctx = AuthContext {
                     tenant_id: record.tenant_id,
                     role: record.role,
                     key_id: Some(record.id),
                 };
                 req.extensions_mut().insert(ctx);
+                req.extensions_mut().insert(scope);
                 return next.run(req).await;
             }
             Ok(None) => return auth_error(StatusCode::UNAUTHORIZED, "Invalid API key"),
@@ -494,6 +543,38 @@ fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {
         .and_then(|v| v.strip_prefix("Bearer "))
 }
 
+/// True when the caller requested cross-tenant scope via
+/// `X-LLMTrace-Tenant-Scope: all` (case-insensitive).
+fn wants_all_tenants(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-llmtrace-tenant-scope")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().eq_ignore_ascii_case("all"))
+        .unwrap_or(false)
+}
+
+/// Resolve the effective [`TenantScope`] for a request from its extensions.
+///
+/// Returns:
+///   * `Some(scope)` when the auth middleware established a concrete scope.
+///   * `None` when an admin presented neither `X-LLMTrace-Tenant-ID` nor
+///     `X-LLMTrace-Tenant-Scope: all` — tenant-scoped read handlers MUST treat
+///     this as a `400 Bad Request` (per CONTRACT 2) rather than defaulting to a
+///     nil tenant.
+#[must_use]
+pub fn resolve_request_scope(extensions: &axum::http::Extensions) -> Option<TenantScope> {
+    if let Some(scope) = extensions.get::<TenantScope>() {
+        return Some(*scope);
+    }
+    // No explicit scope was inserted. Fall back to the AuthContext tenant when
+    // it is a concrete (non-nil) tenant so non-admin flows keep working even if
+    // a future caller forgets to insert a scope; a nil admin tenant yields None.
+    extensions
+        .get::<AuthContext>()
+        .filter(|ctx| !ctx.tenant_id.0.is_nil())
+        .map(|ctx| TenantScope::Single(ctx.tenant_id))
+}
+
 /// Extract tenant ID from the `X-LLMTrace-Tenant-ID` header.
 fn resolve_tenant_from_header(headers: &HeaderMap) -> Option<TenantId> {
     if let Some(raw) = headers.get("x-llmtrace-tenant-id") {
@@ -796,8 +877,12 @@ mod tests {
         let state = auth_state("admin-secret").await;
         let app = auth_router(state);
 
+        // The admin bootstrap key is accepted. Under CONTRACT 2 a tenant-scoped
+        // read also needs an explicit tenant id (or scope=all); we supply a
+        // single-tenant id here to prove the admin key grants access.
         let req = Request::get("/api/v1/traces")
             .header("authorization", "Bearer admin-secret")
+            .header("x-llmtrace-tenant-id", TenantId::new().0.to_string())
             .body(Body::empty())
             .unwrap();
 
@@ -817,6 +902,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -864,6 +951,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -904,6 +993,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -960,6 +1051,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         let t2 = Tenant {
             id: TenantId::new(),
@@ -968,6 +1061,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&t1).await.unwrap();
         state.metadata().create_tenant(&t2).await.unwrap();
@@ -1046,6 +1141,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -1082,5 +1179,132 @@ mod tests {
         for key_json in keys {
             assert!(key_json.get("key_hash").is_none());
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin tenant scoping (CONTRACT 2 / P0 isolation)
+    // -----------------------------------------------------------------------
+
+    /// Seed one trace for each of two tenants and return their ids.
+    async fn seed_two_tenants(state: &Arc<AppState>) -> (TenantId, TenantId) {
+        let t1 = TenantId::new();
+        let t2 = TenantId::new();
+        for tid in [t1, t2] {
+            let trace_id = Uuid::new_v4();
+            let trace = llmtrace_core::TraceEvent {
+                trace_id,
+                tenant_id: tid,
+                spans: vec![llmtrace_core::TraceSpan::new(
+                    trace_id,
+                    tid,
+                    "chat_completion".to_string(),
+                    llmtrace_core::LLMProvider::OpenAI,
+                    "gpt-4".to_string(),
+                    "hello".to_string(),
+                )],
+                created_at: Utc::now(),
+            };
+            state.storage.traces.store_trace(&trace).await.unwrap();
+        }
+        (t1, t2)
+    }
+
+    #[tokio::test]
+    async fn test_admin_scope_all_aggregates_across_tenants() {
+        let state = auth_state("admin-secret").await;
+        seed_two_tenants(&state).await;
+
+        let app = auth_router(state);
+        let req = Request::get("/api/v1/traces")
+            .header("authorization", "Bearer admin-secret")
+            .header("x-llmtrace-tenant-scope", "all")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(
+            body["total"], 2,
+            "all-tenants scope must aggregate both tenants"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_admin_single_tenant_filters() {
+        let state = auth_state("admin-secret").await;
+        let (t1, _t2) = seed_two_tenants(&state).await;
+
+        let app = auth_router(state);
+        let req = Request::get("/api/v1/traces")
+            .header("authorization", "Bearer admin-secret")
+            .header("x-llmtrace-tenant-id", t1.0.to_string())
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(
+            body["total"], 1,
+            "single-tenant scope must filter to one tenant"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_admin_no_tenant_no_scope_is_bad_request() {
+        let state = auth_state("admin-secret").await;
+        seed_two_tenants(&state).await;
+
+        let app = auth_router(state);
+        let req = Request::get("/api/v1/traces")
+            .header("authorization", "Bearer admin-secret")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "admin with neither tenant id nor scope=all must be rejected 400"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_admin_scope_all_is_forbidden() {
+        let state = auth_state("admin-secret").await;
+        let tenant = Tenant {
+            id: TenantId::new(),
+            name: "Viewer Org".to_string(),
+            api_token: "token-scope".to_string(),
+            plan: "free".to_string(),
+            created_at: Utc::now(),
+            config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
+        };
+        state.metadata().create_tenant(&tenant).await.unwrap();
+        let (plaintext, hash) = generate_api_key();
+        let rec = ApiKeyRecord {
+            id: Uuid::new_v4(),
+            tenant_id: tenant.id,
+            name: "viewer".to_string(),
+            key_hash: hash,
+            key_prefix: key_prefix(&plaintext),
+            role: ApiKeyRole::Viewer,
+            created_at: Utc::now(),
+            revoked_at: None,
+        };
+        state.metadata().create_api_key(&rec).await.unwrap();
+
+        let app = auth_router(state);
+        let req = Request::get("/api/v1/traces")
+            .header("authorization", format!("Bearer {plaintext}"))
+            .header("x-llmtrace-tenant-scope", "all")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "non-admin requesting scope=all must be 403"
+        );
     }
 }

--- a/crates/llmtrace-proxy/src/config.rs
+++ b/crates/llmtrace-proxy/src/config.rs
@@ -35,6 +35,10 @@ pub fn load_config(path: &Path) -> anyhow::Result<ProxyConfig> {
 /// - `LLMTRACE_RATE_LIMIT_RPS` → `rate_limiting.requests_per_second`
 /// - `LLMTRACE_RATE_LIMIT_BURST` → `rate_limiting.burst_size`
 /// - `LLMTRACE_ML_MAX_CONCURRENT` → `ml_pipeline.max_concurrent_requests`
+/// - `LLMTRACE_DATAMARKING_ENABLED` → `boundary_defense.datamarking.enabled`
+/// - `LLMTRACE_DATAMARKING_SHADOW_MODE` → `boundary_defense.datamarking.shadow_mode`
+/// - `LLMTRACE_ZONE_DETECTION_ENABLED` → `security_analysis.zone_detection.enabled`
+/// - `LLMTRACE_DEFAULT_TENANT_ID` → `default_tenant_id`
 ///
 /// Rate-limit overrides only take effect when the parsed value is `> 0`
 /// (a `u32`). Invalid or non-positive values are ignored, leaving the
@@ -76,6 +80,29 @@ pub fn apply_env_overrides(config: &mut ProxyConfig) {
     }
     if let Some(burst) = parse_positive_u32("LLMTRACE_RATE_LIMIT_BURST") {
         config.rate_limiting.burst_size = burst;
+    }
+    if let Ok(val) = std::env::var("LLMTRACE_DATAMARKING_ENABLED") {
+        let val = val.to_lowercase();
+        config.boundary_defense.datamarking.enabled = val == "1" || val == "true" || val == "yes";
+    }
+    if let Ok(val) = std::env::var("LLMTRACE_DATAMARKING_SHADOW_MODE") {
+        let val = val.to_lowercase();
+        config.boundary_defense.datamarking.shadow_mode =
+            val == "1" || val == "true" || val == "yes";
+    }
+    if let Ok(val) = std::env::var("LLMTRACE_ZONE_DETECTION_ENABLED") {
+        let val = val.to_lowercase();
+        config.security_analysis.zone_detection.enabled =
+            val == "1" || val == "true" || val == "yes";
+    }
+    if let Ok(val) = std::env::var("LLMTRACE_DEFAULT_TENANT_ID") {
+        match uuid::Uuid::parse_str(val.trim()) {
+            Ok(uuid) => config.default_tenant_id = Some(llmtrace_core::TenantId(uuid)),
+            Err(_) => tracing::warn!(
+                value = %val,
+                "LLMTRACE_DEFAULT_TENANT_ID must be a valid UUID; ignoring"
+            ),
+        }
     }
     if let Ok(val) = std::env::var("LLMTRACE_ML_MAX_CONCURRENT") {
         match val.parse::<usize>() {
@@ -407,6 +434,47 @@ health_check:
             config.rate_limiting.burst_size,
             baseline.rate_limiting.burst_size
         );
+    }
+
+    #[test]
+    fn test_apply_env_overrides_datamarking_and_zone() {
+        let mut config = ProxyConfig::default();
+        // Defaults: datamarking disabled, shadow_mode true, zone detection off.
+        assert!(!config.boundary_defense.datamarking.enabled);
+        assert!(config.boundary_defense.datamarking.shadow_mode);
+        assert!(!config.security_analysis.zone_detection.enabled);
+
+        std::env::set_var("LLMTRACE_DATAMARKING_ENABLED", "true");
+        std::env::set_var("LLMTRACE_DATAMARKING_SHADOW_MODE", "false");
+        std::env::set_var("LLMTRACE_ZONE_DETECTION_ENABLED", "1");
+        apply_env_overrides(&mut config);
+        std::env::remove_var("LLMTRACE_DATAMARKING_ENABLED");
+        std::env::remove_var("LLMTRACE_DATAMARKING_SHADOW_MODE");
+        std::env::remove_var("LLMTRACE_ZONE_DETECTION_ENABLED");
+
+        assert!(config.boundary_defense.datamarking.enabled);
+        assert!(!config.boundary_defense.datamarking.shadow_mode);
+        assert!(config.security_analysis.zone_detection.enabled);
+    }
+
+    #[test]
+    fn test_apply_env_overrides_default_tenant_id() {
+        let mut config = ProxyConfig::default();
+        assert!(config.default_tenant_id.is_none());
+        let id = uuid::Uuid::new_v4();
+        std::env::set_var("LLMTRACE_DEFAULT_TENANT_ID", id.to_string());
+        apply_env_overrides(&mut config);
+        std::env::remove_var("LLMTRACE_DEFAULT_TENANT_ID");
+        assert_eq!(config.default_tenant_id.map(|t| t.0), Some(id));
+    }
+
+    #[test]
+    fn test_apply_env_overrides_default_tenant_id_invalid_ignored() {
+        let mut config = ProxyConfig::default();
+        std::env::set_var("LLMTRACE_DEFAULT_TENANT_ID", "not-a-uuid");
+        apply_env_overrides(&mut config);
+        std::env::remove_var("LLMTRACE_DEFAULT_TENANT_ID");
+        assert!(config.default_tenant_id.is_none());
     }
 
     #[test]

--- a/crates/llmtrace-proxy/src/lib.rs
+++ b/crates/llmtrace-proxy/src/lib.rs
@@ -30,6 +30,7 @@ pub mod otel;
 pub mod provider;
 pub mod proxy;
 pub mod rate_limit;
+pub mod secretbox;
 pub mod shutdown;
 pub mod streaming;
 pub mod tenant_api;

--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -588,11 +588,48 @@ fn render_zone_ranges(per_message: &[Vec<std::ops::Range<usize>>]) -> String {
 }
 
 /// Build the upstream URL for a given request path.
-fn build_upstream_url(config: &ProxyConfig, path: &str, query: Option<&str>) -> String {
-    let base = config.upstream_url.trim_end_matches('/');
+///
+/// `base_url` is the resolved upstream base — a per-tenant override when set,
+/// otherwise the global `config.upstream_url`.
+fn build_upstream_url(base_url: &str, path: &str, query: Option<&str>) -> String {
+    let base = base_url.trim_end_matches('/');
     match query {
         Some(q) => format!("{base}{path}?{q}"),
         None => format!("{base}{path}"),
+    }
+}
+
+/// Resolve the upstream base URL for a request: the tenant override when
+/// present and non-empty, otherwise the global configured `upstream_url`.
+fn resolve_upstream_base<'a>(config: &'a ProxyConfig, tenant_upstream: Option<&'a str>) -> &'a str {
+    match tenant_upstream {
+        Some(url) if !url.trim().is_empty() => url,
+        _ => &config.upstream_url,
+    }
+}
+
+/// Decrypt a tenant's stored upstream provider key, if present.
+///
+/// Returns `None` when the tenant has no stored ciphertext, when the master
+/// key (`LLMTRACE_SECRET_ENCRYPTION_KEY`) is unset/invalid, or when decryption
+/// fails — in every such case the caller falls back to the global env-based
+/// credential. A decryption failure is logged because it usually signals a
+/// rotated/incorrect master key.
+fn decrypt_tenant_upstream_key(tenant: Option<&llmtrace_core::Tenant>) -> Option<String> {
+    let ciphertext = tenant?.upstream_api_key_ciphertext.as_deref()?;
+    let secret_box = match crate::secretbox::SecretBox::from_env() {
+        Ok(sb) => sb,
+        Err(e) => {
+            warn!(error = %e, "tenant has an encrypted upstream key but the master key is unavailable; falling back to global credential");
+            return None;
+        }
+    };
+    match secret_box.decrypt(ciphertext) {
+        Ok(bytes) => String::from_utf8(bytes).ok(),
+        Err(e) => {
+            warn!(error = %e, "failed to decrypt per-tenant upstream key; falling back to global credential");
+            None
+        }
     }
 }
 
@@ -618,15 +655,19 @@ pub(crate) fn upstream_extra_headers(
     }
 }
 
-/// Resolve the upstream credential header for the detected provider.
+/// Resolve the upstream credential header for the detected provider, preferring
+/// an explicit per-tenant key when supplied.
 ///
-/// Returns `Some((header_name, header_value))` when the matching env var is
-/// set; returns `None` (with a `tracing::warn!`) when the var is missing/empty
+/// When `tenant_key` is `Some(non-empty)`, it is used as the credential for the
+/// provider's auth scheme. Otherwise this falls back to the global env-var
+/// convention: returns `Some((header_name, header_value))` when the matching env
+/// var is set; returns `None` (with a `tracing::warn!`) when it is missing/empty
 /// or when the provider has no known credential convention. The caller is
 /// expected to skip inserting any `Authorization` header in the `None` case so
 /// the upstream surfaces its own 401.
-pub(crate) fn upstream_auth_for(
+pub(crate) fn upstream_auth_for_with_key(
     provider: &LLMProvider,
+    tenant_key: Option<&str>,
 ) -> Option<(reqwest::header::HeaderName, reqwest::header::HeaderValue)> {
     let (env_var, header_name, value_fmt): (&str, reqwest::header::HeaderName, fn(&str) -> String) =
         match provider {
@@ -665,6 +706,19 @@ pub(crate) fn upstream_auth_for(
                 return None;
             }
         };
+
+    // Prefer the explicit per-tenant key when provided and non-empty.
+    if let Some(key) = tenant_key {
+        if !key.is_empty() {
+            return match reqwest::header::HeaderValue::from_str(&value_fmt(key)) {
+                Ok(hv) => Some((header_name, hv)),
+                Err(e) => {
+                    warn!(error = %e, "per-tenant upstream credential is not a valid HTTP header value; forwarding without Authorization");
+                    None
+                }
+            };
+        }
+    }
 
     match std::env::var(env_var) {
         Ok(raw) if !raw.is_empty() => {
@@ -1117,25 +1171,34 @@ pub async fn proxy_handler(
     let query = uri.query().map(|q| q.to_string());
     let headers = req.headers().clone();
 
-    // Use authenticated tenant if available, otherwise fall back to header resolution
+    // Use authenticated tenant if available, otherwise fall back to header resolution.
     let (tenant_id_opt, _) = crate::auth::resolve_authenticated_tenant(&headers, req.extensions());
 
-    // Resolve tenant ID. If auth is enabled, we MUST have a tenant ID from resolve_authenticated_tenant.
-    let tenant_id = match tenant_id_opt {
-        Some(id) if !id.0.is_nil() => id,
-        _ => {
-            if cfg.auth.enabled {
-                // This shouldn't be reached if auth_middleware is working correctly
-                warn!(%trace_id, "Missing authenticated tenant when auth is enabled");
-                return error_response(
-                    StatusCode::UNAUTHORIZED,
-                    "Authentication required",
-                    trace_id,
-                );
-            }
-            // Fallback for when auth is disabled: use deterministic "Unknown" tenant
-            TenantId(Uuid::new_v5(&Uuid::NAMESPACE_OID, b"Unknown"))
-        }
+    // Resolve the tenant for this request. Phantom-tenant guard (issue #292):
+    // we NEVER auto-create a tenant per call. Resolution order:
+    //   1. A concrete (non-nil) tenant resolved from auth / header / key.
+    //   2. The explicit `default_tenant_id` for header-less traffic.
+    //   3. Auth ENABLED with neither => reject 401 (do not invent a tenant).
+    //   4. Auth DISABLED with neither => stamp a deterministic, stable
+    //      "anonymous" tenant id so dev/test traffic still has a home, WITHOUT
+    //      provisioning a DB row (no phantom creation).
+    let tenant_explicitly_identified = matches!(tenant_id_opt, Some(id) if !id.0.is_nil());
+    let tenant_id = if tenant_explicitly_identified {
+        tenant_id_opt.expect("checked above")
+    } else if let Some(default_id) = cfg.default_tenant_id {
+        default_id
+    } else if cfg.auth.enabled {
+        state.metrics.active_connections.dec();
+        warn!(%trace_id, "No tenant resolved and auth is enabled; rejecting (phantom-tenant guard)");
+        return error_response(
+            StatusCode::UNAUTHORIZED,
+            "Authentication required: no tenant resolved from header or key",
+            trace_id,
+        );
+    } else {
+        // Auth disabled, no header, no default: deterministic anonymous tenant.
+        // Stamped only — never auto-created.
+        TenantId(Uuid::new_v5(&Uuid::NAMESPACE_OID, b"llmtrace-anonymous"))
     };
 
     // RBAC: when auth is enabled, the catch-all forwarder (/v1/*) requires
@@ -1176,22 +1239,27 @@ pub async fn proxy_handler(
         .map(|c| c.monitoring_scope)
         .unwrap_or(llmtrace_core::MonitoringScope::Hybrid);
 
-    // Auto-create tenant on first request (best-effort, non-blocking).
-    // If auth is enabled, only create if we have an authenticated tenant.
-    // If auth is disabled, we still auto-create the "Unknown" tenant.
-    if !cfg.auth.enabled || tenant_id_opt.is_some() {
+    // Fetch the tenant record to resolve per-tenant upstream routing overrides
+    // (base URL + encrypted provider key). Best-effort: on miss/error we fall
+    // back to the global upstream_url and env-based credential.
+    let tenant_record = state.metadata().get_tenant(tenant_id).await.ok().flatten();
+    let tenant_upstream_url = tenant_record.as_ref().and_then(|t| t.upstream_url.clone());
+    let tenant_upstream_key = decrypt_tenant_upstream_key(tenant_record.as_ref());
+
+    // Provision the tenant on first request ONLY when it was explicitly
+    // identified (header / API key / authenticated context). Header-less
+    // traffic that fell back to `default_tenant_id` is provisioned
+    // out-of-band, and we never create a phantom "Unknown" tenant per call
+    // (issue #292). `ensure_tenant_exists` is idempotent on the stable id.
+    if tenant_explicitly_identified {
         let state_ac = Arc::clone(&state);
-        let name = if tenant_id_opt.is_some() {
-            _api_key
-                .as_deref()
-                .map(|k| {
-                    let prefix_len = k.len().min(8);
-                    format!("key-{}", &k[..prefix_len])
-                })
-                .unwrap_or_else(|| format!("tenant-{}", tenant_id.0))
-        } else {
-            "Unknown".to_string()
-        };
+        let name = _api_key
+            .as_deref()
+            .map(|k| {
+                let prefix_len = k.len().min(8);
+                format!("key-{}", &k[..prefix_len])
+            })
+            .unwrap_or_else(|| format!("tenant-{}", tenant_id.0));
         tokio::spawn(async move {
             crate::tenant_api::ensure_tenant_exists(&state_ac, tenant_id, &name).await;
         });
@@ -1599,8 +1667,10 @@ pub async fn proxy_handler(
         && datamarking_outcome.body_rewritten;
     let body_was_rewritten = body_was_rewritten || datamarking_active;
 
-    // Build the upstream request
-    let upstream_url = build_upstream_url(&cfg, &path, query.as_deref());
+    // Build the upstream request. Resolve the base URL from the tenant override
+    // (when set) or the global config.
+    let upstream_base = resolve_upstream_base(&cfg, tenant_upstream_url.as_deref());
+    let upstream_url = build_upstream_url(upstream_base, &path, query.as_deref());
 
     let mut upstream_req = state.client.request(
         reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::POST),
@@ -1616,7 +1686,7 @@ pub async fn proxy_handler(
     // Security (issue #274): always strip the incoming `Authorization` header
     // here. It was the tenant-facing LLMTrace bearer (e.g. `llmt_…`) and must
     // NEVER reach the upstream provider. The correct provider credential is
-    // injected below from `upstream_auth_for(&detected_provider)`.
+    // injected below from `upstream_auth_for_with_key(&detected_provider, ...)`.
     let mut forwarded_headers = reqwest::header::HeaderMap::new();
     for (name, value) in headers.iter() {
         if name == "host" || name == "accept-encoding" || name == "authorization" {
@@ -1636,7 +1706,9 @@ pub async fn proxy_handler(
     // var is unset we deliberately forward with NO Authorization header so
     // the upstream returns its own 401, which surfaces the gap as an
     // operator-actionable signal rather than a silent 5xx.
-    if let Some((auth_name, auth_value)) = upstream_auth_for(&detected_provider) {
+    if let Some((auth_name, auth_value)) =
+        upstream_auth_for_with_key(&detected_provider, tenant_upstream_key.as_deref())
+    {
         forwarded_headers.insert(auth_name, auth_value);
     }
     for (extra_name, extra_value) in upstream_extra_headers(&detected_provider) {
@@ -3044,8 +3116,9 @@ mod tests {
             upstream_url: "http://localhost:11434".to_string(),
             ..ProxyConfig::default()
         };
+        let base = resolve_upstream_base(&config, None);
         assert_eq!(
-            build_upstream_url(&config, "/v1/chat/completions", None),
+            build_upstream_url(base, "/v1/chat/completions", None),
             "http://localhost:11434/v1/chat/completions"
         );
     }
@@ -3056,9 +3129,56 @@ mod tests {
             upstream_url: "http://localhost:11434/".to_string(),
             ..ProxyConfig::default()
         };
+        let base = resolve_upstream_base(&config, None);
         assert_eq!(
-            build_upstream_url(&config, "/v1/models", Some("format=json")),
+            build_upstream_url(base, "/v1/models", Some("format=json")),
             "http://localhost:11434/v1/models?format=json"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_base_prefers_tenant_override() {
+        let config = ProxyConfig {
+            upstream_url: "https://global.example.com".to_string(),
+            ..ProxyConfig::default()
+        };
+        // Tenant override wins when present and non-empty.
+        assert_eq!(
+            resolve_upstream_base(&config, Some("https://tenant.example.com")),
+            "https://tenant.example.com"
+        );
+        // Empty/whitespace override falls back to the global URL.
+        assert_eq!(
+            resolve_upstream_base(&config, Some("   ")),
+            "https://global.example.com"
+        );
+        assert_eq!(
+            resolve_upstream_base(&config, None),
+            "https://global.example.com"
+        );
+    }
+
+    #[test]
+    fn test_upstream_auth_for_with_key_prefers_tenant_key() {
+        // Explicit per-tenant key is used for the OpenAI Bearer scheme,
+        // regardless of any env var.
+        let (name, value) =
+            upstream_auth_for_with_key(&llmtrace_core::LLMProvider::OpenAI, Some("sk-tenant-key"))
+                .expect("tenant key must produce an Authorization header");
+        assert_eq!(name, reqwest::header::AUTHORIZATION);
+        assert_eq!(value.to_str().unwrap(), "Bearer sk-tenant-key");
+    }
+
+    #[test]
+    fn test_build_upstream_url_uses_tenant_base() {
+        let config = ProxyConfig {
+            upstream_url: "https://global.example.com".to_string(),
+            ..ProxyConfig::default()
+        };
+        let base = resolve_upstream_base(&config, Some("https://tenant.example.com/"));
+        assert_eq!(
+            build_upstream_url(base, "/v1/chat/completions", None),
+            "https://tenant.example.com/v1/chat/completions"
         );
     }
 
@@ -3632,6 +3752,248 @@ mod tests {
             compute_security_score(&findings),
             span.security_score,
             "compute_security_score diverged from TraceSpan::add_security_finding"
+        );
+    }
+}
+
+// ===========================================================================
+// Phantom-tenant guard + per-tenant upstream routing tests (issues #292, #316)
+// ===========================================================================
+#[cfg(test)]
+mod tenant_routing_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::post;
+    use axum::Router;
+    use llmtrace_core::{
+        AuthConfig, ProxyConfig, SecurityAnalyzer, StorageConfig, Tenant, TenantId,
+    };
+    use llmtrace_security::RegexSecurityAnalyzer;
+    use llmtrace_storage::StorageProfile;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// Build an [`AppState`] with the given config, backed by in-memory storage.
+    async fn state_with(config: ProxyConfig) -> Arc<AppState> {
+        let storage = StorageProfile::Memory.build().await.unwrap();
+        let security = Arc::new(RegexSecurityAnalyzer::new().unwrap()) as Arc<dyn SecurityAnalyzer>;
+        let client = reqwest::Client::new();
+        let storage_breaker = Arc::new(crate::circuit_breaker::CircuitBreaker::from_config(
+            &config.circuit_breaker,
+        ));
+        let security_breaker = Arc::new(crate::circuit_breaker::CircuitBreaker::from_config(
+            &config.circuit_breaker,
+        ));
+        let cost_estimator = crate::cost::CostEstimator::new(&config.cost_estimation);
+        let cost_tracker =
+            crate::cost_caps::CostTracker::new(&config.cost_caps, Arc::clone(&storage.cache));
+        let rate_limiter =
+            crate::rate_limit::RateLimiter::new(&config.rate_limiting, Arc::clone(&storage.cache));
+        Arc::new(AppState {
+            config_handle: crate::config_handle::ConfigHandle::new(config, None, None),
+            client,
+            storage,
+            fast_analyzer: security.clone(),
+            security,
+            #[cfg(feature = "ml")]
+            security_ensemble: None,
+            ensemble_runtime: Arc::new(llmtrace_security::EnsembleRuntimeHandle::inert()),
+            storage_breaker,
+            security_breaker,
+            cost_estimator,
+            alert_engine: None,
+            cost_tracker,
+            anomaly_detector: None,
+            action_router: crate::action_router::ActionRouter::new(
+                &llmtrace_core::ActionRouterConfig::default(),
+                llmtrace_core::JudgePromotionConfig::default(),
+                llmtrace_core::JudgeWorkerConfig::default().max_analysis_text_bytes,
+                None,
+                reqwest::Client::new(),
+            ),
+            report_store: crate::compliance::new_report_store(),
+            rate_limiter,
+            ml_status: crate::proxy::MlModelStatus::Disabled,
+            judge_worker_spawned: false,
+            runtime_overlay_status: crate::proxy::RuntimeOverlayStatus::Disabled,
+            shutdown: crate::shutdown::ShutdownCoordinator::new(30),
+            metrics: crate::metrics::Metrics::new(),
+            ml_pipeline_semaphore: Arc::new(tokio::sync::Semaphore::new(8)),
+            ready: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        })
+    }
+
+    /// Start a mock upstream that returns 200 and records the requested URI.
+    async fn mock_upstream() -> (String, Arc<tokio::sync::Mutex<Vec<String>>>) {
+        let seen: Arc<tokio::sync::Mutex<Vec<String>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let store = Arc::clone(&seen);
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move |req: Request<Body>| {
+                let store = Arc::clone(&store);
+                async move {
+                    store.lock().await.push(req.uri().to_string());
+                    axum::response::Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .body(Body::from("{\"ok\":true}"))
+                        .unwrap()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        (format!("http://{addr}"), seen)
+    }
+
+    fn chat_body() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}]
+        }))
+        .unwrap()
+    }
+
+    fn router(state: Arc<AppState>) -> Router {
+        Router::new()
+            .fallback(axum::routing::any(proxy_handler))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn test_header_less_with_default_tenant_is_stamped() {
+        let (upstream, _seen) = mock_upstream().await;
+        let default_id = TenantId::new();
+        let config = ProxyConfig {
+            upstream_url: upstream.clone(),
+            listen_addr: "127.0.0.1:0".to_string(),
+            storage: StorageConfig {
+                profile: "memory".to_string(),
+                database_path: String::new(),
+                ..StorageConfig::default()
+            },
+            auth: AuthConfig {
+                enabled: false,
+                admin_key: None,
+            },
+            default_tenant_id: Some(default_id),
+            ..ProxyConfig::default()
+        };
+        let state = state_with(config).await;
+        let app = router(Arc::clone(&state));
+
+        let req = Request::post("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(chat_body()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // Forwarded upstream (no 4xx from the guard) — the default tenant was stamped.
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // The default tenant must NOT be auto-created (provisioned out-of-band).
+        // Give the spawned tasks a moment; there must be no tenant rows.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let tenants = state.metadata().list_tenants().await.unwrap();
+        assert!(
+            tenants.is_empty(),
+            "header-less default-tenant traffic must not create phantom tenants"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_header_less_no_default_auth_enabled_is_unauthorized() {
+        let (upstream, _seen) = mock_upstream().await;
+        let config = ProxyConfig {
+            upstream_url: upstream,
+            listen_addr: "127.0.0.1:0".to_string(),
+            storage: StorageConfig {
+                profile: "memory".to_string(),
+                database_path: String::new(),
+                ..StorageConfig::default()
+            },
+            auth: AuthConfig {
+                enabled: true,
+                admin_key: Some("admin-secret".to_string()),
+            },
+            default_tenant_id: None,
+            ..ProxyConfig::default()
+        };
+        let state = state_with(config).await;
+        // Bypass the auth middleware (none mounted) to exercise the in-handler
+        // guard directly: no AuthContext + auth enabled + no default => 401.
+        let app = router(Arc::clone(&state));
+        let req = Request::post("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(chat_body()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let tenants = state.metadata().list_tenants().await.unwrap();
+        assert!(
+            tenants.is_empty(),
+            "rejected traffic must not create a phantom tenant"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tenant_upstream_override_is_used() {
+        // Global upstream points nowhere useful; the tenant override points at
+        // the live mock. A successful 200 proves the override was honoured.
+        let (tenant_upstream, seen) = mock_upstream().await;
+        let tenant_id = TenantId::new();
+        let config = ProxyConfig {
+            upstream_url: "http://127.0.0.1:1/unreachable".to_string(),
+            listen_addr: "127.0.0.1:0".to_string(),
+            storage: StorageConfig {
+                profile: "memory".to_string(),
+                database_path: String::new(),
+                ..StorageConfig::default()
+            },
+            auth: AuthConfig {
+                enabled: false,
+                admin_key: None,
+            },
+            default_tenant_id: Some(tenant_id),
+            ..ProxyConfig::default()
+        };
+        let state = state_with(config).await;
+        // Provision the tenant WITH an upstream override.
+        let tenant = Tenant {
+            id: tenant_id,
+            name: "Routed".to_string(),
+            api_token: "tok".to_string(),
+            plan: "pro".to_string(),
+            created_at: Utc::now(),
+            config: serde_json::json!({}),
+            upstream_url: Some(tenant_upstream.clone()),
+            upstream_api_key_ciphertext: None,
+        };
+        state.metadata().create_tenant(&tenant).await.unwrap();
+
+        let app = router(Arc::clone(&state));
+        let req = Request::post("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("x-llmtrace-tenant-id", tenant_id.0.to_string())
+            .body(Body::from(chat_body()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "tenant override upstream must be reached"
+        );
+        let hits = seen.lock().await;
+        assert_eq!(
+            hits.len(),
+            1,
+            "the tenant override upstream must receive the request"
         );
     }
 }

--- a/crates/llmtrace-proxy/src/secretbox.rs
+++ b/crates/llmtrace-proxy/src/secretbox.rs
@@ -1,0 +1,262 @@
+//! Authenticated encryption (AEAD) for secrets at rest.
+//!
+//! Encrypts per-tenant upstream provider credentials before they are written
+//! to the metadata store. Uses AES-256-GCM (`aes-gcm` crate) with a random
+//! 96-bit nonce per encryption. The wire format is base64(`nonce || ciphertext`)
+//! where `ciphertext` already includes the GCM authentication tag.
+//!
+//! The master key is read from the `LLMTRACE_SECRET_ENCRYPTION_KEY` environment
+//! variable. It must decode to exactly 32 bytes. Two encodings are accepted:
+//! 64-char hex, or standard base64. Hex is tried first; base64 is the fallback.
+//!
+//! **Fail-closed contract:** if the master key is unset or invalid, [`SecretBox::from_env`]
+//! returns an error. Callers that SET a per-tenant secret must surface that
+//! error as a `400 Bad Request`. The proxy itself still boots and the global
+//! credential fallback continues to work because decryption is only attempted
+//! when a tenant actually has a stored ciphertext.
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use rand::RngCore;
+
+/// Environment variable holding the 32-byte master encryption key.
+pub const SECRET_ENCRYPTION_KEY_ENV: &str = "LLMTRACE_SECRET_ENCRYPTION_KEY";
+
+/// Required master key length in bytes (AES-256).
+const KEY_LEN: usize = 32;
+
+/// AES-GCM nonce length in bytes (96 bits, the standard for GCM).
+const NONCE_LEN: usize = 12;
+
+/// Errors raised by [`SecretBox`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SecretBoxError {
+    /// The master key env var is unset.
+    #[error("{SECRET_ENCRYPTION_KEY_ENV} is not set")]
+    KeyMissing,
+    /// The master key could not be decoded to exactly 32 bytes.
+    #[error(
+        "{SECRET_ENCRYPTION_KEY_ENV} must decode to {KEY_LEN} bytes (64-char hex or base64); {0}"
+    )]
+    KeyInvalid(String),
+    /// Encryption failed (should be infallible for valid inputs).
+    #[error("encryption failed")]
+    EncryptFailed,
+    /// The stored ciphertext is malformed (bad base64 or too short).
+    #[error("ciphertext is malformed: {0}")]
+    CiphertextMalformed(String),
+    /// Decryption/authentication failed (wrong key or tampered data).
+    #[error("decryption failed: ciphertext could not be authenticated")]
+    DecryptFailed,
+}
+
+/// An AEAD cipher bound to a 32-byte master key.
+pub struct SecretBox {
+    cipher: Aes256Gcm,
+}
+
+impl std::fmt::Debug for SecretBox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never expose key material in debug output.
+        f.debug_struct("SecretBox").finish_non_exhaustive()
+    }
+}
+
+impl SecretBox {
+    /// Construct a [`SecretBox`] from the `LLMTRACE_SECRET_ENCRYPTION_KEY` env var.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretBoxError::KeyMissing`] when unset and
+    /// [`SecretBoxError::KeyInvalid`] when it does not decode to 32 bytes.
+    pub fn from_env() -> Result<Self, SecretBoxError> {
+        let raw =
+            std::env::var(SECRET_ENCRYPTION_KEY_ENV).map_err(|_| SecretBoxError::KeyMissing)?;
+        Self::from_master_key_str(&raw)
+    }
+
+    /// Construct a [`SecretBox`] from a hex- or base64-encoded master key string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretBoxError::KeyInvalid`] when the string does not decode to
+    /// exactly 32 bytes under either encoding.
+    pub fn from_master_key_str(raw: &str) -> Result<Self, SecretBoxError> {
+        let key_bytes = decode_master_key(raw)?;
+        let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+        Ok(Self {
+            cipher: Aes256Gcm::new(key),
+        })
+    }
+
+    /// Encrypt `plaintext`, returning base64(`nonce || ciphertext`).
+    ///
+    /// A fresh random nonce is generated per call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretBoxError::EncryptFailed`] if the underlying AEAD fails.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<String, SecretBoxError> {
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = self
+            .cipher
+            .encrypt(nonce, plaintext)
+            .map_err(|_| SecretBoxError::EncryptFailed)?;
+
+        let mut combined = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        combined.extend_from_slice(&nonce_bytes);
+        combined.extend_from_slice(&ciphertext);
+        Ok(BASE64.encode(combined))
+    }
+
+    /// Decrypt a base64(`nonce || ciphertext`) string back to plaintext bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecretBoxError::CiphertextMalformed`] for bad base64 / short
+    /// input and [`SecretBoxError::DecryptFailed`] when authentication fails.
+    pub fn decrypt(&self, encoded: &str) -> Result<Vec<u8>, SecretBoxError> {
+        let combined = BASE64
+            .decode(encoded.as_bytes())
+            .map_err(|e| SecretBoxError::CiphertextMalformed(e.to_string()))?;
+        if combined.len() <= NONCE_LEN {
+            return Err(SecretBoxError::CiphertextMalformed(
+                "shorter than nonce".to_string(),
+            ));
+        }
+        let (nonce_bytes, ciphertext) = combined.split_at(NONCE_LEN);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        self.cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|_| SecretBoxError::DecryptFailed)
+    }
+}
+
+/// Decode a master key string (hex first, base64 fallback) into 32 bytes.
+fn decode_master_key(raw: &str) -> Result<[u8; KEY_LEN], SecretBoxError> {
+    let trimmed = raw.trim();
+    // Try hex (exactly 64 chars => 32 bytes).
+    if let Ok(bytes) = hex::decode(trimmed) {
+        return to_key_array(bytes);
+    }
+    // Fall back to standard base64.
+    if let Ok(bytes) = BASE64.decode(trimmed.as_bytes()) {
+        return to_key_array(bytes);
+    }
+    Err(SecretBoxError::KeyInvalid(
+        "not valid hex or base64".to_string(),
+    ))
+}
+
+/// Convert a decoded byte vector to a fixed 32-byte array, or error.
+fn to_key_array(bytes: Vec<u8>) -> Result<[u8; KEY_LEN], SecretBoxError> {
+    let len = bytes.len();
+    <[u8; KEY_LEN]>::try_from(bytes.as_slice())
+        .map_err(|_| SecretBoxError::KeyInvalid(format!("decoded to {len} bytes, need {KEY_LEN}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A valid 32-byte key encoded as 64 hex chars.
+    const HEX_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+    fn box_from_hex() -> SecretBox {
+        SecretBox::from_master_key_str(HEX_KEY).unwrap()
+    }
+
+    #[test]
+    fn test_round_trip_hex_key() {
+        let sb = box_from_hex();
+        let secret = b"sk-super-secret-provider-key";
+        let ct = sb.encrypt(secret).unwrap();
+        let pt = sb.decrypt(&ct).unwrap();
+        assert_eq!(pt, secret);
+    }
+
+    #[test]
+    fn test_round_trip_base64_key() {
+        // 32 zero bytes, base64-encoded.
+        let b64_key = BASE64.encode([0u8; KEY_LEN]);
+        let sb = SecretBox::from_master_key_str(&b64_key).unwrap();
+        let secret = b"another-secret";
+        let ct = sb.encrypt(secret).unwrap();
+        assert_eq!(sb.decrypt(&ct).unwrap(), secret);
+    }
+
+    #[test]
+    fn test_ciphertext_is_not_plaintext() {
+        let sb = box_from_hex();
+        let secret = b"do-not-leak";
+        let ct = sb.encrypt(secret).unwrap();
+        assert!(!ct.as_bytes().windows(secret.len()).any(|w| w == secret));
+    }
+
+    #[test]
+    fn test_nonce_is_random_per_encryption() {
+        let sb = box_from_hex();
+        let secret = b"same-input";
+        let a = sb.encrypt(secret).unwrap();
+        let b = sb.encrypt(secret).unwrap();
+        assert_ne!(a, b, "two encryptions of the same plaintext must differ");
+    }
+
+    #[test]
+    fn test_wrong_key_fails_to_decrypt() {
+        let sb = box_from_hex();
+        let ct = sb.encrypt(b"secret").unwrap();
+        let other = SecretBox::from_master_key_str(&BASE64.encode([0xAAu8; KEY_LEN])).unwrap();
+        assert!(matches!(
+            other.decrypt(&ct),
+            Err(SecretBoxError::DecryptFailed)
+        ));
+    }
+
+    #[test]
+    fn test_tampered_ciphertext_fails() {
+        let sb = box_from_hex();
+        let ct = sb.encrypt(b"secret").unwrap();
+        let mut bytes = BASE64.decode(ct.as_bytes()).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        let tampered = BASE64.encode(bytes);
+        assert!(matches!(
+            sb.decrypt(&tampered),
+            Err(SecretBoxError::DecryptFailed)
+        ));
+    }
+
+    #[test]
+    fn test_short_key_rejected() {
+        // 16 bytes hex => too short.
+        let err = SecretBox::from_master_key_str("00112233445566778899aabbccddeeff").unwrap_err();
+        assert!(matches!(err, SecretBoxError::KeyInvalid(_)));
+    }
+
+    #[test]
+    fn test_garbage_key_rejected() {
+        let err = SecretBox::from_master_key_str("not-a-key!!!").unwrap_err();
+        assert!(matches!(err, SecretBoxError::KeyInvalid(_)));
+    }
+
+    #[test]
+    fn test_malformed_ciphertext_rejected() {
+        let sb = box_from_hex();
+        assert!(matches!(
+            sb.decrypt("not-base64-???"),
+            Err(SecretBoxError::CiphertextMalformed(_))
+        ));
+        // Valid base64 but too short to contain a nonce.
+        let short = BASE64.encode([0u8; 4]);
+        assert!(matches!(
+            sb.decrypt(&short),
+            Err(SecretBoxError::CiphertextMalformed(_))
+        ));
+    }
+}

--- a/crates/llmtrace-proxy/src/tenant_api.rs
+++ b/crates/llmtrace-proxy/src/tenant_api.rs
@@ -24,6 +24,13 @@ use crate::proxy::AppState;
 /// Request body for `POST /api/v1/tenants`.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateTenantRequest {
+    /// Optional caller-supplied tenant id. Absent => a fresh id is generated.
+    /// The Basilica deployment bootstrap supplies a stable id so the SAME
+    /// tenant persists across `--strategy recreate` (issue 9). When a tenant
+    /// with this id already exists, create is idempotent and returns it
+    /// unchanged.
+    #[serde(default)]
+    pub id: Option<TenantId>,
     /// Human-readable tenant name.
     pub name: String,
     /// Subscription plan (e.g., "free", "pro", "enterprise").
@@ -281,6 +288,21 @@ pub async fn create_tenant(
         return api_error(StatusCode::BAD_REQUEST, "Tenant name must not be empty");
     }
 
+    // Resolve the tenant id. A caller-supplied id makes create idempotent so the
+    // SAME tenant persists across `--strategy recreate` (issue 9): if a tenant
+    // with this id already exists, return it unchanged (mirroring the
+    // get-or-create semantics of `ensure_tenant_exists`). Absent => fresh id.
+    let tenant_id = match body.id {
+        Some(id) => match state.metadata().get_tenant(id).await {
+            Ok(Some(existing)) => {
+                return Json(TenantView::from(existing)).into_response();
+            }
+            Ok(None) => id,
+            Err(e) => return api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        },
+        None => TenantId::new(),
+    };
+
     let (api_token, _) = crate::auth::generate_api_key(); // Reusing the same generator for tokens
 
     // Encrypt the optional per-tenant upstream key (fail-closed via 400).
@@ -300,7 +322,7 @@ pub async fn create_tenant(
         .map(str::to_string);
 
     let tenant = Tenant {
-        id: TenantId::new(),
+        id: tenant_id,
         name: body.name.clone(),
         api_token: api_token.clone(),
         plan: body.plan.clone(),
@@ -938,6 +960,81 @@ mod tests {
 
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_create_tenant_honors_explicit_id() {
+        let state = test_state().await;
+        let app = tenant_router(Arc::clone(&state));
+
+        // A fixed, caller-supplied tenant id (Basilica bootstrap supplies a
+        // stable id so the SAME tenant persists across redeploy — issue 9).
+        let explicit_id = "550e8400-e29b-41d4-a716-446655440000";
+        let body = serde_json::json!({ "id": explicit_id, "name": "Stable Org", "plan": "pro" });
+        let req = Request::post("/api/v1/tenants")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let json = json_body(resp).await;
+        // The response id must equal the caller-supplied id, not a random one.
+        assert_eq!(json["id"], explicit_id);
+        // Fresh creation still surfaces the one-time plaintext api_key.
+        assert!(json["api_key"].as_str().unwrap().starts_with("llmt_"));
+
+        // A row with exactly that id must exist in the metadata store.
+        let expected = TenantId(Uuid::parse_str(explicit_id).unwrap());
+        let stored = state
+            .metadata()
+            .get_tenant(expected)
+            .await
+            .unwrap()
+            .expect("tenant with explicit id must exist");
+        assert_eq!(stored.id, expected);
+        assert_eq!(stored.name, "Stable Org");
+    }
+
+    #[tokio::test]
+    async fn test_create_tenant_idempotent_on_explicit_id() {
+        let state = test_state().await;
+        let explicit_id = "550e8400-e29b-41d4-a716-446655440000";
+        let expected = TenantId(Uuid::parse_str(explicit_id).unwrap());
+
+        // First create with the explicit id.
+        let app1 = tenant_router(Arc::clone(&state));
+        let body = serde_json::json!({ "id": explicit_id, "name": "First", "plan": "pro" });
+        let req = Request::post("/api/v1/tenants")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp1 = app1.oneshot(req).await.unwrap();
+        assert_eq!(resp1.status(), StatusCode::CREATED);
+        let json1 = json_body(resp1).await;
+        assert_eq!(json1["id"], explicit_id);
+
+        // Second create with the SAME explicit id (e.g. after `recreate`).
+        let app2 = tenant_router(Arc::clone(&state));
+        let body2 =
+            serde_json::json!({ "id": explicit_id, "name": "Second", "plan": "enterprise" });
+        let req2 = Request::post("/api/v1/tenants")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body2).unwrap()))
+            .unwrap();
+        let resp2 = app2.oneshot(req2).await.unwrap();
+        // Idempotent: returns 200 with the existing tenant unchanged.
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let json2 = json_body(resp2).await;
+        assert_eq!(json2["id"], explicit_id);
+        // The existing record is returned unchanged (original name kept).
+        assert_eq!(json2["name"], "First");
+
+        // Exactly ONE tenant row exists for that id — no duplicate minted.
+        let all = state.metadata().list_tenants().await.unwrap();
+        let matching: Vec<_> = all.iter().filter(|t| t.id == expected).collect();
+        assert_eq!(matching.len(), 1, "must not create a duplicate tenant");
     }
 
     // -- GET /api/v1/tenants ------------------------------------------------

--- a/crates/llmtrace-proxy/src/tenant_api.rs
+++ b/crates/llmtrace-proxy/src/tenant_api.rs
@@ -32,14 +32,65 @@ pub struct CreateTenantRequest {
     /// Optional arbitrary tenant-level configuration.
     #[serde(default = "default_config")]
     pub config: serde_json::Value,
+    /// Optional per-tenant upstream base URL override. `null`/absent => inherit
+    /// the global `upstream_url`.
+    #[serde(default)]
+    pub upstream_url: Option<String>,
+    /// Optional per-tenant upstream provider API key (write-only). When present
+    /// and non-empty it is AEAD-encrypted before storage; `null`/empty clears
+    /// it (inherit the global env-based credential). NEVER returned.
+    #[serde(default)]
+    pub upstream_api_key: Option<String>,
+}
+
+/// Public, secret-safe view of a tenant returned by GET/LIST/CREATE/UPDATE.
+///
+/// Mirrors [`Tenant`] but NEVER exposes the encrypted upstream key. Instead it
+/// surfaces `upstream_api_key_set: bool` (CONTRACT 1).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TenantView {
+    /// Unique tenant identifier.
+    pub id: TenantId,
+    /// Human-readable tenant name.
+    pub name: String,
+    /// Unique API token for proxy traffic.
+    pub api_token: String,
+    /// Subscription plan.
+    pub plan: String,
+    /// When the tenant was created.
+    #[schema(value_type = String, format = "date-time")]
+    pub created_at: chrono::DateTime<Utc>,
+    /// Arbitrary tenant-level configuration.
+    #[schema(value_type = Object)]
+    pub config: serde_json::Value,
+    /// Per-tenant upstream base URL override, or `null` to inherit global.
+    pub upstream_url: Option<String>,
+    /// Whether a per-tenant upstream API key is set. The secret is never
+    /// returned.
+    pub upstream_api_key_set: bool,
+}
+
+impl From<Tenant> for TenantView {
+    fn from(t: Tenant) -> Self {
+        Self {
+            id: t.id,
+            name: t.name,
+            api_token: t.api_token,
+            plan: t.plan,
+            created_at: t.created_at,
+            config: t.config,
+            upstream_url: t.upstream_url,
+            upstream_api_key_set: t.upstream_api_key_ciphertext.is_some(),
+        }
+    }
 }
 
 /// Response body for `POST /api/v1/tenants`.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct CreateTenantResponse {
-    /// The created tenant metadata.
+    /// The created tenant metadata (secret-safe view).
     #[serde(flatten)]
-    pub tenant: Tenant,
+    pub tenant: TenantView,
     /// The plaintext API key (only returned once on creation).
     pub api_key: Option<String>,
 }
@@ -53,6 +104,29 @@ pub struct UpdateTenantRequest {
     pub plan: Option<String>,
     /// Updated configuration (optional).
     pub config: Option<serde_json::Value>,
+    /// Updated per-tenant upstream base URL. Present-with-value sets it;
+    /// present-and-null/empty clears it (inherit global); absent leaves it
+    /// unchanged.
+    #[serde(default, deserialize_with = "deserialize_optional_field")]
+    pub upstream_url: Option<Option<String>>,
+    /// Updated per-tenant upstream API key (write-only). Present-with-value
+    /// encrypts + stores it; present-and-null/empty clears it; absent leaves it
+    /// unchanged. NEVER returned.
+    #[serde(default, deserialize_with = "deserialize_optional_field")]
+    pub upstream_api_key: Option<Option<String>>,
+}
+
+/// Deserialize a JSON field that may be absent, null, or a value, into a
+/// double-`Option`: outer `None` = absent (leave unchanged), inner `None` =
+/// explicit null (clear), `Some(v)` = set.
+fn deserialize_optional_field<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
 }
 
 /// API error response body.
@@ -87,6 +161,32 @@ fn default_config() -> serde_json::Value {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Encrypt a plaintext per-tenant upstream key, failing closed.
+///
+/// Returns `Ok(Some(ciphertext))` on success, `Ok(None)` when `plaintext` is
+/// empty (caller should clear the stored key), or `Err(SecretBoxError)` when the
+/// master key is unavailable/invalid (CONTRACT 1 fail-closed). Callers map the
+/// error to a `400 Bad Request` via [`upstream_key_error`].
+fn encrypt_upstream_key(
+    plaintext: &str,
+) -> std::result::Result<Option<String>, crate::secretbox::SecretBoxError> {
+    if plaintext.is_empty() {
+        return Ok(None);
+    }
+    let secret_box = crate::secretbox::SecretBox::from_env()?;
+    let ciphertext = secret_box.encrypt(plaintext.as_bytes())?;
+    Ok(Some(ciphertext))
+}
+
+/// Build the `400` response for an upstream-key encryption failure
+/// (CONTRACT 1 fail-closed).
+fn upstream_key_error(e: &crate::secretbox::SecretBoxError) -> Response {
+    api_error(
+        StatusCode::BAD_REQUEST,
+        &format!("Cannot store upstream_api_key: {e}"),
+    )
+}
 
 /// Build a JSON error response.
 fn api_error(status: StatusCode, message: &str) -> Response {
@@ -183,6 +283,22 @@ pub async fn create_tenant(
 
     let (api_token, _) = crate::auth::generate_api_key(); // Reusing the same generator for tokens
 
+    // Encrypt the optional per-tenant upstream key (fail-closed via 400).
+    let upstream_api_key_ciphertext = match body.upstream_api_key.as_deref() {
+        Some(key) => match encrypt_upstream_key(key) {
+            Ok(ct) => ct,
+            Err(e) => return upstream_key_error(&e),
+        },
+        None => None,
+    };
+    // Normalise upstream_url: empty/whitespace => inherit (None).
+    let upstream_url = body
+        .upstream_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
     let tenant = Tenant {
         id: TenantId::new(),
         name: body.name.clone(),
@@ -190,6 +306,8 @@ pub async fn create_tenant(
         plan: body.plan.clone(),
         created_at: Utc::now(),
         config: body.config.clone(),
+        upstream_url,
+        upstream_api_key_ciphertext,
     };
 
     match state.metadata().create_tenant(&tenant).await {
@@ -221,7 +339,7 @@ pub async fn create_tenant(
                 tracing::error!(tenant_id = %tenant.id, "Failed to auto-generate API key: {e}");
                 // Return tenant without key if key generation fails
                 let resp = CreateTenantResponse {
-                    tenant,
+                    tenant: TenantView::from(tenant),
                     api_key: None,
                 };
                 (StatusCode::CREATED, Json(resp)).into_response()
@@ -241,7 +359,7 @@ pub async fn create_tenant(
                 .await;
 
                 let resp = CreateTenantResponse {
-                    tenant,
+                    tenant: TenantView::from(tenant),
                     api_key: Some(plaintext),
                 };
                 (StatusCode::CREATED, Json(resp)).into_response()
@@ -256,7 +374,7 @@ pub async fn create_tenant(
     get,
     path = "/api/v1/tenants",
     responses(
-        (status = 200, description = "Tenants", body = [Tenant]),
+        (status = 200, description = "Tenants", body = [TenantView]),
         (status = 401, description = "Unauthorized", body = ApiError),
         (status = 403, description = "Forbidden", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
@@ -272,7 +390,10 @@ pub async fn list_tenants(
         return err;
     }
     match state.metadata().list_tenants().await {
-        Ok(tenants) => Json(tenants).into_response(),
+        Ok(tenants) => {
+            let views: Vec<TenantView> = tenants.into_iter().map(TenantView::from).collect();
+            Json(views).into_response()
+        }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     }
 }
@@ -285,7 +406,7 @@ pub async fn list_tenants(
         ("id" = String, Path, description = "Tenant ID"),
     ),
     responses(
-        (status = 200, description = "Tenant", body = Tenant),
+        (status = 200, description = "Tenant", body = TenantView),
         (status = 401, description = "Unauthorized", body = ApiError),
         (status = 403, description = "Forbidden", body = ApiError),
         (status = 404, description = "Tenant not found", body = ApiError),
@@ -304,7 +425,7 @@ pub async fn get_tenant(
     }
     let tenant_id = TenantId(id);
     match state.metadata().get_tenant(tenant_id).await {
-        Ok(Some(tenant)) => Json(tenant).into_response(),
+        Ok(Some(tenant)) => Json(TenantView::from(tenant)).into_response(),
         Ok(None) => api_error(StatusCode::NOT_FOUND, "Tenant not found"),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     }
@@ -319,7 +440,7 @@ pub async fn get_tenant(
     ),
     request_body = UpdateTenantRequest,
     responses(
-        (status = 200, description = "Updated tenant", body = Tenant),
+        (status = 200, description = "Updated tenant", body = TenantView),
         (status = 400, description = "Bad request", body = ApiError),
         (status = 401, description = "Unauthorized", body = ApiError),
         (status = 403, description = "Forbidden", body = ApiError),
@@ -347,6 +468,29 @@ pub async fn update_tenant(
         Err(e) => return api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     };
 
+    // Resolve upstream_url: absent => keep; present null/empty => clear; set.
+    let upstream_url = match body.upstream_url {
+        None => existing.upstream_url,
+        Some(opt) => opt
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+    };
+
+    // Resolve upstream_api_key: absent => keep ciphertext; present null/empty =>
+    // clear; set => encrypt (fail-closed via 400).
+    let upstream_api_key_ciphertext = match body.upstream_api_key {
+        None => existing.upstream_api_key_ciphertext,
+        Some(opt) => match opt.as_deref().unwrap_or("") {
+            "" => None,
+            key => match encrypt_upstream_key(key) {
+                Ok(ct) => ct,
+                Err(e) => return upstream_key_error(&e),
+            },
+        },
+    };
+
     let updated = Tenant {
         id: existing.id,
         name: body.name.unwrap_or(existing.name),
@@ -354,6 +498,8 @@ pub async fn update_tenant(
         plan: body.plan.unwrap_or(existing.plan),
         created_at: existing.created_at,
         config: body.config.unwrap_or(existing.config),
+        upstream_url,
+        upstream_api_key_ciphertext,
     };
 
     match state.metadata().update_tenant(&updated).await {
@@ -366,7 +512,7 @@ pub async fn update_tenant(
                 serde_json::json!({ "name": updated.name, "plan": updated.plan }),
             )
             .await;
-            Json(updated).into_response()
+            Json(TenantView::from(updated)).into_response()
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     }
@@ -590,6 +736,8 @@ pub async fn ensure_tenant_exists(state: &Arc<AppState>, tenant_id: TenantId, na
         plan: "default".to_string(),
         created_at: Utc::now(),
         config: serde_json::json!({}),
+        upstream_url: None,
+        upstream_api_key_ciphertext: None,
     };
 
     match state.metadata().create_tenant(&tenant).await {
@@ -820,6 +968,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         let t2 = Tenant {
             id: TenantId::new(),
@@ -828,6 +978,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&t1).await.unwrap();
         state.metadata().create_tenant(&t2).await.unwrap();
@@ -854,6 +1006,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -894,6 +1048,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -922,6 +1078,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -971,6 +1129,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -1044,6 +1204,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -1077,6 +1239,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -1145,6 +1309,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -1159,5 +1325,208 @@ mod tests {
             .unwrap();
         assert_eq!(after.name, "Already Here"); // not overwritten
         assert_eq!(after.plan, "pro"); // not changed to "default"
+    }
+
+    // -- Idempotent bootstrap (issue 9) ------------------------------------
+
+    #[tokio::test]
+    async fn test_ensure_tenant_exists_is_idempotent_on_stable_id() {
+        let state = test_state().await;
+        // A stable, externally-provided tenant id (e.g. user-uuid-...).
+        let stable_id = TenantId(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
+
+        ensure_tenant_exists(&state, stable_id, "first-call").await;
+        let first = state
+            .metadata()
+            .get_tenant(stable_id)
+            .await
+            .unwrap()
+            .expect("tenant created");
+
+        // Re-provision after a notional redeploy with the SAME id.
+        ensure_tenant_exists(&state, stable_id, "second-call").await;
+
+        let all = state.metadata().list_tenants().await.unwrap();
+        let matching: Vec<_> = all.iter().filter(|t| t.id == stable_id).collect();
+        assert_eq!(matching.len(), 1, "must not mint a duplicate tenant row");
+
+        let second = state
+            .metadata()
+            .get_tenant(stable_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            second.id, stable_id,
+            "tenant id must be stable across calls"
+        );
+        assert_eq!(second.id, first.id);
+        // Existing record is returned unchanged (name not overwritten).
+        assert_eq!(second.name, "first-call");
+        assert_eq!(second.api_token, first.api_token);
+    }
+
+    // -- Per-tenant upstream creds (CONTRACT 1) ----------------------------
+
+    /// A valid 32-byte master key in hex used to exercise encryption paths.
+    const TEST_MASTER_KEY: &str =
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+    /// Serialises tests that mutate the master-key env var. A tokio mutex is
+    /// used so the guard can be safely held across `.await` points.
+    static MASTER_KEY_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[tokio::test]
+    async fn test_create_tenant_with_upstream_creds_contract() {
+        let _guard = MASTER_KEY_LOCK.lock().await;
+        std::env::set_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV, TEST_MASTER_KEY);
+        let state = test_state().await;
+        let app = tenant_router(Arc::clone(&state));
+
+        let body = serde_json::json!({
+            "name": "Routed Org",
+            "upstream_url": "https://tenant.example.com",
+            "upstream_api_key": "sk-tenant-secret"
+        });
+        let req = Request::post("/api/v1/tenants")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        std::env::remove_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV);
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let json = json_body(resp).await;
+        // CONTRACT 1: response surfaces upstream_url + upstream_api_key_set,
+        // and NEVER the secret/ciphertext.
+        assert_eq!(json["upstream_url"], "https://tenant.example.com");
+        assert_eq!(json["upstream_api_key_set"], true);
+        assert!(json.get("upstream_api_key").is_none());
+        assert!(json.get("upstream_api_key_ciphertext").is_none());
+
+        // The stored ciphertext must NOT contain the plaintext secret.
+        let tid = TenantId(Uuid::parse_str(json["id"].as_str().unwrap()).unwrap());
+        let stored = state.metadata().get_tenant(tid).await.unwrap().unwrap();
+        let ct = stored
+            .upstream_api_key_ciphertext
+            .expect("ciphertext stored");
+        assert!(
+            !ct.contains("sk-tenant-secret"),
+            "secret must be encrypted at rest"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_tenant_upstream_key_fails_closed_without_master_key() {
+        let _guard = MASTER_KEY_LOCK.lock().await;
+        std::env::remove_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV);
+        let state = test_state().await;
+        let app = tenant_router(state);
+
+        let body = serde_json::json!({
+            "name": "No Key Org",
+            "upstream_api_key": "sk-should-fail"
+        });
+        let req = Request::post("/api/v1/tenants")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "setting a per-tenant key without a master key must fail closed (400)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_tenant_clears_upstream_key_on_null() {
+        let _guard = MASTER_KEY_LOCK.lock().await;
+        std::env::set_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV, TEST_MASTER_KEY);
+        let secret_box = crate::secretbox::SecretBox::from_env().unwrap();
+        let ct = secret_box.encrypt(b"sk-existing").unwrap();
+        let tenant = Tenant {
+            id: TenantId::new(),
+            name: "Has Key".to_string(),
+            api_token: "token-haskey".to_string(),
+            plan: "pro".to_string(),
+            created_at: Utc::now(),
+            config: serde_json::json!({}),
+            upstream_url: Some("https://old.example.com".to_string()),
+            upstream_api_key_ciphertext: Some(ct),
+        };
+        let state = test_state().await;
+        state.metadata().create_tenant(&tenant).await.unwrap();
+
+        let app = tenant_router(Arc::clone(&state));
+        // Explicit null clears the key and the url (inherit global).
+        let body = serde_json::json!({ "upstream_api_key": null, "upstream_url": null });
+        let req = Request::put(format!("/api/v1/tenants/{}", tenant.id.0))
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        std::env::remove_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV);
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let json = json_body(resp).await;
+        assert_eq!(json["upstream_api_key_set"], false);
+        assert!(json["upstream_url"].is_null());
+
+        let after = state
+            .metadata()
+            .get_tenant(tenant.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(after.upstream_api_key_ciphertext.is_none());
+        assert!(after.upstream_url.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_tenant_absent_upstream_fields_unchanged() {
+        let _guard = MASTER_KEY_LOCK.lock().await;
+        std::env::set_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV, TEST_MASTER_KEY);
+        let secret_box = crate::secretbox::SecretBox::from_env().unwrap();
+        let ct = secret_box.encrypt(b"sk-keep").unwrap();
+        let tenant = Tenant {
+            id: TenantId::new(),
+            name: "Keep Key".to_string(),
+            api_token: "token-keep".to_string(),
+            plan: "pro".to_string(),
+            created_at: Utc::now(),
+            config: serde_json::json!({}),
+            upstream_url: Some("https://keep.example.com".to_string()),
+            upstream_api_key_ciphertext: Some(ct.clone()),
+        };
+        let state = test_state().await;
+        state.metadata().create_tenant(&tenant).await.unwrap();
+
+        let app = tenant_router(Arc::clone(&state));
+        // Only updating the name; upstream fields are absent => unchanged.
+        let body = serde_json::json!({ "name": "Renamed" });
+        let req = Request::put(format!("/api/v1/tenants/{}", tenant.id.0))
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        std::env::remove_var(crate::secretbox::SECRET_ENCRYPTION_KEY_ENV);
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let after = state
+            .metadata()
+            .get_tenant(tenant.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after.upstream_api_key_ciphertext.as_deref(),
+            Some(ct.as_str())
+        );
+        assert_eq!(
+            after.upstream_url.as_deref(),
+            Some("https://keep.example.com")
+        );
+        assert_eq!(after.name, "Renamed");
     }
 }

--- a/crates/llmtrace-proxy/tests/integration_test.rs
+++ b/crates/llmtrace-proxy/tests/integration_test.rs
@@ -1400,6 +1400,8 @@ async fn seed_role_key(state: &Arc<AppState>, role: llmtrace_core::ApiKeyRole) -
         plan: "free".to_string(),
         created_at: chrono::Utc::now(),
         config: serde_json::json!({}),
+        upstream_url: None,
+        upstream_api_key_ciphertext: None,
     };
     state.metadata().create_tenant(&tenant).await.unwrap();
 
@@ -1423,8 +1425,11 @@ async fn test_v1_forward_admin_role_allowed() {
     let (upstream_url, _h) = serve(mock_upstream()).await;
     let (_state, app) = build_auth_enabled_proxy(&upstream_url, "admin-bootstrap").await;
 
+    // Phantom-tenant guard: when auth is enabled the admin must identify the
+    // tenant the forwarded traffic belongs to (no auto-invented tenant).
     let req = Request::post("/v1/chat/completions")
         .header("authorization", "Bearer admin-bootstrap")
+        .header("x-llmtrace-tenant-id", uuid::Uuid::new_v4().to_string())
         .header("content-type", "application/json")
         .body(Body::from(
             serde_json::to_vec(&json!({

--- a/crates/llmtrace-storage/migrations/sqlite/007_add_tenant_upstream.sql
+++ b/crates/llmtrace-storage/migrations/sqlite/007_add_tenant_upstream.sql
@@ -1,0 +1,12 @@
+-- 007_add_tenant_upstream.sql: per-tenant upstream routing overrides.
+--
+-- Adds two nullable columns to the tenants table:
+--   * upstream_url                  — optional per-tenant upstream base URL.
+--   * upstream_api_key_ciphertext   — AEAD-encrypted per-tenant provider key,
+--                                     base64-encoded `nonce || ciphertext`.
+--                                     NULL means "inherit the global key".
+-- Both default to NULL so existing tenants transparently fall back to the
+-- global upstream_url / env-based provider credential.
+
+ALTER TABLE tenants ADD COLUMN upstream_url TEXT;
+ALTER TABLE tenants ADD COLUMN upstream_api_key_ciphertext TEXT;

--- a/crates/llmtrace-storage/src/lib.rs
+++ b/crates/llmtrace-storage/src/lib.rs
@@ -181,6 +181,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         storage.metadata.create_tenant(&t).await.unwrap();
         let retrieved = storage.metadata.get_tenant(tenant).await.unwrap();
@@ -229,6 +231,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         storage.metadata.create_tenant(&t).await.unwrap();
         let retrieved = storage.metadata.get_tenant(tenant).await.unwrap().unwrap();
@@ -296,6 +300,8 @@ mod tests {
             plan: "enterprise".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         storage.metadata.create_tenant(&t).await.unwrap();
         let retrieved = storage.metadata.get_tenant(tenant).await.unwrap().unwrap();

--- a/crates/llmtrace-storage/src/memory.rs
+++ b/crates/llmtrace-storage/src/memory.rs
@@ -184,6 +184,69 @@ impl TraceRepository for InMemoryTraceRepository {
         Ok(results)
     }
 
+    async fn query_traces_all_tenants(&self, query: &TraceQuery) -> Result<Vec<TraceEvent>> {
+        let traces = self.traces.read().await;
+        let standalone = self.standalone_spans.read().await;
+
+        // Collect every span (all tenants) and the trace ids matching the
+        // non-tenant filters in the query.
+        let mut all_spans: Vec<TraceSpan> = traces
+            .iter()
+            .flat_map(|t| t.spans.iter().cloned())
+            .collect();
+        all_spans.extend(standalone.iter().cloned());
+
+        let mut matching_trace_ids: Vec<Uuid> = all_spans
+            .iter()
+            .filter(|s| Self::span_matches(s, query))
+            .map(|s| s.trace_id)
+            .collect();
+        matching_trace_ids.sort();
+        matching_trace_ids.dedup();
+
+        let mut results: Vec<TraceEvent> = Vec::new();
+        for tid in &matching_trace_ids {
+            if let Some(t) = traces.iter().find(|t| t.trace_id == *tid) {
+                results.push(t.clone());
+            } else {
+                let spans: Vec<TraceSpan> = standalone
+                    .iter()
+                    .filter(|s| s.trace_id == *tid)
+                    .cloned()
+                    .collect();
+                if let Some(first) = spans.first() {
+                    let created_at = spans
+                        .iter()
+                        .map(|s| s.start_time)
+                        .min()
+                        .unwrap_or_else(Utc::now);
+                    results.push(TraceEvent {
+                        trace_id: *tid,
+                        tenant_id: first.tenant_id,
+                        spans,
+                        created_at,
+                    });
+                }
+            }
+        }
+
+        results.sort_by_key(|x| std::cmp::Reverse(x.created_at));
+
+        if let Some(offset) = query.offset {
+            let offset = offset as usize;
+            if offset < results.len() {
+                results = results.split_off(offset);
+            } else {
+                results.clear();
+            }
+        }
+        if let Some(limit) = query.limit {
+            results.truncate(limit as usize);
+        }
+
+        Ok(results)
+    }
+
     async fn query_spans(&self, query: &TraceQuery) -> Result<Vec<TraceSpan>> {
         let mut all = self.all_spans_for_tenant(query.tenant_id).await;
         all.retain(|s| Self::span_matches(s, query));
@@ -211,6 +274,11 @@ impl TraceRepository for InMemoryTraceRepository {
             .find(|t| t.tenant_id == tenant_id && t.trace_id == trace_id)
             .cloned();
         Ok(trace)
+    }
+
+    async fn get_trace_any_tenant(&self, trace_id: Uuid) -> Result<Option<TraceEvent>> {
+        let traces = self.traces.read().await;
+        Ok(traces.iter().find(|t| t.trace_id == trace_id).cloned())
     }
 
     async fn get_span(&self, tenant_id: TenantId, span_id: Uuid) -> Result<Option<TraceSpan>> {
@@ -668,6 +736,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
 
         repo.create_tenant(&tenant).await.unwrap();

--- a/crates/llmtrace-storage/src/migration.rs
+++ b/crates/llmtrace-storage/src/migration.rs
@@ -61,6 +61,11 @@ pub fn sqlite_migrations() -> Vec<Migration> {
             description: "add_monitoring_scope".to_string(),
             sql: include_str!("../migrations/sqlite/006_add_monitoring_scope.sql"),
         },
+        Migration {
+            version: 7,
+            description: "add_tenant_upstream".to_string(),
+            sql: include_str!("../migrations/sqlite/007_add_tenant_upstream.sql"),
+        },
     ]
 }
 

--- a/crates/llmtrace-storage/src/postgres.rs
+++ b/crates/llmtrace-storage/src/postgres.rs
@@ -111,6 +111,8 @@ impl MetadataRepository for PostgresMetadataRepository {
             plan: row.get("plan"),
             created_at: row.get("created_at"),
             config: row.get("config"),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         }))
     }
 
@@ -135,6 +137,8 @@ impl MetadataRepository for PostgresMetadataRepository {
             plan: row.get("plan"),
             created_at: row.get("created_at"),
             config: row.get("config"),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         }))
     }
 
@@ -178,6 +182,8 @@ impl MetadataRepository for PostgresMetadataRepository {
                 plan: row.get("plan"),
                 created_at: row.get("created_at"),
                 config: row.get("config"),
+                upstream_url: None,
+                upstream_api_key_ciphertext: None,
             })
             .collect())
     }
@@ -614,6 +620,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({"max_traces_per_day": 10000}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         }
     }
 

--- a/crates/llmtrace-storage/src/sqlite.rs
+++ b/crates/llmtrace-storage/src/sqlite.rs
@@ -439,6 +439,115 @@ impl SqliteTraceRepository {
 
         qb
     }
+
+    /// Build a trace-id query across ALL tenants (admin cross-tenant scope).
+    ///
+    /// Identical to [`Self::build_trace_id_query`] but without the
+    /// `tenant_id` predicate. Every other filter still applies.
+    fn build_trace_id_query_all_tenants<'args>(
+        &self,
+        query: &TraceQuery,
+    ) -> QueryBuilder<'args, Sqlite> {
+        let mut qb = QueryBuilder::<Sqlite>::new(
+            "SELECT DISTINCT s.trace_id FROM spans s              JOIN traces t ON s.trace_id = t.trace_id AND s.tenant_id = t.tenant_id              WHERE 1 = 1",
+        );
+
+        if let Some(ref trace_id) = query.trace_id {
+            qb.push(" AND s.trace_id = ");
+            qb.push_bind(trace_id.to_string());
+        }
+        if let Some(ref start) = query.start_time {
+            qb.push(" AND s.start_time >= ");
+            qb.push_bind(start.to_rfc3339());
+        }
+        if let Some(ref end) = query.end_time {
+            qb.push(" AND s.start_time <= ");
+            qb.push_bind(end.to_rfc3339());
+        }
+        if let Some(ref provider) = query.provider {
+            qb.push(" AND s.provider = ");
+            qb.push_bind(serialize_provider(provider));
+        }
+        if let Some(ref model) = query.model_name {
+            qb.push(" AND s.model_name = ");
+            qb.push_bind(model.clone());
+        }
+        if let Some(ref op) = query.operation_name {
+            qb.push(" AND s.operation_name = ");
+            qb.push_bind(op.clone());
+        }
+        if let Some(min) = query.min_security_score {
+            qb.push(" AND s.security_score >= ");
+            qb.push_bind(min as i64);
+        }
+        if let Some(max) = query.max_security_score {
+            qb.push(" AND s.security_score <= ");
+            qb.push_bind(max as i64);
+        }
+
+        qb.push(" ORDER BY t.created_at DESC");
+
+        if let Some(limit) = query.limit {
+            qb.push(" LIMIT ");
+            qb.push_bind(limit as i64);
+        }
+        if let Some(offset) = query.offset {
+            qb.push(" OFFSET ");
+            qb.push_bind(offset as i64);
+        }
+
+        qb
+    }
+
+    /// Load full trace events for a set of trace ids across all tenants.
+    async fn load_traces_for_ids_all_tenants(
+        &self,
+        trace_ids: &[String],
+    ) -> Result<Vec<TraceEvent>> {
+        if trace_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut meta_qb = QueryBuilder::<Sqlite>::new("SELECT * FROM traces WHERE trace_id IN (");
+        let mut sep = meta_qb.separated(", ");
+        for tid in trace_ids {
+            sep.push_bind(tid.clone());
+        }
+        sep.push_unseparated(") ORDER BY created_at DESC");
+
+        let meta_rows =
+            meta_qb.build().fetch_all(&self.pool).await.map_err(|e| {
+                LLMTraceError::Storage(format!("Failed to load trace metadata: {e}"))
+            })?;
+
+        let mut results = Vec::with_capacity(meta_rows.len());
+        for row in &meta_rows {
+            let tid_str: String = row.get("trace_id");
+            let trace_id = parse_uuid(&tid_str)?;
+            let tenant_id = TenantId(parse_uuid(&row.get::<String, _>("tenant_id"))?);
+            let created_at = parse_datetime(&row.get::<String, _>("created_at"))?;
+
+            let span_rows =
+                sqlx::query("SELECT * FROM spans WHERE trace_id = ?1 ORDER BY start_time ASC")
+                    .bind(&tid_str)
+                    .fetch_all(&self.pool)
+                    .await
+                    .map_err(|e| {
+                        LLMTraceError::Storage(format!("Failed to load trace spans: {e}"))
+                    })?;
+            let spans: Vec<TraceSpan> =
+                span_rows.iter().map(span_from_row).collect::<Result<_>>()?;
+
+            results.push(TraceEvent {
+                trace_id,
+                tenant_id,
+                spans,
+                created_at,
+            });
+        }
+
+        Ok(results)
+    }
 }
 
 #[async_trait]
@@ -545,6 +654,49 @@ impl TraceRepository for SqliteTraceRepository {
         }
 
         Ok(results)
+    }
+
+    async fn query_traces_all_tenants(&self, query: &TraceQuery) -> Result<Vec<TraceEvent>> {
+        let mut qb = self.build_trace_id_query_all_tenants(query);
+        let rows = qb
+            .build()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| LLMTraceError::Storage(format!("Failed to query trace IDs: {e}")))?;
+
+        let trace_ids: Vec<String> = rows.iter().map(|r| r.get("trace_id")).collect();
+        self.load_traces_for_ids_all_tenants(&trace_ids).await
+    }
+
+    async fn get_trace_any_tenant(&self, trace_id: Uuid) -> Result<Option<TraceEvent>> {
+        let row = sqlx::query("SELECT * FROM traces WHERE trace_id = ?1")
+            .bind(trace_id.to_string())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| LLMTraceError::Storage(format!("Failed to get trace: {e}")))?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        let tenant_id = TenantId(parse_uuid(&row.get::<String, _>("tenant_id"))?);
+        let created_at = parse_datetime(&row.get::<String, _>("created_at"))?;
+
+        let span_rows =
+            sqlx::query("SELECT * FROM spans WHERE trace_id = ?1 ORDER BY start_time ASC")
+                .bind(trace_id.to_string())
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| LLMTraceError::Storage(format!("Failed to load trace spans: {e}")))?;
+
+        let spans: Vec<TraceSpan> = span_rows.iter().map(span_from_row).collect::<Result<_>>()?;
+
+        Ok(Some(TraceEvent {
+            trace_id,
+            tenant_id,
+            spans,
+            created_at,
+        }))
     }
 
     async fn query_spans(&self, query: &TraceQuery) -> Result<Vec<TraceSpan>> {
@@ -787,7 +939,7 @@ impl MetadataRepository for SqliteMetadataRepository {
             .map_err(|e| LLMTraceError::Storage(format!("serialize tenant config: {e}")))?;
 
         sqlx::query(
-            "INSERT INTO tenants (id, name, api_token, plan, created_at, config) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO tenants              (id, name, api_token, plan, created_at, config, upstream_url, upstream_api_key_ciphertext)              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         )
         .bind(tenant.id.0.to_string())
         .bind(&tenant.name)
@@ -795,6 +947,8 @@ impl MetadataRepository for SqliteMetadataRepository {
         .bind(&tenant.plan)
         .bind(tenant.created_at.to_rfc3339())
         .bind(&config_json)
+        .bind(&tenant.upstream_url)
+        .bind(&tenant.upstream_api_key_ciphertext)
         .execute(&self.pool)
         .await
         .map_err(|e| LLMTraceError::Storage(format!("Failed to create tenant: {e}")))?;
@@ -826,6 +980,9 @@ impl MetadataRepository for SqliteMetadataRepository {
             plan: row.get("plan"),
             created_at: parse_datetime(&row.get::<String, _>("created_at"))?,
             config,
+            upstream_url: row.get::<Option<String>, _>("upstream_url"),
+            upstream_api_key_ciphertext: row
+                .get::<Option<String>, _>("upstream_api_key_ciphertext"),
         }))
     }
 
@@ -853,6 +1010,9 @@ impl MetadataRepository for SqliteMetadataRepository {
             plan: row.get("plan"),
             created_at: parse_datetime(&row.get::<String, _>("created_at"))?,
             config,
+            upstream_url: row.get::<Option<String>, _>("upstream_url"),
+            upstream_api_key_ciphertext: row
+                .get::<Option<String>, _>("upstream_api_key_ciphertext"),
         }))
     }
 
@@ -861,12 +1021,14 @@ impl MetadataRepository for SqliteMetadataRepository {
             .map_err(|e| LLMTraceError::Storage(format!("serialize tenant config: {e}")))?;
 
         let result = sqlx::query(
-            "UPDATE tenants SET name = ?1, plan = ?2, config = ?3, api_token = ?4 WHERE id = ?5",
+            "UPDATE tenants SET name = ?1, plan = ?2, config = ?3, api_token = ?4,              upstream_url = ?5, upstream_api_key_ciphertext = ?6 WHERE id = ?7",
         )
         .bind(&tenant.name)
         .bind(&tenant.plan)
         .bind(&config_json)
         .bind(&tenant.api_token)
+        .bind(&tenant.upstream_url)
+        .bind(&tenant.upstream_api_key_ciphertext)
         .bind(tenant.id.0.to_string())
         .execute(&self.pool)
         .await
@@ -901,6 +1063,9 @@ impl MetadataRepository for SqliteMetadataRepository {
                     plan: row.get("plan"),
                     created_at: parse_datetime(&row.get::<String, _>("created_at"))?,
                     config,
+                    upstream_url: row.get::<Option<String>, _>("upstream_url"),
+                    upstream_api_key_ciphertext: row
+                        .get::<Option<String>, _>("upstream_api_key_ciphertext"),
                 })
             })
             .collect()
@@ -1754,6 +1919,8 @@ mod tests {
             plan: "pro".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({"max_traces": 10000}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
 
         repo.create_tenant(&tenant).await.unwrap();
@@ -1788,6 +1955,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_tenant_upstream_fields_persist() {
+        let repo = test_metadata().await;
+        let tenant = Tenant {
+            id: TenantId::new(),
+            name: "Routed".to_string(),
+            api_token: "tok-routed".to_string(),
+            plan: "pro".to_string(),
+            created_at: Utc::now(),
+            config: serde_json::json!({}),
+            upstream_url: Some("https://tenant.example.com".to_string()),
+            // Opaque base64 ciphertext blob (not real, just round-tripped).
+            upstream_api_key_ciphertext: Some("Y2lwaGVydGV4dC1ibG9i".to_string()),
+        };
+        repo.create_tenant(&tenant).await.unwrap();
+
+        // get_tenant must round-trip both new columns.
+        let got = repo.get_tenant(tenant.id).await.unwrap().unwrap();
+        assert_eq!(
+            got.upstream_url.as_deref(),
+            Some("https://tenant.example.com")
+        );
+        assert_eq!(
+            got.upstream_api_key_ciphertext.as_deref(),
+            Some("Y2lwaGVydGV4dC1ibG9i")
+        );
+
+        // list_tenants must also surface them.
+        let listed = repo.list_tenants().await.unwrap();
+        let listed = listed.iter().find(|t| t.id == tenant.id).unwrap();
+        assert_eq!(
+            listed.upstream_url.as_deref(),
+            Some("https://tenant.example.com")
+        );
+        assert!(listed.upstream_api_key_ciphertext.is_some());
+
+        // update clearing both columns persists NULL.
+        let mut cleared = got.clone();
+        cleared.upstream_url = None;
+        cleared.upstream_api_key_ciphertext = None;
+        repo.update_tenant(&cleared).await.unwrap();
+        let after = repo.get_tenant(tenant.id).await.unwrap().unwrap();
+        assert!(after.upstream_url.is_none());
+        assert!(after.upstream_api_key_ciphertext.is_none());
+    }
+
+    #[tokio::test]
     async fn test_update_nonexistent_tenant_returns_error() {
         let repo = test_metadata().await;
         let tenant = Tenant {
@@ -1797,6 +2010,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         let result = repo.update_tenant(&tenant).await;
         assert!(result.is_err());
@@ -1815,6 +2030,8 @@ mod tests {
             plan: "free".to_string(),
             created_at: Utc::now(),
             config: serde_json::json!({}),
+            upstream_url: None,
+            upstream_api_key_ciphertext: None,
         };
         repo.create_tenant(&tenant).await.unwrap();
 


### PR DESCRIPTION
Proxy-side counterpart to the dashboard tenant-isolation PR. Enforces both contracts server-side and adds per-tenant provider routing. (A small follow-up commit on this branch makes `create_tenant` honor a caller-supplied `id` so the Basilica bootstrap can pin a stable tenant id across recreate — issue 9 identity.)

## Items
1. **#316 env overrides** — `apply_env_overrides` now wires `LLMTRACE_DATAMARKING_ENABLED`, `LLMTRACE_DATAMARKING_SHADOW_MODE`, `LLMTRACE_ZONE_DETECTION_ENABLED`.
2. **Per-tenant upstream (CONTRACT 1)** — `Tenant` gains `upstream_url` + `upstream_api_key_ciphertext` (write-only). Per request, upstream base URL + auth prefer the tenant override, else global. Secret encrypted at rest.
3. **Admin scope (CONTRACT 2)** — new `TenantScope { Single, All }` in request extensions. `X-LLMTrace-Tenant-ID`→Single; admin + `X-LLMTrace-Tenant-Scope: all`→All (aggregate reads); non-admin+all→403; admin+neither on a scoped read→400.
4. **#292 phantom guard** — removed per-call 'Unknown' auto-create. Header-less traffic uses `LLMTRACE_DEFAULT_TENANT_ID`; auth-on + unresolved + no default → 401; only explicitly-identified tenants are provisioned.
5. **Idempotent bootstrap (issue 9)** — `ensure_tenant_exists` + `create_tenant` get-or-create on a stable id.

## Encryption
AES-256-GCM (`aes-gcm 0.10`), master key `LLMTRACE_SECRET_ENCRYPTION_KEY` (32 bytes; 64-char hex then base64 fallback). Wire = base64(nonce||ct||tag), fresh nonce per op. **Fail-closed**: setting a per-tenant key with the master key unset/invalid → 400; proxy still boots; decrypt failure falls back to the global credential (logged).

## Verification
- `cargo fmt --all` exit 0
- `cargo clippy --workspace -- -D warnings` (exact CI command) exit 0
- `cargo test -p llmtrace-core -p llmtrace -p llmtrace-storage` exit 0 (zero failures; 28 ignored = live PG/ClickHouse)
- `cargo build --workspace` exit 0

## Scoped follow-ups (documented, not silent)
- Postgres + ClickHouse trace stores: per-tenant upstream falls back to global / all-tenants reads return a clear 'unsupported' error (fail-closed). Fully implemented for SQLite + in-memory (the deployed stores). Wire these if a PG/CH backend is adopted.