### PR TITLE
feat(core): enable cost tracking by default (cost_caps.enabled defaults true)

### DIFF
--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -2175,10 +2175,15 @@ pub struct AgentCostCap {
 }
 
 /// Top-level cost cap configuration section within [`ProxyConfig`].
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+///
+/// `enabled` defaults to `true` so spend TRACKING is on out of the box.
+/// This does NOT enforce or block any traffic: enforcement only happens when
+/// explicit budget/token caps are configured. With the empty defaults below,
+/// every cap check returns `Allowed`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CostCapConfig {
-    /// Enable cost cap enforcement.
-    #[serde(default)]
+    /// Enable cost tracking (and cap enforcement when caps are configured).
+    #[serde(default = "default_cost_caps_enabled")]
     pub enabled: bool,
     /// Default budget caps applied to all tenants/agents unless overridden.
     #[serde(default)]
@@ -2189,6 +2194,22 @@ pub struct CostCapConfig {
     /// Per-agent overrides.
     #[serde(default)]
     pub agents: Vec<AgentCostCap>,
+}
+
+/// Serde default for [`CostCapConfig::enabled`]: tracking on by default.
+fn default_cost_caps_enabled() -> bool {
+    true
+}
+
+impl Default for CostCapConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            default_budget_caps: Vec::new(),
+            default_token_cap: None,
+            agents: Vec::new(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4673,7 +4694,9 @@ mod tests {
     #[test]
     fn test_cost_cap_config_default() {
         let config = CostCapConfig::default();
-        assert!(!config.enabled);
+        // Tracking is on by default; enforcement stays off because the
+        // default caps are empty (every cap check returns Allowed).
+        assert!(config.enabled);
         assert!(config.default_budget_caps.is_empty());
         assert!(config.default_token_cap.is_none());
         assert!(config.agents.is_empty());
@@ -4713,9 +4736,30 @@ mod tests {
     }
 
     #[test]
+    fn test_cost_cap_config_enabled_defaults_true_when_section_omits_enabled() {
+        // A cost_caps section present but without an explicit `enabled`
+        // must default to true (tracking on) via default_cost_caps_enabled.
+        let config: CostCapConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.enabled);
+        assert!(config.default_budget_caps.is_empty());
+        assert!(config.default_token_cap.is_none());
+        assert!(config.agents.is_empty());
+    }
+
+    #[test]
+    fn test_cost_cap_config_explicit_false_is_honored() {
+        // An explicit `enabled: false` in config must still be honored;
+        // serde only applies the default for an ABSENT field.
+        let config: CostCapConfig = serde_json::from_str(r#"{"enabled": false}"#).unwrap();
+        assert!(!config.enabled);
+    }
+
+    #[test]
     fn test_proxy_config_default_includes_cost_caps() {
         let config = ProxyConfig::default();
-        assert!(!config.cost_caps.enabled);
+        // Tracking on by default; enforcement still off because the default
+        // budget caps are empty.
+        assert!(config.cost_caps.enabled);
         assert!(config.cost_caps.default_budget_caps.is_empty());
     }
 

--- a/crates/llmtrace-proxy/src/api.rs
+++ b/crates/llmtrace-proxy/src/api.rs
@@ -1905,7 +1905,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_costs_disabled_returns_not_found() {
-        let state = test_state().await; // cost_tracker = None
+        // cost_caps tracking is on by default now, so explicitly disable it
+        // through the live config to exercise the disabled -> 404 branch.
+        let state = test_state().await;
+        state
+            .config_handle
+            .update::<_, std::convert::Infallible>(|cfg| {
+                cfg.cost_caps.enabled = false;
+                Ok(())
+            })
+            .unwrap();
+        assert!(!state.config_handle.load().cost_caps.enabled);
         let (_, hdr) = tenant_header();
 
         let app = api_router(state);

--- a/crates/llmtrace-proxy/src/cost_caps.rs
+++ b/crates/llmtrace-proxy/src/cost_caps.rs
@@ -428,11 +428,28 @@ mod tests {
 
     // -- constructor -------------------------------------------------------
 
+    fn disabled_config() -> CostCapConfig {
+        CostCapConfig {
+            enabled: false,
+            ..CostCapConfig::default()
+        }
+    }
+
     #[test]
     fn test_disabled_config_tracker_reports_disabled() {
         let cache = make_cache();
-        let tracker = CostTracker::new(&CostCapConfig::default(), cache);
+        // CostCapConfig::default() now enables tracking, so construct an
+        // explicitly-disabled config to exercise the disabled path.
+        let tracker = CostTracker::new(&disabled_config(), cache);
         assert!(!tracker.is_enabled());
+    }
+
+    #[test]
+    fn test_default_config_tracker_reports_enabled() {
+        let cache = make_cache();
+        // Tracking is on by default (CostCapConfig::default().enabled == true).
+        let tracker = CostTracker::new(&CostCapConfig::default(), cache);
+        assert!(tracker.is_enabled());
     }
 
     #[test]
@@ -816,5 +833,35 @@ mod tests {
         let tid = TenantId::new();
         let result = tracker.check_budget_caps(tid, None).await;
         assert!(matches!(result, CapCheckResult::Allowed));
+    }
+
+    // -- default-on never enforces -----------------------------------------
+
+    #[tokio::test]
+    async fn test_cost_caps_enabled_by_default_does_not_enforce() {
+        // The default CostCapConfig has enabled=true (tracking on) but no
+        // configured caps, so every cap check must return Allowed: enabling
+        // tracking by default never blocks traffic. Enforcement requires
+        // explicitly-configured caps.
+        let config = CostCapConfig::default();
+        assert!(config.enabled);
+        assert!(config.default_budget_caps.is_empty());
+        assert!(config.default_token_cap.is_none());
+        assert!(config.agents.is_empty());
+
+        let tracker = CostTracker::new(&config, make_cache());
+        let tid = TenantId::new();
+
+        // No token cap configured -> token check always Allowed, even for
+        // absurdly large token counts.
+        let token_result =
+            tracker.check_token_caps(None, Some(u32::MAX), Some(u32::MAX), Some(u32::MAX));
+        assert!(matches!(token_result, CapCheckResult::Allowed));
+
+        // No budget caps configured -> budget check always Allowed, even
+        // after recording spend (which is a no-op without caps).
+        tracker.record_spend(tid, None, 1_000_000.0).await;
+        let budget_result = tracker.check_budget_caps(tid, None).await;
+        assert!(matches!(budget_result, CapCheckResult::Allowed));
     }
 }

--- a/crates/llmtrace-proxy/src/feature_flags_api.rs
+++ b/crates/llmtrace-proxy/src/feature_flags_api.rs
@@ -1362,7 +1362,9 @@ mod tests {
     async fn put_bulk_bumps_counter_once_per_changed_field() {
         let state = test_state().await;
         let mut flags = FeatureFlags::from_config(&state.config_handle.snapshot());
-        flags.cost_caps_enabled = true;
+        // cost_caps_enabled defaults to true now, so toggle it OFF to make a
+        // genuine, counted diff (a no-op same-value PUT would not bump).
+        flags.cost_caps_enabled = false;
         flags.over_defence = true;
         flags.enforcement_mode = "flag".to_string();
         let app = admin_router(state.clone());
@@ -1434,19 +1436,21 @@ mod tests {
             &state,
             &FeatureFlags::from_config(&state.config_handle.snapshot()),
         );
+        // cost_caps_enabled is on by default, so the gauge starts at 1.
         assert_eq!(
             state
                 .metrics
                 .feature_flag_bool_state
                 .with_label_values(&["cost_caps_enabled"])
                 .get(),
-            0
+            1
         );
         let app = admin_router(state.clone());
+        // Toggle OFF and confirm the gauge tracks the live flag down to 0.
         let _ = app
             .oneshot(admin_put(
                 "/api/v1/config/features/cost_caps_enabled",
-                serde_json::json!({"value": true}),
+                serde_json::json!({"value": false}),
             ))
             .await
             .unwrap();
@@ -1456,7 +1460,7 @@ mod tests {
                 .feature_flag_bool_state
                 .with_label_values(&["cost_caps_enabled"])
                 .get(),
-            1
+            0
         );
     }
 


### PR DESCRIPTION
Fixes the dashboard costs page showing "Cost tracking is disabled. Enable `cost_caps.enabled: true`…". The live proxy runs on `ProxyConfig::default()` + env (no config file mounted), where `CostCapConfig` defaulted `enabled=false`.

## Change
- `CostCapConfig`: manual `Default` impl with `enabled: true`, plus `#[serde(default = "default_cost_caps_enabled")]` so a `cost_caps:` section that omits `enabled` also defaults true. Covers both the code-default boot path and partial config files.
- An explicit `enabled: false` in a config is still honored (serde only defaults absent fields) — proven by test.

## Safety: tracking-only, no enforcement
Defaults keep `default_budget_caps` empty, `default_token_cap` None, `agents` empty — so nothing is ever blocked. `check_token_caps` returns Allowed with no cap; `check_budget_caps` returns Allowed with empty caps. Regression test `test_cost_caps_enabled_by_default_does_not_enforce` proves both checks return `Allowed` even at u32::MAX tokens / $1,000,000 recorded spend.

## Tests
- Updated default-asserting tests (core `test_cost_cap_config_default`, `test_proxy_config_default_includes_cost_caps`) false→true; kept empty-caps assertions.
- New: serde-default-true, explicit-false-honored, default-config-enabled, does-not-enforce.
- Preserved disabled-path coverage by explicitly disabling in `api.rs` (404 branch) and `cost_caps.rs` (disabled tracker); fixed two `feature_flags_api.rs` gauge/counter tests that assumed false-by-default.

## Verification
- `cargo fmt --all` 0; `cargo clippy --workspace -- -D warnings` 0
- `cargo test --workspace` 0 (full workspace)
- `cargo build --workspace` 0

Dashboard untouched (the message is conditional on the live flag and clears once enabled).