### PR TITLE
feat(storage): aggregate per-span cost into StorageStats.total_cost_usd (powers dashboard Total Cost)

### DIFF
--- a/crates/llmtrace-core/src/lib.rs
+++ b/crates/llmtrace-core/src/lib.rs
@@ -3390,6 +3390,8 @@ pub struct StorageStats {
     pub total_traces: u64,
     /// Total number of spans stored.
     pub total_spans: u64,
+    /// Total estimated spend in USD (sum of span estimated_cost_usd).
+    pub total_cost_usd: f64,
     /// Storage size in bytes.
     pub storage_size_bytes: u64,
     /// Oldest trace timestamp.
@@ -4360,6 +4362,7 @@ mod tests {
         let stats = StorageStats {
             total_traces: 12345,
             total_spans: 67890,
+            total_cost_usd: 42.5,
             storage_size_bytes: 1024 * 1024 * 1024, // 1GB
             oldest_trace: Some(Utc::now() - chrono::Duration::days(30)),
             newest_trace: Some(Utc::now()),
@@ -4370,6 +4373,7 @@ mod tests {
 
         assert_eq!(stats.total_traces, deserialized.total_traces);
         assert_eq!(stats.total_spans, deserialized.total_spans);
+        assert!((stats.total_cost_usd - deserialized.total_cost_usd).abs() < f64::EPSILON);
         assert_eq!(stats.storage_size_bytes, deserialized.storage_size_bytes);
     }
 

--- a/crates/llmtrace-storage/src/clickhouse.rs
+++ b/crates/llmtrace-storage/src/clickhouse.rs
@@ -81,12 +81,12 @@ struct SizeRow {
 
 /// Row type for aggregated estimated spend.
 ///
-/// `sum` over a `Nullable(Float64)` column yields a non-nullable `Float64`
-/// (0 when there are no rows / all values are NULL), so the total is always a
-/// concrete number for the dashboard.
+/// `sum` over the `Nullable(Float64)` `estimated_cost_usd` column yields a
+/// `Nullable(Float64)` (NULL when there are no rows / all values are NULL), so
+/// it must be read as `Option<f64>` and defaulted to `0.0` at the call site.
 #[derive(Debug, clickhouse::Row, Deserialize)]
 struct CostRow {
-    total_cost: f64,
+    total_cost: Option<f64>,
 }
 
 /// Row type for time-range queries on the traces table.
@@ -752,7 +752,7 @@ impl TraceRepository for ClickHouseTraceRepository {
         Ok(StorageStats {
             total_traces: trace_count.cnt,
             total_spans: span_count.cnt,
-            total_cost_usd: cost_row.total_cost,
+            total_cost_usd: cost_row.total_cost.unwrap_or(0.0),
             storage_size_bytes: size_row.sz,
             oldest_trace,
             newest_trace,
@@ -813,7 +813,7 @@ impl TraceRepository for ClickHouseTraceRepository {
         Ok(StorageStats {
             total_traces: trace_count.cnt,
             total_spans: span_count.cnt,
-            total_cost_usd: cost_row.total_cost,
+            total_cost_usd: cost_row.total_cost.unwrap_or(0.0),
             storage_size_bytes: size_row.sz,
             oldest_trace,
             newest_trace,

--- a/crates/llmtrace-storage/src/clickhouse.rs
+++ b/crates/llmtrace-storage/src/clickhouse.rs
@@ -79,6 +79,16 @@ struct SizeRow {
     sz: u64,
 }
 
+/// Row type for aggregated estimated spend.
+///
+/// `sum` over a `Nullable(Float64)` column yields a non-nullable `Float64`
+/// (0 when there are no rows / all values are NULL), so the total is always a
+/// concrete number for the dashboard.
+#[derive(Debug, clickhouse::Row, Deserialize)]
+struct CostRow {
+    total_cost: f64,
+}
+
 /// Row type for time-range queries on the traces table.
 ///
 /// Uses non-optional `DateTime64(3)` fields because ClickHouse's `min`/`max`
@@ -714,6 +724,16 @@ impl TraceRepository for ClickHouseTraceRepository {
             .await
             .map_err(|e| LLMTraceError::Storage(format!("Failed to calculate size: {e}")))?;
 
+        let cost_row: CostRow = self
+            .client
+            .query(&format!(
+                "SELECT sum(estimated_cost_usd) as total_cost \
+                 FROM spans WHERE tenant_id = {tid}"
+            ))
+            .fetch_one()
+            .await
+            .map_err(|e| LLMTraceError::Storage(format!("Failed to calculate total cost: {e}")))?;
+
         let (oldest_trace, newest_trace) = if trace_count.cnt > 0 {
             let time_row: TimeRangeRow = self
                 .client
@@ -732,6 +752,7 @@ impl TraceRepository for ClickHouseTraceRepository {
         Ok(StorageStats {
             total_traces: trace_count.cnt,
             total_spans: span_count.cnt,
+            total_cost_usd: cost_row.total_cost,
             storage_size_bytes: size_row.sz,
             oldest_trace,
             newest_trace,
@@ -763,6 +784,15 @@ impl TraceRepository for ClickHouseTraceRepository {
             .await
             .map_err(|e| LLMTraceError::Storage(format!("Failed to calculate global size: {e}")))?;
 
+        let cost_row: CostRow = self
+            .client
+            .query("SELECT sum(estimated_cost_usd) as total_cost FROM spans")
+            .fetch_one()
+            .await
+            .map_err(|e| {
+                LLMTraceError::Storage(format!("Failed to calculate global total cost: {e}"))
+            })?;
+
         let (oldest_trace, newest_trace) = if trace_count.cnt > 0 {
             let time_row: TimeRangeRow = self
                 .client
@@ -783,6 +813,7 @@ impl TraceRepository for ClickHouseTraceRepository {
         Ok(StorageStats {
             total_traces: trace_count.cnt,
             total_spans: span_count.cnt,
+            total_cost_usd: cost_row.total_cost,
             storage_size_bytes: size_row.sz,
             oldest_trace,
             newest_trace,

--- a/crates/llmtrace-storage/src/memory.rs
+++ b/crates/llmtrace-storage/src/memory.rs
@@ -339,9 +339,22 @@ impl TraceRepository for InMemoryTraceRepository {
         let oldest_trace = tenant_traces.iter().map(|t| t.created_at).min();
         let newest_trace = tenant_traces.iter().map(|t| t.created_at).max();
 
+        let trace_cost: f64 = tenant_traces
+            .iter()
+            .flat_map(|t| t.spans.iter())
+            .filter_map(|s| s.estimated_cost_usd)
+            .sum();
+        let standalone_cost: f64 = standalone
+            .iter()
+            .filter(|s| s.tenant_id == tenant_id)
+            .filter_map(|s| s.estimated_cost_usd)
+            .sum();
+        let total_cost_usd = trace_cost + standalone_cost;
+
         Ok(StorageStats {
             total_traces,
             total_spans,
+            total_cost_usd,
             storage_size_bytes: 0,
             oldest_trace,
             newest_trace,
@@ -359,9 +372,18 @@ impl TraceRepository for InMemoryTraceRepository {
         let oldest_trace = traces.iter().map(|t| t.created_at).min();
         let newest_trace = traces.iter().map(|t| t.created_at).max();
 
+        let trace_cost: f64 = traces
+            .iter()
+            .flat_map(|t| t.spans.iter())
+            .filter_map(|s| s.estimated_cost_usd)
+            .sum();
+        let standalone_cost: f64 = standalone.iter().filter_map(|s| s.estimated_cost_usd).sum();
+        let total_cost_usd = trace_cost + standalone_cost;
+
         Ok(StorageStats {
             total_traces,
             total_spans,
+            total_cost_usd,
             storage_size_bytes: 0,
             oldest_trace,
             newest_trace,
@@ -684,17 +706,51 @@ mod tests {
         assert!(storage.health_check().await.is_ok());
     }
 
+    /// Build a [`TraceEvent`] whose single span carries an explicit cost.
+    fn make_trace_with_cost(tenant_id: TenantId, cost: f64) -> TraceEvent {
+        let trace_id = Uuid::new_v4();
+        let mut span = make_span(trace_id, tenant_id);
+        span.estimated_cost_usd = Some(cost);
+        TraceEvent {
+            trace_id,
+            tenant_id,
+            spans: vec![span],
+            created_at: Utc::now(),
+        }
+    }
+
     #[tokio::test]
     async fn test_in_memory_get_stats() {
         let storage = InMemoryTraceRepository::new();
         let tenant = TenantId::new();
+        let other = TenantId::new();
 
+        storage
+            .store_trace(&make_trace_with_cost(tenant, 0.0015))
+            .await
+            .unwrap();
+        storage
+            .store_trace(&make_trace_with_cost(tenant, 0.0025))
+            .await
+            .unwrap();
+        // A span with no cost must not break the sum.
         storage.store_trace(&make_trace(tenant)).await.unwrap();
-        storage.store_trace(&make_trace(tenant)).await.unwrap();
+        // Another tenant's cost must not leak into tenant-scoped stats.
+        storage
+            .store_trace(&make_trace_with_cost(other, 1.0))
+            .await
+            .unwrap();
 
         let stats = storage.get_stats(tenant).await.unwrap();
-        assert_eq!(stats.total_traces, 2);
-        assert_eq!(stats.total_spans, 2);
+        assert_eq!(stats.total_traces, 3);
+        assert_eq!(stats.total_spans, 3);
+        assert!((stats.total_cost_usd - 0.0040).abs() < f64::EPSILON);
+
+        // Global stats aggregate across all tenants.
+        let global = storage.get_global_stats().await.unwrap();
+        assert_eq!(global.total_traces, 4);
+        assert_eq!(global.total_spans, 4);
+        assert!((global.total_cost_usd - 1.0040).abs() < f64::EPSILON);
     }
 
     #[tokio::test]

--- a/crates/llmtrace-storage/src/sqlite.rs
+++ b/crates/llmtrace-storage/src/sqlite.rs
@@ -824,6 +824,16 @@ impl TraceRepository for SqliteTraceRepository {
         .map_err(|e| LLMTraceError::Storage(format!("Failed to calculate size: {e}")))?;
         let storage_size_bytes: i64 = size_row.get("sz");
 
+        let cost_row = sqlx::query(
+            "SELECT COALESCE(SUM(estimated_cost_usd), 0.0) as total_cost \
+             FROM spans WHERE tenant_id = ?1",
+        )
+        .bind(&tid)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| LLMTraceError::Storage(format!("Failed to calculate total cost: {e}")))?;
+        let total_cost_usd: f64 = cost_row.get("total_cost");
+
         let time_row = sqlx::query(
             "SELECT MIN(created_at) as oldest, MAX(created_at) as newest \
              FROM traces WHERE tenant_id = ?1",
@@ -845,6 +855,7 @@ impl TraceRepository for SqliteTraceRepository {
         Ok(StorageStats {
             total_traces: trace_count as u64,
             total_spans: span_count as u64,
+            total_cost_usd,
             storage_size_bytes: storage_size_bytes as u64,
             oldest_trace,
             newest_trace,
@@ -873,6 +884,15 @@ impl TraceRepository for SqliteTraceRepository {
         .map_err(|e| LLMTraceError::Storage(format!("Failed to calculate global size: {e}")))?;
         let storage_size_bytes: i64 = size_row.get("sz");
 
+        let cost_row =
+            sqlx::query("SELECT COALESCE(SUM(estimated_cost_usd), 0.0) as total_cost FROM spans")
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|e| {
+                    LLMTraceError::Storage(format!("Failed to calculate global total cost: {e}"))
+                })?;
+        let total_cost_usd: f64 = cost_row.get("total_cost");
+
         let time_row =
             sqlx::query("SELECT MIN(created_at) as oldest, MAX(created_at) as newest FROM traces")
                 .fetch_one(&self.pool)
@@ -893,6 +913,7 @@ impl TraceRepository for SqliteTraceRepository {
         Ok(StorageStats {
             total_traces: trace_count as u64,
             total_spans: span_count as u64,
+            total_cost_usd,
             storage_size_bytes: storage_size_bytes as u64,
             oldest_trace,
             newest_trace,
@@ -1729,20 +1750,84 @@ mod tests {
         assert!(old_span.is_none());
     }
 
+    /// Build a [`TraceEvent`] whose single span carries an explicit cost.
+    fn make_trace_with_cost(tenant_id: TenantId, cost: f64) -> TraceEvent {
+        let trace_id = Uuid::new_v4();
+        let mut span = make_span(trace_id, tenant_id, LLMProvider::OpenAI, "gpt-4");
+        span.estimated_cost_usd = Some(cost);
+        TraceEvent {
+            trace_id,
+            tenant_id,
+            spans: vec![span],
+            created_at: Utc::now(),
+        }
+    }
+
     #[tokio::test]
     async fn test_get_stats() {
         let storage = test_storage().await;
         let tenant = TenantId::new();
 
-        storage.store_trace(&make_trace(tenant)).await.unwrap();
-        storage.store_trace(&make_trace(tenant)).await.unwrap();
+        storage
+            .store_trace(&make_trace_with_cost(tenant, 0.0015))
+            .await
+            .unwrap();
+        storage
+            .store_trace(&make_trace_with_cost(tenant, 0.0025))
+            .await
+            .unwrap();
 
         let stats = storage.get_stats(tenant).await.unwrap();
         assert_eq!(stats.total_traces, 2);
         assert_eq!(stats.total_spans, 2);
+        assert!((stats.total_cost_usd - 0.0040).abs() < f64::EPSILON);
         assert!(stats.storage_size_bytes > 0);
         assert!(stats.oldest_trace.is_some());
         assert!(stats.newest_trace.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_total_cost_ignores_null_costs() {
+        let storage = test_storage().await;
+        let tenant = TenantId::new();
+
+        // One span with a known cost, one with no cost (NULL) -> sum is the
+        // single known value, not NULL.
+        storage
+            .store_trace(&make_trace_with_cost(tenant, 0.0015))
+            .await
+            .unwrap();
+        storage.store_trace(&make_trace(tenant)).await.unwrap();
+
+        let stats = storage.get_stats(tenant).await.unwrap();
+        assert_eq!(stats.total_spans, 2);
+        assert!((stats.total_cost_usd - 0.0015).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_get_global_stats_total_cost() {
+        let storage = test_storage().await;
+        let t1 = TenantId::new();
+        let t2 = TenantId::new();
+
+        storage
+            .store_trace(&make_trace_with_cost(t1, 0.0015))
+            .await
+            .unwrap();
+        storage
+            .store_trace(&make_trace_with_cost(t2, 0.0025))
+            .await
+            .unwrap();
+
+        // Tenant-scoped stats only see that tenant's cost.
+        let t1_stats = storage.get_stats(t1).await.unwrap();
+        assert!((t1_stats.total_cost_usd - 0.0015).abs() < f64::EPSILON);
+
+        // Global stats aggregate across all tenants.
+        let global = storage.get_global_stats().await.unwrap();
+        assert_eq!(global.total_traces, 2);
+        assert_eq!(global.total_spans, 2);
+        assert!((global.total_cost_usd - 0.0040).abs() < f64::EPSILON);
     }
 
     #[tokio::test]
@@ -1752,6 +1837,7 @@ mod tests {
         let stats = storage.get_stats(tenant).await.unwrap();
         assert_eq!(stats.total_traces, 0);
         assert_eq!(stats.total_spans, 0);
+        assert_eq!(stats.total_cost_usd, 0.0);
         assert_eq!(stats.storage_size_bytes, 0);
         assert!(stats.oldest_trace.is_none());
     }


### PR DESCRIPTION
Completes cost tracking end-to-end (follow-up to #333/#334). Every span already carries `estimated_cost_usd`, but `StorageStats` had no cost field, so the dashboard 'Total Cost' card showed '—'. This sums per-span cost into the stats the dashboard reads.

## Change
- core: add `StorageStats.total_cost_usd: f64` (non-Option; 0.0 when no cost data, serializes as a number, ToSchema/OpenAPI included).
- sqlite `get_stats`/`get_global_stats`: `COALESCE(SUM(estimated_cost_usd), 0.0)` (tenant-scoped / unscoped).
- in-memory `get_stats`/`get_global_stats`: `filter_map(estimated_cost_usd).sum()` over traces' spans + standalone spans.
- clickhouse `get_stats`/`get_global_stats`: `sum(estimated_cost_usd)` (compile/clippy-verified; no live CH in env).
- postgres: metadata-only, stores no spans — no StorageStats/get_stats there, unchanged.

## Tests
- sqlite: sum (0.0015+0.0025=0.0040), NULL-cost ignored (0.0015), global vs tenant-scoped isolation, empty tenant = 0.0.
- memory: tenant sum + NULL-skip + second-tenant isolation + global.
- core: serialization round-trip includes the field.

## Verification
- `cargo fmt --all` 0; `cargo clippy --workspace -- -D warnings` 0
- `cargo test --workspace` 0; `cargo build --workspace` 0

Dashboard already expects `stats.total_cost_usd` (TS + Total Cost card); no dashboard change needed. Will be live-validated after merge+redeploy.