### PR TITLE
ci(publish-images): rebuild on baked config changes (config.example.yaml et al)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -25,6 +25,10 @@ on:
       - "Dockerfile"
       - "dashboard/**"
       - ".github/workflows/publish-images.yml"
+      # Baked into the proxy image — a change alters image content but is not
+      # under crates/** or dashboard/**, so it must trigger a rebuild too.
+      - "config.example.yaml" # Dockerfile: COPY config.example.yaml /etc/llmtrace/config.yaml
+      - "benchmarks/**" # Dockerfile: COPY benchmarks/ (workspace member built into the proxy binary)
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Closes the gap that made #334 (a config-only change) merge without rebuilding the image: `publish-images.yml` only triggered on `crates/**`, `Cargo.{toml,lock}`, `Dockerfile`, `dashboard/**`, and itself — but the proxy image bakes `config.example.yaml` (`COPY config.example.yaml /etc/llmtrace/config.yaml`) and runs `--config` on it, so config-only changes silently skipped the rebuild.

## Change (publish-images.yml push paths only)
- `config.example.yaml` — baked into the proxy image (Dockerfile:67).
- `benchmarks/**` — workspace member compiled in the proxy build (Dockerfile COPY).

Audited every host-context `COPY` in both Dockerfiles; all others are already covered by `crates/**`/`dashboard/**`/`Cargo.*`. No other workflow changes. YAML validated.