### PR TITLE
fix(dashboard): reconcile stale tenant selection + notify sidebar on config save

### DIFF
--- a/dashboard/src/app/tenants/_client.tsx
+++ b/dashboard/src/app/tenants/_client.tsx
@@ -228,6 +228,9 @@ export default function TenantsClient() {
       if (configUpstreamKey.trim() !== "") setConfigUpstreamKeySet(true);
       setConfigUpstreamKey("");
       setConfigSuccess(true);
+      // A config save may rename the tenant — refresh the sidebar selector so
+      // its option label stays in sync without a full page reload (issue 7).
+      notifyTenantsChanged();
       setTimeout(() => {
         setConfigSuccess(false);
         setEditingConfig(null);

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -64,13 +64,17 @@ export function Sidebar() {
       ) {
         setSelectedTenant(stored);
       } else if (data.length > 0) {
-        // If we have tenants but none stored, pick the first one from DB
+        // Either nothing is stored, or the stored tenant no longer exists
+        // (e.g. it was just deleted). Fall back to the first tenant AND
+        // reconcile localStorage so later API calls don't keep sending the
+        // stale/dead tenant id in X-LLMTrace-Tenant-ID (issue 7).
         setSelectedTenant(data[0].id);
-        if (!stored) setStoredTenant(data[0].id);
+        setStoredTenant(data[0].id);
       } else {
-        // Fallback to nil tenant if no tenants exist in DB
+        // No tenants exist in the DB — fall back to the nil tenant and clear
+        // any stale stored id so reads don't scope to a non-existent tenant.
         setSelectedTenant(DEFAULT_TENANT_ID);
-        if (!stored) setStoredTenant(DEFAULT_TENANT_ID);
+        setStoredTenant(DEFAULT_TENANT_ID);
       }
     } catch (e) {
       console.error("Failed to load tenants in sidebar", e);


### PR DESCRIPTION
Round-2 UI audit (#4). Dark-mode and per-tenant cred form audited **clean** (no changes); two real auto-refresh/selection bugs fixed.

## Fixes
- **Stale tenant id in localStorage (sidebar.tsx).** When the stored tenant was deleted, the sidebar showed the first tenant but the `if (!stored)` guard kept the dead id in localStorage, so `tenantScopeHeaders()` kept sending a dead `X-LLMTrace-Tenant-ID` on every API call. Now localStorage is always reconciled to a valid selection. The first branch still preserves `__all__` (all-tenants) and `DEFAULT_TENANT_ID`, so those selections are not clobbered.
- **Config/rename didn't refresh the sidebar (tenants/_client.tsx).** `handleSaveConfig` only refreshed the page-local list; the navbar selector kept the stale name until reload. Added `notifyTenantsChanged()` so the rename propagates (create already did; delete reloads).

## Audited clean (no churn)
- Dark-mode: 0 hardcoded color literals / palette classes / non-token hsl across app + components (print-scoped utilities excluded).
- Per-tenant cred form: blank URL→null (inherit), blank key on edit leaves stored secret unchanged, password input, GET exposes only `upstream_api_key_set`, secret never rendered/logged.

## Verification
- `npm run lint` 0, `npm run build` 0, `npx tsc --noEmit` 0. No e2e selectors changed (valid-stored test branch untouched).