### PR TITLE
feat(deploy): catch-all tenant at provision + remove hardcoded tenant ids from pro.yaml

### DIFF
--- a/deployments/basilica/cli.py
+++ b/deployments/basilica/cli.py
@@ -205,6 +205,8 @@ def _serialise(instances: lifecycle.TenantInstances) -> dict[str, Any]:
         "api_key": instances.api_key,
         "admin_key": instances.admin_key,
         "admin_username": instances.admin_username,
+        "operator_tenant_id": instances.operator_tenant_id,
+        "catch_all_tenant_id": instances.catch_all_tenant_id,
     }
 
 

--- a/deployments/basilica/configs/examples/pro.yaml
+++ b/deployments/basilica/configs/examples/pro.yaml
@@ -32,13 +32,16 @@
 #      restart 404s on a freshly-provisioned deployment until its k8s CR
 #      materialises. Treat as a stopgap, not a guarantee.
 #
-# tenant_uuid: the STABLE internal tenant id reused across redeploys. The
-# lifecycle library sends it as the `id` on POST /api/v1/tenants so the proxy
-# keeps the SAME tenant id every recreate (the proxy honours an explicit id on
-# create — idempotent create). MUST be a valid UUID. Override via the
-# LLMTRACE_TENANT_UUID env var; the default below is the dashboard's canonical
-# default tenant id so the bootstrapped tenant and the dashboard fallback align.
-tenant_uuid: "${LLMTRACE_TENANT_UUID:-6ae1ab34-02d8-5b68-ad6f-132bf4de8408}"
+# tenant_uuid: the STABLE internal operator tenant id, CALLER-PROVIDED for a
+# stable identity across redeploys. The lifecycle library sends it as the `id`
+# on POST /api/v1/tenants so the proxy keeps the SAME tenant id every recreate
+# (the proxy honours an explicit id on create — idempotent create). Supply it
+# via the LLMTRACE_TENANT_UUID env var (a valid UUID). There is NO hardcoded
+# default: when empty, the lifecycle generates a fresh uuid4 at provision,
+# uses it, and RETURNS it as `operator_tenant_id` — but that id is EPHEMERAL
+# (identity will NOT survive recreate) unless you persist it and re-pass it
+# here on the next provision/update.
+tenant_uuid: "${LLMTRACE_TENANT_UUID:-}"
 
 proxy:
   image: "ghcr.io/techlab-innov/llmtrace-proxy:${LLMTRACE_VERSION:-latest}"
@@ -93,10 +96,12 @@ proxy:
     LLMTRACE_DATAMARKING_ENABLED: "true"
     LLMTRACE_DATAMARKING_SHADOW_MODE: "false"
     LLMTRACE_ZONE_DETECTION_ENABLED: "true"
-    # Explicit default tenant for header-less /v1 traffic (issue #292): the
-    # proxy stamps this id instead of creating a phantom tenant per call.
-    # Matches `tenant_uuid` above so the default path stays consistent.
-    LLMTRACE_DEFAULT_TENANT_ID: "${LLMTRACE_DEFAULT_TENANT_ID:-6ae1ab34-02d8-5b68-ad6f-132bf4de8408}"
+    # Catch-all tenant for header-less /v1 traffic (issue #292): the proxy
+    # stamps this id instead of creating a phantom tenant per call. NOT a
+    # fixed id — the lifecycle generates a fresh catch-all uuid4 at provision,
+    # sets it on this env, and creates the matching `catch-all` tenant row
+    # (returned as `catch_all_tenant_id`). If left unset, the proxy
+    # self-provisions one at startup. Do NOT hardcode it here.
     # Master key (32 bytes; 64-char hex or base64) used to encrypt per-tenant
     # upstream API keys at rest. MUST be stable across recreates or stored
     # ciphertext becomes undecryptable. Unset => per-tenant key writes fail

--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -32,6 +32,7 @@ import secrets as _secrets
 import time
 import urllib.error
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
@@ -127,6 +128,16 @@ AUTH_KEYS_PATH = "/api/v1/auth/keys"
 OPERATOR_KEY_NAME = "tenant-runtime"
 # How long we'll wait on an admin HTTP call before bailing.
 ADMIN_HTTP_TIMEOUT_SECONDS = 30
+
+# Proxy env var holding the catch-all tenant id stamped on header-less `/v1`
+# traffic (issue #292). The lifecycle generates a FRESH id at provision time
+# and sets this on the proxy env BEFORE the proxy is created so the proxy
+# reads it at startup. The proxy self-provisions a catch-all if this is unset
+# (Option B, owned by a separate change); we coordinate via this var only.
+DEFAULT_TENANT_ID_ENV = "LLMTRACE_DEFAULT_TENANT_ID"
+# Human-readable label applied to the catch-all tenant row created in the
+# proxy DB. The separate proxy change keys off this name too.
+CATCH_ALL_TENANT_LABEL = "catch-all"
 
 
 def generate_api_key() -> str:
@@ -293,15 +304,18 @@ class TenantSpec:
     tenant_id: str
     proxy: ComponentSpec
     dashboard: ComponentSpec
-    # Stable internal tenant UUID to reuse across redeploys. When set, the
-    # lifecycle layer sends it as the `id` field on `POST /api/v1/tenants`
-    # so the proxy reuses the SAME tenant id every recreate instead of
-    # minting a fresh UUID (requires the proxy to honour an explicit id on
-    # create — idempotent-create is owned by the proxy; until then the field
-    # is ignored server-side, which is harmless). None means "let the proxy
-    # mint a UUID" (legacy behaviour, identity NOT stable across recreate).
-    # Format is the caller's choice (e.g. `user-uuid-<uuid>`); the proxy
-    # validates / canonicalises it.
+    # Stable internal operator tenant UUID to reuse across redeploys. When
+    # supplied, the lifecycle layer sends it as the `id` field on
+    # `POST /api/v1/tenants` so the proxy reuses the SAME tenant id every
+    # recreate (requires the proxy to honour an explicit id on create —
+    # idempotent-create is owned by the proxy; until then the field is
+    # ignored server-side, which is harmless). When None/empty, `provision`
+    # generates a fresh `uuid.uuid4()`, uses it, RETURNS it in
+    # `TenantInstances.operator_tenant_id`, and logs a WARNING that the id is
+    # ephemeral — identity will NOT survive recreate unless the caller stores
+    # and re-passes it. There is no hardcoded fallback id. Format is the
+    # caller's choice (e.g. `user-uuid-<uuid>`); the proxy validates /
+    # canonicalises it.
     tenant_uuid: Optional[str] = None
     proxy_name_template: str = DEFAULT_PROXY_NAME_TEMPLATE
     dashboard_name_template: str = DEFAULT_DASHBOARD_NAME_TEMPLATE
@@ -387,6 +401,18 @@ class TenantInstances:
     # checked against `LLMTRACE_DASHBOARD_ADMIN_USERNAME`). Defaults to
     # "admin"; set per-tenant via `TenantSpec.admin_username`.
     admin_username: Optional[str] = None
+    # Operator tenant UUID the proxy assigned/honoured for this deployment.
+    # When the caller left `TenantSpec.tenant_uuid` empty the lifecycle
+    # generates a fresh one; the caller MUST persist and re-pass this value
+    # to keep tenant identity stable across recreate. None when proxy auth is
+    # disabled (no tenant row is materialised).
+    operator_tenant_id: Optional[str] = None
+    # Catch-all tenant UUID generated at provision time and set on the proxy
+    # env as `LLMTRACE_DEFAULT_TENANT_ID` so header-less `/v1` traffic is
+    # attributed to one stable tenant instead of spawning a phantom per call.
+    # Generated fresh each provision; None when proxy auth is disabled or on
+    # status/deprovision paths.
+    catch_all_tenant_id: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -641,6 +667,45 @@ def _resolve_api_key(spec: TenantSpec) -> Optional[str]:
     if env_key:
         return env_key
     return generate_api_key()
+
+
+def _resolve_operator_tenant_id(spec: TenantSpec) -> str:
+    """Resolve the operator tenant UUID. Caller-owned, never hardcoded.
+
+    When `spec.tenant_uuid` is supplied (env `LLMTRACE_TENANT_UUID` /
+    config `tenant_uuid`), it is used verbatim so identity is stable across
+    recreate. When empty/absent, a fresh `uuid.uuid4()` is generated and a
+    WARNING is emitted: the id is ephemeral and tenant identity will NOT
+    survive recreate unless the caller stores and re-passes it. There is no
+    hardcoded fallback.
+    """
+    supplied = (spec.tenant_uuid or "").strip()
+    if supplied:
+        return supplied
+    generated = str(uuid.uuid4())
+    LOGGER.warning(
+        "tenant=%s: no tenant_uuid supplied (LLMTRACE_TENANT_UUID / config "
+        "tenant_uuid empty); generated ephemeral operator tenant id %s. "
+        "This identity will NOT survive recreate unless you persist this id "
+        "and re-pass it as tenant_uuid on the next provision/update.",
+        spec.tenant_id,
+        generated,
+    )
+    return generated
+
+
+def _apply_catch_all_tenant_env(
+    proxy_spec: ComponentSpec, catch_all_id: str
+) -> ComponentSpec:
+    """Set `LLMTRACE_DEFAULT_TENANT_ID` on the proxy env to the catch-all id.
+
+    The lifecycle owns this id (generated fresh per provision), so it
+    overwrites any caller-supplied value — same precedence model as
+    `_apply_proxy_auth` / `_apply_rate_limit`. Must run BEFORE the proxy is
+    created so the proxy reads the catch-all id at startup.
+    """
+    env = {**proxy_spec.env, DEFAULT_TENANT_ID_ENV: catch_all_id}
+    return dataclasses.replace(proxy_spec, env=env)
 
 
 def _apply_proxy_auth(
@@ -1040,19 +1105,32 @@ def provision(
     1. Resolves a bootstrap admin key (explicit `spec.api_key` > existing
        `LLMTRACE_AUTH_ADMIN_KEY` in proxy env > auto-generated). Injects
        it into both proxy and dashboard envs as `LLMTRACE_AUTH_ADMIN_KEY`.
-    2. Creates the proxy and waits for it to become ready.
-    3. Calls `POST /api/v1/tenants` on the live proxy to materialise a
-       tenant row (the operator-key mint requires the tenant to exist).
-    4. Calls `POST /api/v1/auth/keys` to mint a scoped Operator-role key
+    2. Generates a FRESH catch-all tenant id (`uuid.uuid4()`, never
+       hardcoded) and sets it on the proxy env as
+       `LLMTRACE_DEFAULT_TENANT_ID` BEFORE the proxy is created so the proxy
+       reads it at startup.
+    3. Creates the proxy and waits for it to become ready.
+    4. Resolves the operator tenant id from the caller (`spec.tenant_uuid`,
+       stable across recreate) or generates a fresh `uuid.uuid4()` and warns
+       that the identity is ephemeral. Calls `POST /api/v1/tenants` on the
+       live proxy to materialise the operator tenant row (the operator-key
+       mint requires the tenant to exist).
+    5. Calls `POST /api/v1/auth/keys` to mint a scoped Operator-role key
        named `tenant-runtime`. This is the key the tenant gets.
-    5. Deploys the dashboard. Only the admin key is in the dashboard env
+    6. Calls the same idempotent `POST /api/v1/tenants` with the explicit
+       catch-all id from step 2 to materialise a tenant row named
+       `catch-all`, so header-less `/v1` traffic resolves to a real tenant.
+    7. Deploys the dashboard. Only the admin key is in the dashboard env
        because the dashboard's only call path today is the proxy's admin
        endpoints; the operator key is returned to the caller for the
        tenant's external runtime apps.
 
     Returns both keys: `api_key` is the operator key (runtime traffic);
     `admin_key` is the bootstrap admin key (retained by the caller for
-    self-service / admin portal use, never given to tenants).
+    self-service / admin portal use, never given to tenants). Also returns
+    `operator_tenant_id` (caller-supplied or freshly generated — persist and
+    re-pass to keep identity stable) and `catch_all_tenant_id` (freshly
+    generated each provision).
     """
     tenant_id = validate_tenant_id(spec.tenant_id)
     client = client or make_client()
@@ -1068,6 +1146,14 @@ def provision(
         )
     if spec.rate_limit is not None:
         proxy_spec = _apply_rate_limit(proxy_spec, spec.rate_limit)
+    # Generate a FRESH catch-all tenant id (never hardcoded) and set it on the
+    # proxy env BEFORE the proxy is created so the proxy reads it at startup.
+    # Only meaningful when proxy auth is on (the catch-all tenant row is
+    # materialised via the admin API after the proxy is healthy).
+    catch_all_tenant_id: Optional[str] = None
+    if admin_key is not None:
+        catch_all_tenant_id = str(uuid.uuid4())
+        proxy_spec = _apply_catch_all_tenant_env(proxy_spec, catch_all_tenant_id)
     # Repoint the sqlite DB onto the persistent mount (if attached) BEFORE
     # creating the proxy so the very first boot writes to the durable path.
     proxy_spec = _apply_persistent_db_path(proxy_spec)
@@ -1095,14 +1181,27 @@ def provision(
             proxy = rotation.proxy
             admin_key = rotation.admin_key
 
-        # Pass the stable internal tenant id so the proxy reuses the SAME
-        # tenant id across redeploys (identity persists when the proxy honours
-        # an explicit id on create — owned by the proxy). We still trust the
-        # returned id, so this is correct whether or not the proxy honours it.
+        # Resolve the operator tenant id from the caller (stable across
+        # recreate) or generate a fresh one and warn that it's ephemeral.
+        # Never hardcoded. Passed as the stable `id` so the proxy reuses the
+        # SAME tenant id across redeploys when it honours an explicit id on
+        # create. We still trust the returned id, so this is correct whether
+        # or not the proxy honours it.
+        operator_tenant_id = _resolve_operator_tenant_id(spec)
         tenant_uuid = _bootstrap_tenant_in_proxy(
-            proxy.url, admin_key, tenant_id, stable_id=spec.tenant_uuid
+            proxy.url, admin_key, tenant_id, stable_id=operator_tenant_id
         )
         operator_key = _mint_operator_key(proxy.url, admin_key, tenant_uuid)
+        # Materialise the catch-all tenant row in the proxy DB using the SAME
+        # idempotent POST /api/v1/tenants path with the explicit id we set on
+        # the proxy env above, so header-less /v1 traffic resolves to a real
+        # tenant. The returned id is authoritative; pin our record to it.
+        catch_all_tenant_id = _bootstrap_tenant_in_proxy(
+            proxy.url,
+            admin_key,
+            CATCH_ALL_TENANT_LABEL,
+            stable_id=catch_all_tenant_id,
+        )
     else:
         tenant_uuid = None
 
@@ -1138,6 +1237,8 @@ def provision(
         api_key=operator_key,
         admin_key=admin_key,
         admin_username=spec.admin_username,
+        operator_tenant_id=tenant_uuid,
+        catch_all_tenant_id=catch_all_tenant_id,
     )
 
 

--- a/deployments/basilica/tests/test_catchall_and_operator_tenant.py
+++ b/deployments/basilica/tests/test_catchall_and_operator_tenant.py
@@ -1,0 +1,369 @@
+"""Tests for the provision-time catch-all tenant and operator-tenant sourcing.
+
+Scope:
+- `provision()` generates a fresh catch-all uuid, sets it on the proxy env as
+  `LLMTRACE_DEFAULT_TENANT_ID` BEFORE the proxy is created, materialises a
+  `catch-all` tenant row via `POST /api/v1/tenants`, and returns the id.
+- The operator tenant id is caller-owned: a supplied `tenant_uuid` is used as
+  the stable `id`; an empty one is freshly generated, used, returned, and a
+  WARNING is logged.
+- A guard test asserting the previously-hardcoded UUID `6ae1ab34...` appears
+  nowhere in `pro.yaml`.
+
+The proxy admin API is a real in-process `http.server` (reused pattern from
+`test_operator_key_minting`); the Basilica SDK is a fake client. We never hit
+a real backend.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Callable, Optional
+
+import pytest
+
+from deployments.basilica import lifecycle
+
+
+# ---------------------------------------------------------------------------
+# In-process fake proxy admin API (mirrors test_operator_key_minting)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    responder: Callable[[str, str, dict[str, str], bytes], tuple[int, dict[str, Any]]]
+    recorded: list[dict[str, Any]]
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    def _dispatch(self, method: str) -> None:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length) if length else b""
+        headers = {k.lower(): v for k, v in self.headers.items()}
+        self.recorded.append(
+            {"method": method, "path": self.path, "headers": headers, "body": body}
+        )
+        status, payload = self.responder(method, self.path, headers, body)
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._dispatch("GET")
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._dispatch("POST")
+
+
+class FakeProxy:
+    def __init__(
+        self,
+        responder: Callable[[str, str, dict[str, str], bytes], tuple[int, dict[str, Any]]],
+    ) -> None:
+        self.recorded: list[dict[str, Any]] = []
+        handler_cls = type(
+            "Handler",
+            (_RecordingHandler,),
+            {"responder": staticmethod(responder), "recorded": self.recorded},
+        )
+        self.server = HTTPServer(("127.0.0.1", 0), handler_cls)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+
+@pytest.fixture
+def fake_proxy() -> Any:
+    servers: list[FakeProxy] = []
+
+    def make(responder: Callable[..., tuple[int, dict[str, Any]]]) -> FakeProxy:
+        s = FakeProxy(responder)
+        servers.append(s)
+        return s
+
+    yield make
+    for s in servers:
+        s.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Fake Basilica client
+# ---------------------------------------------------------------------------
+
+
+class _FakeReplicas:
+    def __init__(self, ready: int, desired: int) -> None:
+        self.ready = ready
+        self.desired = desired
+
+
+class _FakeDetail:
+    def __init__(self, instance_name: str, url: str) -> None:
+        self.instance_name = instance_name
+        self.state = "running"
+        self.url = url
+        self.replicas = _FakeReplicas(1, 1)
+        self.phase = "ready"
+        self.message = None
+
+
+class _FakeBasilicaClient:
+    def __init__(self, proxy_url: str, dashboard_url: str) -> None:
+        self.proxy_url = proxy_url
+        self.dashboard_url = dashboard_url
+        self.creates: list[dict[str, Any]] = []
+
+    def create_deployment(self, **kwargs: Any) -> _FakeDetail:
+        name = kwargs.get("instance_name", "")
+        self.creates.append(kwargs)
+        if "proxy" in name:
+            return _FakeDetail(instance_name="proxy-uuid", url=self.proxy_url)
+        return _FakeDetail(instance_name="dash-uuid", url=self.dashboard_url)
+
+    def get_deployment(self, instance_name: str) -> _FakeDetail:
+        if instance_name == "proxy-uuid":
+            return _FakeDetail(instance_name="proxy-uuid", url=self.proxy_url)
+        return _FakeDetail(instance_name="dash-uuid", url=self.dashboard_url)
+
+
+ADMIN_KEY = "llmt_" + "a" * 64
+OPERATOR_KEY = "llmt_" + "b" * 64
+
+
+def _proxy_spec() -> lifecycle.ComponentSpec:
+    return lifecycle.ComponentSpec(
+        image="ghcr.io/example/proxy:latest",
+        port=8080,
+        cpu="1",
+        memory="1Gi",
+        replicas=1,
+        env={"LLMTRACE_UPSTREAM_URL": "https://upstream.example"},
+    )
+
+
+def _dashboard_spec() -> lifecycle.ComponentSpec:
+    return lifecycle.ComponentSpec(
+        image="ghcr.io/example/dashboard:latest",
+        port=3000,
+        cpu="1",
+        memory="1Gi",
+        replicas=1,
+        env={"HOSTNAME": "0.0.0.0"},
+    )
+
+
+def _echo_id_responder(
+    tenants_seen: list[dict[str, Any]],
+) -> Callable[..., tuple[int, dict[str, Any]]]:
+    """Responder that echoes the posted tenant `id` (or mints one) so the
+    lifecycle's "trust the returned id" path is exercised faithfully.
+
+    Records each `POST /api/v1/tenants` body into `tenants_seen` so tests can
+    assert which tenants were created (operator + catch-all) and with which
+    explicit ids.
+    """
+
+    def responder(
+        method: str, path: str, headers: dict[str, str], body: bytes
+    ) -> tuple[int, dict[str, Any]]:
+        if method == "POST" and path == "/api/v1/tenants":
+            decoded = json.loads(body)
+            tenants_seen.append(decoded)
+            tenant_id = decoded.get("id") or str(uuid.uuid4())
+            return 201, {
+                "id": tenant_id,
+                "name": decoded.get("name"),
+                "plan": decoded.get("plan", "default"),
+                "config": {},
+            }
+        if method == "POST" and path == "/api/v1/auth/keys":
+            return 201, {
+                "id": "key-uuid",
+                "key": OPERATOR_KEY,
+                "key_prefix": OPERATOR_KEY[:8],
+                "tenant_id": json.loads(body).get("tenant_id"),
+                "role": "operator",
+            }
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    return responder
+
+
+# ---------------------------------------------------------------------------
+# Catch-all tenant at provision (Option A)
+# ---------------------------------------------------------------------------
+
+
+def test_provision_generates_sets_creates_and_returns_catch_all(
+    fake_proxy: Any,
+) -> None:
+    tenants_seen: list[dict[str, Any]] = []
+    proxy = fake_proxy(_echo_id_responder(tenants_seen))
+    client = _FakeBasilicaClient(proxy.url, "https://dashboard.example")
+
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_dashboard_spec(),
+        api_key=ADMIN_KEY,
+        tenant_uuid="33333333-3333-4333-8333-333333333333",
+    )
+    result = lifecycle.provision(spec, client=client)
+
+    # A fresh catch-all id was returned, distinct from the operator tenant id.
+    assert result.catch_all_tenant_id
+    uuid.UUID(result.catch_all_tenant_id)  # parses as a real uuid
+    assert result.catch_all_tenant_id != result.operator_tenant_id
+
+    # It was set on the proxy env BEFORE create (so the proxy reads it at boot).
+    proxy_create = next(c for c in client.creates if "proxy" in c["instance_name"])
+    assert (
+        proxy_create["env"]["LLMTRACE_DEFAULT_TENANT_ID"]
+        == result.catch_all_tenant_id
+    )
+
+    # The catch-all tenant row was created via POST /api/v1/tenants with the
+    # explicit id and the "catch-all" label.
+    catch_all_posts = [
+        t
+        for t in tenants_seen
+        if t.get("name") == lifecycle.CATCH_ALL_TENANT_LABEL
+    ]
+    assert len(catch_all_posts) == 1
+    assert catch_all_posts[0]["id"] == result.catch_all_tenant_id
+
+    # Exactly two tenant rows are created: the operator tenant and catch-all.
+    assert len(tenants_seen) == 2
+
+
+def test_provision_no_catch_all_when_auth_disabled(fake_proxy: Any) -> None:
+    def responder(
+        method: str, path: str, headers: dict[str, str], body: bytes
+    ) -> tuple[int, dict[str, Any]]:
+        raise AssertionError(f"no HTTP call expected: {method} {path}")
+
+    proxy = fake_proxy(responder)
+    client = _FakeBasilicaClient(proxy.url, "https://dashboard.example")
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_dashboard_spec(),
+        enable_proxy_auth=False,
+    )
+    result = lifecycle.provision(spec, client=client)
+
+    assert result.catch_all_tenant_id is None
+    assert result.operator_tenant_id is None
+    proxy_create = next(c for c in client.creates if "proxy" in c["instance_name"])
+    assert "LLMTRACE_DEFAULT_TENANT_ID" not in proxy_create["env"]
+
+
+# ---------------------------------------------------------------------------
+# Operator tenant id sourcing (caller-owned, no hardcode)
+# ---------------------------------------------------------------------------
+
+
+def test_supplied_tenant_uuid_is_used_as_stable_id(fake_proxy: Any) -> None:
+    supplied = "44444444-4444-4444-8444-444444444444"
+    tenants_seen: list[dict[str, Any]] = []
+    proxy = fake_proxy(_echo_id_responder(tenants_seen))
+    client = _FakeBasilicaClient(proxy.url, "https://dashboard.example")
+
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_dashboard_spec(),
+        api_key=ADMIN_KEY,
+        tenant_uuid=supplied,
+    )
+    result = lifecycle.provision(spec, client=client)
+
+    assert result.operator_tenant_id == supplied
+    operator_posts = [t for t in tenants_seen if t.get("name") == "acme"]
+    assert len(operator_posts) == 1
+    assert operator_posts[0]["id"] == supplied
+
+
+def test_empty_tenant_uuid_generates_used_returned_and_warns(
+    fake_proxy: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    tenants_seen: list[dict[str, Any]] = []
+    proxy = fake_proxy(_echo_id_responder(tenants_seen))
+    client = _FakeBasilicaClient(proxy.url, "https://dashboard.example")
+
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_dashboard_spec(),
+        api_key=ADMIN_KEY,
+        tenant_uuid=None,  # caller did not supply one
+    )
+    with caplog.at_level(logging.WARNING, logger=lifecycle.LOGGER.name):
+        result = lifecycle.provision(spec, client=client)
+
+    # A fresh uuid was generated and returned.
+    assert result.operator_tenant_id
+    uuid.UUID(result.operator_tenant_id)
+    # It was actually used as the explicit `id` for the operator tenant row.
+    operator_posts = [t for t in tenants_seen if t.get("name") == "acme"]
+    assert len(operator_posts) == 1
+    assert operator_posts[0]["id"] == result.operator_tenant_id
+    # A clear ephemeral-identity warning was emitted.
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("ephemeral" in m.lower() for m in warnings)
+
+
+def test_resolve_operator_tenant_id_treats_whitespace_as_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    spec = lifecycle.TenantSpec(
+        tenant_id="acme",
+        proxy=_proxy_spec(),
+        dashboard=_dashboard_spec(),
+        tenant_uuid="   ",
+    )
+    with caplog.at_level(logging.WARNING, logger=lifecycle.LOGGER.name):
+        resolved = lifecycle._resolve_operator_tenant_id(spec)
+    uuid.UUID(resolved)  # generated a real uuid rather than using whitespace
+    assert any(
+        "ephemeral" in r.message.lower()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard: no hardcoded tenant UUID remains in pro.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_pro_yaml_has_no_hardcoded_tenant_uuid() -> None:
+    pro_yaml = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "configs"
+        / "examples"
+        / "pro.yaml"
+    )
+    text = pro_yaml.read_text()
+    assert "6ae1ab34" not in text, (
+        "the previously-hardcoded catch-all/default tenant UUID must not "
+        "appear anywhere in pro.yaml"
+    )

--- a/deployments/basilica/tests/test_persistent_storage.py
+++ b/deployments/basilica/tests/test_persistent_storage.py
@@ -281,12 +281,15 @@ class _FakeBasilicaClient:
 def test_provision_attaches_storage_and_repoints_db_and_sends_stable_id(
     fake_proxy: Any,
 ) -> None:
-    seen: dict[str, Any] = {}
+    seen: dict[str, Any] = {"tenant_bodies": []}
 
     def responder(method: str, path: str, headers: dict[str, str], body: bytes):
         if method == "POST" and path == "/api/v1/tenants":
-            seen["tenant_body"] = json.loads(body)
-            return 201, {"id": _RETURNED_UUID, "name": "acme"}
+            decoded = json.loads(body)
+            seen["tenant_bodies"].append(decoded)
+            # Echo the posted id so the operator and catch-all rows resolve
+            # to their explicit ids (the catch-all carries a fresh uuid).
+            return 201, {"id": decoded.get("id") or _RETURNED_UUID, "name": decoded.get("name")}
         if method == "POST" and path == "/api/v1/auth/keys":
             return 201, {"key": "llmt_" + "b" * 64, "key_prefix": "llmt_bbb"}
         raise AssertionError(f"unexpected: {method} {path}")
@@ -323,8 +326,12 @@ def test_provision_attaches_storage_and_repoints_db_and_sends_stable_id(
     assert persistent.mount_path == "/data"
     # DB path repointed onto the mount.
     assert proxy_create["env"][lifecycle.STORAGE_DB_PATH_ENV] == "/data/llmtrace.db"
-    # Stable id forwarded on tenant create.
-    assert seen["tenant_body"]["id"] == _STABLE_ID
+    # Stable id forwarded on the OPERATOR tenant create (name == tenant_id).
+    operator_bodies = [
+        b for b in seen["tenant_bodies"] if b.get("name") == "acme"
+    ]
+    assert len(operator_bodies) == 1
+    assert operator_bodies[0]["id"] == _STABLE_ID
     # Dashboard has no storage attached (only proxy carries the DB).
     dash_create = next(c for c in client.creates if "dashboard" in c["instance_name"])
     assert "storage" not in dash_create


### PR DESCRIPTION
Removes the hardcoded `6ae1ab34` tenant id I should never have baked in, and implements the catch-all (Option A — lifecycle-provided). Pairs with the proxy Option-B fallback PR.

## Changes
- **Catch-all (Option A):** `provision()` generates a fresh `uuid.uuid4()`, sets it on the proxy env as `LLMTRACE_DEFAULT_TENANT_ID` before the proxy starts, then creates the "catch-all" tenant (idempotent) once healthy. Returned to the caller as `catch_all_tenant_id`.
- **Operator tenant id — caller-owned, no hardcode:** `_resolve_operator_tenant_id` uses a caller-supplied `tenant_uuid`/`LLMTRACE_TENANT_UUID` verbatim (stable identity across recreate); if empty, generates a fresh uuid, returns it, and **warns it is ephemeral unless stored + re-passed**. No hardcoded fallback.
- **pro.yaml:** `tenant_uuid: "${LLMTRACE_TENANT_UUID:-}"` (no default); `LLMTRACE_DEFAULT_TENANT_ID` line removed. `6ae1ab34` appears nowhere (guard test enforces this).

## Tests
6 new (catch-all generated/set/created/returned; no catch-all when auth off; supplied vs empty tenant_uuid; whitespace; pro.yaml 6ae1ab34 guard); persistent-storage test strengthened for the second (catch-all) create.

## Verification
- `py_compile` 0; pro.yaml `yaml.safe_load` 0.
- `pytest deployments/basilica/tests`: +6 new passing vs base; **0 new failures** (4 fail / 2 error are pre-existing env issues — basilica SDK shadow + network-sandbox DNS — reproduced identically on base).

Note: this is deploy tooling + pro.yaml — it does NOT change the baked proxy image; it takes effect at the next provision. Operator-tenant id value is yours to set via `LLMTRACE_TENANT_UUID`.