### PR TITLE
feat(proxy): self-provision catch-all tenant when no default configured (Option B, no hardcoded id)

### DIFF
--- a/crates/llmtrace-proxy/src/config.rs
+++ b/crates/llmtrace-proxy/src/config.rs
@@ -3,8 +3,14 @@
 //! Loads [`ProxyConfig`] from a YAML file on disk, applies environment variable
 //! overrides, and validates the resulting configuration.
 
-use llmtrace_core::ProxyConfig;
+use llmtrace_core::{ProxyConfig, TenantId};
 use std::path::Path;
+
+/// Tenant name assigned to the catch-all tenant that absorbs all inbound
+/// `/v1` traffic which does not identify a tenant (no `X-LLMTrace-Tenant-ID`
+/// header and no derivable API key). Shared with the lifecycle (Option A)
+/// purely by string value -- keep this in sync if it ever changes.
+pub const CATCH_ALL_TENANT_NAME: &str = "catch-all";
 
 /// Load a [`ProxyConfig`] from a YAML file at `path`.
 ///
@@ -111,6 +117,45 @@ pub fn apply_env_overrides(config: &mut ProxyConfig) {
                 value = %val,
                 "LLMTRACE_ML_MAX_CONCURRENT must be a positive integer; keeping current value"
             ),
+        }
+    }
+}
+
+/// Resolve the effective catch-all tenant id and stamp it onto
+/// `config.default_tenant_id`, returning the resolved id.
+///
+/// Tenant-less `/v1` traffic (no `X-LLMTrace-Tenant-ID` and no derivable
+/// API key) is attributed to this catch-all tenant rather than rejected.
+/// Resolution order:
+///
+/// 1. **Option A (lifecycle-supplied):** if `config.default_tenant_id` is
+///    already `Some` (set from `LLMTRACE_DEFAULT_TENANT_ID` by
+///    [`apply_env_overrides`]), that id is used verbatim.
+/// 2. **Option B (self-provisioned fallback):** if it is `None`, a fresh
+///    `TenantId(Uuid::new_v4())` is GENERATED at runtime (never a hardcoded
+///    literal), stamped onto the config, and logged.
+///
+/// Must be called AFTER [`apply_env_overrides`] so the env-provided id
+/// (Option A) wins. The returned id is the catch-all whose row the caller
+/// then ensures exists via `ensure_tenant_exists`.
+pub fn resolve_catch_all_tenant_id(config: &mut ProxyConfig) -> TenantId {
+    match config.default_tenant_id {
+        Some(id) => {
+            tracing::info!(
+                tenant_id = %id.0,
+                "Using configured LLMTRACE_DEFAULT_TENANT_ID as catch-all tenant for tenant-less traffic"
+            );
+            id
+        }
+        None => {
+            let generated = TenantId(uuid::Uuid::new_v4());
+            config.default_tenant_id = Some(generated);
+            tracing::info!(
+                tenant_id = %generated.0,
+                "No LLMTRACE_DEFAULT_TENANT_ID provided; generated catch-all tenant {} for tenant-less traffic",
+                generated.0
+            );
+            generated
         }
     }
 }
@@ -475,6 +520,69 @@ health_check:
         apply_env_overrides(&mut config);
         std::env::remove_var("LLMTRACE_DEFAULT_TENANT_ID");
         assert!(config.default_tenant_id.is_none());
+    }
+
+    /// Option A: when an id is already configured (lifecycle supplied it
+    /// via `LLMTRACE_DEFAULT_TENANT_ID`), it is used verbatim as the
+    /// catch-all and the config is left pointing at the same id.
+    #[test]
+    fn test_resolve_catch_all_uses_configured_id() {
+        let configured = TenantId(uuid::Uuid::new_v4());
+        let mut config = ProxyConfig {
+            default_tenant_id: Some(configured),
+            ..ProxyConfig::default()
+        };
+        let resolved = resolve_catch_all_tenant_id(&mut config);
+        assert_eq!(resolved, configured);
+        assert_eq!(config.default_tenant_id, Some(configured));
+    }
+
+    /// Option B: with no id configured, a fresh non-nil UUID is generated
+    /// and stamped onto the config so the request path can read it.
+    #[test]
+    fn test_resolve_catch_all_generates_fresh_id_when_unset() {
+        let mut config = ProxyConfig::default();
+        assert!(config.default_tenant_id.is_none());
+        let resolved = resolve_catch_all_tenant_id(&mut config);
+        assert!(
+            !resolved.0.is_nil(),
+            "generated catch-all id must not be the nil UUID"
+        );
+        assert_eq!(
+            config.default_tenant_id,
+            Some(resolved),
+            "resolved id must be stamped back onto the config"
+        );
+    }
+
+    /// Proves the Option B id is GENERATED at runtime, not a hardcoded
+    /// literal: two independent resolutions yield two different ids.
+    #[test]
+    fn test_resolve_catch_all_generates_distinct_ids_across_builds() {
+        let mut a = ProxyConfig::default();
+        let mut b = ProxyConfig::default();
+        let id_a = resolve_catch_all_tenant_id(&mut a);
+        let id_b = resolve_catch_all_tenant_id(&mut b);
+        assert_ne!(
+            id_a, id_b,
+            "fresh resolutions must produce distinct ids (proves runtime generation, not a hardcoded literal)"
+        );
+        assert!(!id_a.0.is_nil());
+        assert!(!id_b.0.is_nil());
+    }
+
+    /// The catch-all id must never collapse to the nil UUID nor to the
+    /// deterministic "anonymous" sentinel used by the auth-disabled path.
+    #[test]
+    fn test_resolve_catch_all_never_nil_or_anonymous_sentinel() {
+        let anonymous = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, b"llmtrace-anonymous");
+        let mut config = ProxyConfig::default();
+        let resolved = resolve_catch_all_tenant_id(&mut config);
+        assert!(!resolved.0.is_nil());
+        assert_ne!(
+            resolved.0, anonymous,
+            "catch-all must be a fresh tenant, not the anonymous sentinel"
+        );
     }
 
     #[test]

--- a/crates/llmtrace-proxy/src/main.rs
+++ b/crates/llmtrace-proxy/src/main.rs
@@ -422,9 +422,17 @@ fn probe_runtime_overlay_writable(
 }
 
 async fn build_app_state(
-    config: ProxyConfig,
+    mut config: ProxyConfig,
     runtime_overlay_path: Option<PathBuf>,
 ) -> anyhow::Result<Arc<AppState>> {
+    // Resolve the effective catch-all tenant for tenant-less `/v1` traffic
+    // BEFORE the config is moved into the ConfigHandle. When
+    // `LLMTRACE_DEFAULT_TENANT_ID` was supplied (Option A) that id is used;
+    // otherwise a fresh id is generated at runtime (Option B fallback) and
+    // stamped onto `config.default_tenant_id` so the request path attributes
+    // tenant-less traffic to it instead of rejecting with 401.
+    let catch_all_tenant_id = config::resolve_catch_all_tenant_id(&mut config);
+
     let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_millis(
             config.connection_timeout_ms,
@@ -717,6 +725,17 @@ async fn build_app_state(
         &state,
         &llmtrace_proxy::feature_flags::FeatureFlags::from_config(&state.config_handle.snapshot()),
     );
+
+    // Materialise the catch-all tenant row so tenant-less traffic shows up as
+    // a real tenant for queries/dashboard. Idempotent (get-or-create): a no-op
+    // if the lifecycle (Option A) already created it. Runs for BOTH the
+    // env-provided and self-generated cases.
+    llmtrace_proxy::tenant_api::ensure_tenant_exists(
+        &state,
+        catch_all_tenant_id,
+        config::CATCH_ALL_TENANT_NAME,
+    )
+    .await;
 
     Ok(state)
 }
@@ -1223,6 +1242,94 @@ mod tests {
     async fn test_build_app_state_succeeds() {
         let state = build_app_state(memory_config(), None).await;
         assert!(state.is_ok());
+    }
+
+    // ---- Catch-all tenant fallback (Option B) -------------------------
+    //
+    // Tenant-less `/v1` traffic is attributed to a catch-all tenant. When
+    // `LLMTRACE_DEFAULT_TENANT_ID` (Option A) is set it is used; otherwise
+    // the proxy self-provisions a catch-all with a freshly GENERATED id
+    // (Option B). The request path reads the resolved id from
+    // `config_handle.snapshot().default_tenant_id` to stamp tenant-less
+    // traffic (see proxy.rs tenant resolution).
+
+    /// Option A: a configured `default_tenant_id` becomes the catch-all,
+    /// its row is materialised, and the request path reads back that id.
+    #[tokio::test]
+    async fn test_catch_all_uses_configured_default_tenant_id() {
+        let configured = llmtrace_core::TenantId(uuid::Uuid::new_v4());
+        let cfg = ProxyConfig {
+            default_tenant_id: Some(configured),
+            ..memory_config()
+        };
+        let state = build_app_state(cfg, None).await.unwrap();
+
+        // The request path stamps tenant-less traffic with this id.
+        assert_eq!(
+            state.config_handle.snapshot().default_tenant_id,
+            Some(configured)
+        );
+
+        // The catch-all row is present for queries/dashboard.
+        let tenant = state
+            .metadata()
+            .get_tenant(configured)
+            .await
+            .unwrap()
+            .expect("catch-all tenant row must exist");
+        assert_eq!(tenant.name, llmtrace_proxy::config::CATCH_ALL_TENANT_NAME);
+    }
+
+    /// Option B: with no configured id a fresh non-nil UUID is generated,
+    /// the catch-all row is created, and the request path reads back the
+    /// generated id (stable for the life of this AppState).
+    #[tokio::test]
+    async fn test_catch_all_self_provisions_when_default_tenant_id_unset() {
+        let cfg = memory_config();
+        assert!(cfg.default_tenant_id.is_none());
+        let state = build_app_state(cfg, None).await.unwrap();
+
+        let resolved = state
+            .config_handle
+            .snapshot()
+            .default_tenant_id
+            .expect("a catch-all id must be resolved when none configured");
+        assert!(
+            !resolved.0.is_nil(),
+            "self-provisioned catch-all id must be a fresh non-nil UUID"
+        );
+
+        // The generated catch-all is a real tenant row.
+        let tenant = state
+            .metadata()
+            .get_tenant(resolved)
+            .await
+            .unwrap()
+            .expect("self-provisioned catch-all tenant row must exist");
+        assert_eq!(tenant.name, llmtrace_proxy::config::CATCH_ALL_TENANT_NAME);
+
+        // Stable within the process: a second snapshot reads the same id.
+        assert_eq!(
+            state.config_handle.snapshot().default_tenant_id,
+            Some(resolved)
+        );
+    }
+
+    /// Proves the Option B id is GENERATED at runtime: two independent
+    /// builds with no configured id produce DIFFERENT catch-all ids.
+    /// A hardcoded literal would make these equal.
+    #[tokio::test]
+    async fn test_catch_all_generated_ids_differ_across_builds() {
+        let state_a = build_app_state(memory_config(), None).await.unwrap();
+        let state_b = build_app_state(memory_config(), None).await.unwrap();
+        let id_a = state_a.config_handle.snapshot().default_tenant_id.unwrap();
+        let id_b = state_b.config_handle.snapshot().default_tenant_id.unwrap();
+        assert_ne!(
+            id_a, id_b,
+            "independent builds must self-provision distinct ids (not a hardcoded literal)"
+        );
+        assert!(!id_a.0.is_nil());
+        assert!(!id_b.0.is_nil());
     }
 
     // ---- /debug/judge/verdicts (Loop E2E-L5 of #91) -----------------

--- a/crates/llmtrace-proxy/src/proxy.rs
+++ b/crates/llmtrace-proxy/src/proxy.rs
@@ -1177,8 +1177,13 @@ pub async fn proxy_handler(
     // Resolve the tenant for this request. Phantom-tenant guard (issue #292):
     // we NEVER auto-create a tenant per call. Resolution order:
     //   1. A concrete (non-nil) tenant resolved from auth / header / key.
-    //   2. The explicit `default_tenant_id` for header-less traffic.
-    //   3. Auth ENABLED with neither => reject 401 (do not invent a tenant).
+    //   2. The catch-all `default_tenant_id` for tenant-less traffic. At
+    //      startup `build_app_state` ALWAYS resolves a catch-all id (either
+    //      the lifecycle-supplied `LLMTRACE_DEFAULT_TENANT_ID`, or a freshly
+    //      generated one as a fallback), so tenant-less `/v1` traffic is
+    //      attributed to the catch-all rather than rejected.
+    //   3. Auth ENABLED with neither (defensive: only if no catch-all was
+    //      resolved) => reject 401 (do not invent a tenant).
     //   4. Auth DISABLED with neither => stamp a deterministic, stable
     //      "anonymous" tenant id so dev/test traffic still has a home, WITHOUT
     //      provisioning a DB row (no phantom creation).


### PR DESCRIPTION
Proxy side of the catch-all design. Pairs with the lifecycle PR (#341, Option A primary).

## Change
`build_app_state` resolves an effective catch-all tenant via `resolve_catch_all_tenant_id`:
- **Option A:** if `LLMTRACE_DEFAULT_TENANT_ID` is set (lifecycle-supplied), use it verbatim.
- **Option B (fallback):** if unset, generate a fresh `TenantId(Uuid::new_v4())` at runtime (never hardcoded), log it, and use it.
Then `ensure_tenant_exists(catch_all_id, "catch-all")` (idempotent) so the catch-all is a real tenant row in both cases. Tenant-less `/v1` traffic is attributed to the catch-all; the 401 path remains only as a defensive guard.

## No hardcoded id
Option B is purely `Uuid::new_v4()`; a test asserts the id is never nil / never the anonymous sentinel, and that two builds produce distinct ids (proving runtime generation). `proxy.rs` change is doc-comment only.

## Tests (7, all pass)
config.rs: configured-id-used, generated-when-unset, distinct-across-builds, never-nil/sentinel. main.rs: full `build_app_state` for configured + self-provisioned + distinct-across-builds (catch-all row present, name "catch-all").

## Verification
`cargo fmt --all` 0; `cargo clippy --workspace -- -D warnings` 0; `cargo test -p llmtrace -p llmtrace-core -p llmtrace-storage` 0; `cargo build --workspace` 0.