### PR TITLE
fix(deploy): accept idempotent 200 in tenant bootstrap (fixes catch-all provision abort + dashboard outage)

### DIFF
--- a/deployments/basilica/lifecycle.py
+++ b/deployments/basilica/lifecycle.py
@@ -921,7 +921,11 @@ def _bootstrap_tenant_in_proxy(
         admin_key,
         body=body,
     )
-    if status != 201:
+    # Idempotent create: the proxy returns 201 for a newly-created tenant and
+    # 200 when one with this `id` already exists (e.g. the proxy self-provisions
+    # the catch-all tenant at startup from LLMTRACE_DEFAULT_TENANT_ID before the
+    # lifecycle's create runs). Both carry the same body shape; both are success.
+    if status not in (200, 201):
         raise RuntimeError(
             f"tenant bootstrap failed: status={status} body={payload}"
         )

--- a/deployments/basilica/tests/test_catchall_and_operator_tenant.py
+++ b/deployments/basilica/tests/test_catchall_and_operator_tenant.py
@@ -367,3 +367,44 @@ def test_pro_yaml_has_no_hardcoded_tenant_uuid() -> None:
         "the previously-hardcoded catch-all/default tenant UUID must not "
         "appear anywhere in pro.yaml"
     )
+
+
+def _patch_admin_http(monkeypatch: Any, status: int) -> None:
+    def fake(
+        proxy_url: str,
+        path: str,
+        method: str,
+        admin_key: str,
+        body: Optional[dict[str, Any]] = None,
+    ) -> tuple[int, dict[str, Any]]:
+        body = body or {}
+        return status, {"id": body.get("id") or "generated-id", "name": body.get("name")}
+
+    monkeypatch.setattr(lifecycle, "_admin_http_request", fake)
+
+
+def test_bootstrap_tenant_accepts_idempotent_200(monkeypatch: Any) -> None:
+    """Regression for the 2026-05-30 outage: the proxy self-provisions the
+    catch-all at startup from LLMTRACE_DEFAULT_TENANT_ID, so the lifecycle's
+    subsequent create gets 200 (already exists). 200 MUST be treated as success
+    (the previous code raised on anything != 201, aborting before the dashboard
+    was recreated)."""
+    _patch_admin_http(monkeypatch, 200)
+    tid = lifecycle._bootstrap_tenant_in_proxy(
+        "http://proxy", "admin", "catch-all", stable_id="a0f7d8a5-4524-4a83-afac-27080b4d0432"
+    )
+    assert tid == "a0f7d8a5-4524-4a83-afac-27080b4d0432"
+
+
+def test_bootstrap_tenant_accepts_created_201(monkeypatch: Any) -> None:
+    _patch_admin_http(monkeypatch, 201)
+    tid = lifecycle._bootstrap_tenant_in_proxy(
+        "http://proxy", "admin", "operator", stable_id="550e8400-e29b-41d4-a716-446655440000"
+    )
+    assert tid == "550e8400-e29b-41d4-a716-446655440000"
+
+
+def test_bootstrap_tenant_rejects_error_status(monkeypatch: Any) -> None:
+    _patch_admin_http(monkeypatch, 500)
+    with pytest.raises(RuntimeError, match="tenant bootstrap failed"):
+        lifecycle._bootstrap_tenant_in_proxy("http://proxy", "admin", "catch-all")


### PR DESCRIPTION
## Outage fix
On 2026-05-30 a recreate using the just-merged catch-all PRs (#341 lifecycle + #342 proxy) **aborted mid-provision and left the dashboard deleted-not-recreated** (live outage).

## Root cause
Both the proxy (Option B, #342: `ensure_tenant_exists` at startup) and the lifecycle (Option A, #341) create the catch-all tenant. The proxy wins (it runs at startup, from the `LLMTRACE_DEFAULT_TENANT_ID` the lifecycle set), so the lifecycle's subsequent `POST /api/v1/tenants` for the catch-all returns **200 (already exists)** via the idempotent create — not 201. `_bootstrap_tenant_in_proxy` raised on `status != 201`, throwing **before the dashboard was recreated**. CI couldn't catch it — the bug only appears in the live A+B interaction.

## Fix
`_bootstrap_tenant_in_proxy` accepts **200 and 201** (both carry the same body; 200 = idempotent already-exists, the expected case now that the proxy self-provisions the catch-all). One-line behavior change + 3 regression tests (accept-200, accept-201, reject-5xx).

## Validation
- Fix logic verified directly (200→id, 201→id, 500→RuntimeError).
- **Live**: re-ran the recreate with this fix → dashboard restored, provision completed, operator tenant `550e8400`, generated catch-all `a0f7d8a5`, tenant-less /v1 → catch-all, cost tracking + isolation intact, no `6ae1ab34`.

Deploy tooling only — no image change, no redeploy needed (the live deployment already ran with this fix locally; this lands it on main).