### PR TITLE
feat(dashboard): one-click SSO accept endpoint for portal handoff

### DIFF
--- a/dashboard/src/app/api/auth/sso/route.ts
+++ b/dashboard/src/app/api/auth/sso/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sessionCookieName, SESSION_TTL_SECONDS, isAuthDisabled } from "@/lib/auth";
+import { verifySsoToken } from "@/lib/sso-token";
+
+// node:crypto (HMAC) — force the Node runtime, never edge.
+export const runtime = "nodejs";
+
+/**
+ * GET /api/auth/sso?token=…
+ *
+ * One-click sign-in handoff from the LLMTrace portal. The portal mints a
+ * short-lived token signed with this instance's admin key; we verify it
+ * against `LLMTRACE_AUTH_ADMIN_KEY` (the same per-instance secret) and, on
+ * success, set the normal session cookie and bounce to the dashboard home.
+ *
+ * The admin key is never carried in the URL — only its HMAC signature is — and
+ * is never shown to the user; it lands directly in the HttpOnly session cookie,
+ * exactly as a manual login would. This route is public (see middleware's
+ * `/api/auth/` prefix) because it runs before a session exists.
+ */
+export function GET(req: NextRequest): NextResponse {
+  const token = req.nextUrl.searchParams.get("token");
+
+  // Local-dev escape hatch: auth disabled means no session is required at all.
+  if (isAuthDisabled()) return redirectHome(req);
+
+  if (!token) return rejectToLogin(req, "missing_token");
+
+  const adminKey = process.env.LLMTRACE_AUTH_ADMIN_KEY ?? "";
+  const result = verifySsoToken(token, adminKey, Math.floor(Date.now() / 1000));
+  if (!result.ok) return rejectToLogin(req, result.reason);
+
+  const res = redirectHome(req);
+  res.cookies.set({
+    name: sessionCookieName(req.headers.get("host")),
+    value: adminKey,
+    httpOnly: true,
+    secure: isSecure(req),
+    sameSite: "strict",
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS,
+  });
+  return res;
+}
+
+function isSecure(req: NextRequest): boolean {
+  if (req.nextUrl.protocol === "https:") return true;
+  return req.headers.get("x-forwarded-proto") === "https";
+}
+
+function redirectHome(req: NextRequest): NextResponse {
+  const url = req.nextUrl.clone();
+  url.pathname = "/";
+  url.search = "";
+  return NextResponse.redirect(url, { status: 303 });
+}
+
+function rejectToLogin(req: NextRequest, reason: string): NextResponse {
+  console.warn("[auth/sso] rejected:", reason);
+  const url = req.nextUrl.clone();
+  url.pathname = "/login";
+  url.search = "?error=sso";
+  return NextResponse.redirect(url, { status: 303 });
+}

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -37,6 +37,14 @@ function LoginForm(): React.ReactElement {
     };
   }, []);
 
+  // A failed/expired one-click sign-in bounces here with ?error=sso. Surface a
+  // clear reason rather than leaving the form silently waiting.
+  useEffect(() => {
+    if (search.get("error") === "sso") {
+      setError("That one-click sign-in link has expired or is invalid. Please sign in with your admin key.");
+    }
+  }, [search]);
+
   async function onSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault();
     if (!username || !adminKey) {

--- a/dashboard/src/lib/sso-token.ts
+++ b/dashboard/src/lib/sso-token.ts
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// Portal → dashboard SSO handoff token
+// ---------------------------------------------------------------------------
+//
+// One-click "Open dashboard" works by the portal minting a short-lived token
+// that this dashboard verifies, then establishing the normal session cookie.
+//
+// The token is HMAC-SHA256 signed with the per-instance admin key — a secret
+// already present on BOTH sides (the portal holds it in its vault; this
+// dashboard receives it as `LLMTRACE_AUTH_ADMIN_KEY`). Because the secret is
+// per-instance, a token minted for one instance only verifies on that
+// instance's dashboard. The admin key itself never leaves either server: only
+// the HMAC signature travels in the redirect URL.
+//
+// This module is duplicated verbatim in the Portal repo (lib/sso-token.ts).
+// The two copies MUST stay byte-identical or tokens won't verify — keep the
+// payload shape, field order, and base64url encoding in lock-step.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Single-purpose tag baked into the payload so a token can't be repurposed. */
+const PURPOSE = "dashboard_sso";
+
+/** Default token lifetime. Short: the token is redeemed immediately on click. */
+export const SSO_TOKEN_TTL_SECONDS = 90;
+
+interface SsoPayload {
+  /** purpose tag */
+  p: string;
+  /** expiry, unix seconds */
+  exp: number;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecode(s: string): Buffer {
+  return Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+}
+
+function sign(body: string, secret: string): string {
+  return base64url(createHmac("sha256", secret).update(body).digest());
+}
+
+/**
+ * Mint a signed SSO token valid for `ttlSeconds`. `nowSeconds` is passed in
+ * (not read from the clock) so the function is pure and unit-testable.
+ */
+export function mintSsoToken(
+  secret: string,
+  nowSeconds: number,
+  ttlSeconds: number = SSO_TOKEN_TTL_SECONDS,
+): string {
+  const payload: SsoPayload = { p: PURPOSE, exp: nowSeconds + ttlSeconds };
+  const body = base64url(Buffer.from(JSON.stringify(payload), "utf8"));
+  return `${body}.${sign(body, secret)}`;
+}
+
+export type SsoVerifyResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Verify a token against `secret` at `nowSeconds`. Returns a tagged result
+ * rather than throwing so the caller can branch without try/catch. The
+ * signature check is constant-time.
+ */
+export function verifySsoToken(token: string, secret: string, nowSeconds: number): SsoVerifyResult {
+  if (!secret) return { ok: false, reason: "no_secret" };
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) return { ok: false, reason: "malformed" };
+
+  const body = token.slice(0, dot);
+  const sig = Buffer.from(token.slice(dot + 1));
+  const expected = Buffer.from(sign(body, secret));
+  if (sig.length !== expected.length || !timingSafeEqual(sig, expected)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  let payload: SsoPayload;
+  try {
+    payload = JSON.parse(base64urlDecode(body).toString("utf8")) as SsoPayload;
+  } catch {
+    return { ok: false, reason: "bad_payload" };
+  }
+  if (payload.p !== PURPOSE) return { ok: false, reason: "bad_purpose" };
+  if (typeof payload.exp !== "number" || payload.exp < nowSeconds) return { ok: false, reason: "expired" };
+  return { ok: true };
+}


### PR DESCRIPTION
## What

Adds `GET /api/auth/sso?token=…` so the LLMTrace **portal** can sign an operator into their instance dashboard in **one click** — no admin key shown, typed, copied, or pasted. This is the dashboard half of the portal "Open dashboard" fix (portal PR follows in techlab-innov/Portal).

## Why

Self-serve portal users hit the dashboard login and have no password to enter — the admin key is generated at provision and was never surfaced. Rather than display the secret, we hand off via a signed token so the key never reaches the user.

## How it works

1. Portal mints a short-lived (90s), single-purpose token, **HMAC-SHA256 signed with this instance's admin key**.
2. Browser is 303-redirected here with `?token=…`.
3. We verify the token against `LLMTRACE_AUTH_ADMIN_KEY` (the same per-instance secret, already injected at provision by the portal's `applyProxyAuth`), then set the normal host-scoped session cookie and 303 to `/`.

The shared secret already exists on both sides — no new secret distribution. Because it's **per-instance**, a token only verifies on its own instance's dashboard.

### Security properties
- Admin key **never in the URL** — only its HMAC signature travels.
- Admin key **never rendered** — it lands directly in the existing HttpOnly session cookie, exactly as a manual login would (the cookie value has always been the admin key; see `api/auth/login`).
- Constant-time signature comparison; single-purpose tag; short expiry; rejects unsigned/forged/expired/wrong-secret tokens.
- Route is public via the existing `/api/auth/` middleware prefix (it runs before a session exists); auth-disabled dev mode bounces home without setting a cookie.

## Files
- `src/lib/sso-token.ts` — pure mint/verify. **Duplicated byte-for-byte** in the Portal repo (`lib/sso-token.ts`); the two MUST stay in lock-step or tokens won't verify.
- `src/app/api/auth/sso/route.ts` — verify → set cookie → 303.
- `src/app/login/page.tsx` — friendly message when a stale link bounces back (`?error=sso`).

## Validation
- Token mint/verify proven by real execution: round-trip, expiry boundary, wrong-secret, tampered signature, forged longer-TTL payload reusing an old signature, empty secret, malformed, wrong purpose tag — all reject with the expected reason. The authoritative unit test ships in the Portal PR against the byte-identical module (`node --test`, 8/8 pass).
- Dashboard source typechecks clean (only pre-existing unrelated `next-themes` local-install noise).

## Deploy dependency (read before merge)
This endpoint only exists in a **new dashboard image**. `publish-images` rebuilds `:main`/`:sha-…` on merge (path `dashboard/**`); **`:latest`** (what new instances pull) needs a `workflow_dispatch` with `mark_latest`. **Existing ACTIVE instances run the old image and will 404 `/api/auth/sso` until redeployed/reprovisioned.** Live E2E SSO is validated on a real instance only after `:latest` is rebuilt — that's the sign-off gate, tracked separately.