### PR TITLE
fix(dashboard): SSO redirect uses a relative Location (works behind Basilica)

### DIFF
--- a/dashboard/src/app/api/auth/sso/route.ts
+++ b/dashboard/src/app/api/auth/sso/route.ts
@@ -22,15 +22,15 @@ export function GET(req: NextRequest): NextResponse {
   const token = req.nextUrl.searchParams.get("token");
 
   // Local-dev escape hatch: auth disabled means no session is required at all.
-  if (isAuthDisabled()) return redirectHome(req);
+  if (isAuthDisabled()) return seeOther("/");
 
-  if (!token) return rejectToLogin(req, "missing_token");
+  if (!token) return rejectToLogin("missing_token");
 
   const adminKey = process.env.LLMTRACE_AUTH_ADMIN_KEY ?? "";
   const result = verifySsoToken(token, adminKey, Math.floor(Date.now() / 1000));
-  if (!result.ok) return rejectToLogin(req, result.reason);
+  if (!result.ok) return rejectToLogin(result.reason);
 
-  const res = redirectHome(req);
+  const res = seeOther("/");
   res.cookies.set({
     name: sessionCookieName(req.headers.get("host")),
     value: adminKey,
@@ -48,17 +48,19 @@ function isSecure(req: NextRequest): boolean {
   return req.headers.get("x-forwarded-proto") === "https";
 }
 
-function redirectHome(req: NextRequest): NextResponse {
-  const url = req.nextUrl.clone();
-  url.pathname = "/";
-  url.search = "";
-  return NextResponse.redirect(url, { status: 303 });
+/**
+ * 303 with a RELATIVE Location. The browser resolves it against the public
+ * request URL, so it works behind Basilica's ingress. An absolute
+ * `NextResponse.redirect(req.nextUrl)` would, in the Node runtime, serialise
+ * the container's internal host (`0.0.0.0:3000`) and send the browser to a
+ * dead address — the dashboard's middleware redirects are relative for the
+ * same reason.
+ */
+function seeOther(location: string): NextResponse {
+  return new NextResponse(null, { status: 303, headers: { Location: location } });
 }
 
-function rejectToLogin(req: NextRequest, reason: string): NextResponse {
+function rejectToLogin(reason: string): NextResponse {
   console.warn("[auth/sso] rejected:", reason);
-  const url = req.nextUrl.clone();
-  url.pathname = "/login";
-  url.search = "?error=sso";
-  return NextResponse.redirect(url, { status: 303 });
+  return seeOther("/login?error=sso");
 }


### PR DESCRIPTION
## What
The one-click SSO accept route (`/api/auth/sso`, added in #367) set its post-login redirect from `req.nextUrl`. In the **Node runtime** that serialises the container's **internal** host, so behind Basilica's ingress the browser was 303'd to `http://0.0.0.0:3000/` — a dead address — *after* the session cookie was correctly set. The cookie worked; the landing page didn't.

## Fix
Emit a **relative** `Location` (`/` or `/login?error=sso`), exactly as the dashboard's own `middleware.ts` redirects do. The browser resolves a relative Location against the public request URL, so it lands on the real dashboard.

## Why it wasn't caught in #367
The original validation tested the cookie/auth path (valid token → session cookie == admin key → protected route returns 200), which all passed. The broken redirect only surfaced during **live** end-to-end testing against a real Basilica instance — the redirect `location` header showed `http://0.0.0.0:3000/` vs middleware's relative `/login`.

## Validation (built image, this branch)
```
valid token -> 303  location: /                 + Set-Cookie llmtrace_session…
bad token   -> 303  location: /login?error=sso  (no cookie)
```
Live re-validation on real instances follows after `:latest` is rebuilt.