### PR TITLE
fix(dashboard): SSO session cookie SameSite=Lax (cross-site portal handoff)

### DIFF
--- a/dashboard/src/app/api/auth/sso/route.ts
+++ b/dashboard/src/app/api/auth/sso/route.ts
@@ -36,7 +36,13 @@ export function GET(req: NextRequest): NextResponse {
     value: adminKey,
     httpOnly: true,
     secure: isSecure(req),
-    sameSite: "strict",
+    // Lax, NOT Strict: this cookie is set during a cross-site top-level
+    // navigation (portal -> dashboard). A Strict cookie is withheld on the
+    // landing request that follows a cross-site redirect, so the user lands on
+    // `/` with no session and is bounced to /login. Lax is sent on top-level
+    // GET navigations, which is exactly this handoff. (The manual /login route
+    // stays Strict — it is always same-site.)
+    sameSite: "lax",
     path: "/",
     maxAge: SESSION_TTL_SECONDS,
   });


### PR DESCRIPTION
## What
The SSO accept route (`/api/auth/sso`) set the session cookie with `SameSite=Strict` (copied from the manual `/login` route). That cookie is set during a **cross-site** top-level navigation (portal → dashboard). Browsers **withhold a Strict cookie on the landing request that follows a cross-site redirect**, so the user reached `/` with no session and middleware bounced them to `/login`. The SSO "did nothing" from the user's point of view.

## Fix
`SameSite=Lax` on the SSO cookie — Lax is sent on top-level GET navigations, which is exactly this handoff. The manual `/login` cookie stays `Strict` (always same-site).

## Reproduced + verified in a real headless browser (Chromium)
Cross-site click (a `localhost` page linking to the live dashboard `/api/auth/sso?token=…`):

| image | cookie stored | landing | result |
|---|---|---|---|
| current (Strict) | yes, `sameSite=Strict` | `…/login?next=%2F` | **bounced** |
| this PR (Lax) | yes, `sameSite=Lax` | `…/` | **authenticated** |

`curl` validation in #367 missed this because curl does not enforce SameSite. Live re-validation on the real instances follows after `:latest` rebuilds.