### PR TITLE
fix(deps): bump pyo3 to 0.29.0 (RUSTSEC-2026-0176 / RUSTSEC-2026-0177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,15 +2258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,15 +2694,6 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -3477,37 +3459,32 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3515,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3527,13 +3504,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -5121,12 +5097,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unit-prefix"

--- a/crates/llmtrace-python/Cargo.toml
+++ b/crates/llmtrace-python/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 llmtrace-core.workspace = true
-pyo3 = { version = "0.24.1", features = ["extension-module"] }
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
 serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true

--- a/crates/llmtrace-python/src/lib.rs
+++ b/crates/llmtrace-python/src/lib.rs
@@ -189,7 +189,7 @@ impl PyTraceSpan {
     }
 
     /// Security findings as a list of dicts.
-    fn security_findings(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn security_findings(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let findings: Vec<serde_json::Value> = self
             .inner
             .security_findings
@@ -305,7 +305,7 @@ impl PyTraceSpan {
     // -- serialisation -------------------------------------------------------
 
     /// Serialise the span to a Python dictionary.
-    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let json_str = serde_json::to_string(&self.inner)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
@@ -444,7 +444,7 @@ impl PyLLMSecTracer {
 /// ``tracer`` property.
 #[pyclass(name = "InstrumentedClient")]
 struct PyInstrumentedClient {
-    inner: PyObject,
+    inner: Py<PyAny>,
     tracer: Py<PyLLMSecTracer>,
 }
 
@@ -458,7 +458,7 @@ impl PyInstrumentedClient {
 
     /// The original (unwrapped) client object.
     #[getter]
-    fn wrapped_client(&self, py: Python<'_>) -> PyObject {
+    fn wrapped_client(&self, py: Python<'_>) -> Py<PyAny> {
         self.inner.clone_ref(py)
     }
 
@@ -476,7 +476,7 @@ impl PyInstrumentedClient {
     }
 
     /// Delegate attribute access to the wrapped client.
-    fn __getattr__(&self, py: Python<'_>, name: &str) -> PyResult<PyObject> {
+    fn __getattr__(&self, py: Python<'_>, name: &str) -> PyResult<Py<PyAny>> {
         self.inner.getattr(py, name)
     }
 
@@ -533,7 +533,7 @@ fn configure(config: &Bound<'_, PyDict>) -> PyResult<PyLLMSecTracer> {
 #[pyo3(signature = (client, *, tracer=None))]
 fn instrument(
     py: Python<'_>,
-    client: PyObject,
+    client: Py<PyAny>,
     tracer: Option<Py<PyLLMSecTracer>>,
 ) -> PyResult<PyInstrumentedClient> {
     let tracer = match tracer {


### PR DESCRIPTION
## What

Two RUSTSEC advisories published **2026-06-11** against pyo3 <0.29.0 turned the Security Audit gate red on every branch (first seen on #387, a docs-only PR; main's last green run predates the advisories):

- [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176) — out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators
- [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) — missing `Sync` bound on `PyCFunction::new_closure` closures

`llmtrace-python` does not call the affected APIs directly (no `PyList`/`PyTuple` iteration, no `new_closure`), but the audit gate is binary and correctly so.

## Migration

pyo3 0.24.2 → 0.29.0. The only breaking change that bit: the `PyObject` alias was removed — replaced with `Py<PyAny>` throughout `lib.rs` (6 sites, mechanical). Lockfile updates pyo3* crates only (plus dropping the now-unused `unindent`).

## Evidence

- `cargo build -p llmtrace-python`: clean
- `RUSTFLAGS="-D warnings" cargo clippy -p llmtrace-python --all-targets`: clean
- `cargo fmt --all --check`: clean
- CI's Security Audit job re-runs cargo-audit against the updated lockfile — that is the authoritative verification this PR exists for.