### PR TITLE
release: prepare v0.3.0 — version bump, curated changelog, dashboard image in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: techlab-innov/llmtrace-proxy
+  DASHBOARD_IMAGE_NAME: techlab-innov/llmtrace-dashboard
 
 permissions:
   contents: write
@@ -208,6 +209,25 @@ jobs:
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The tenant fleet runs the proxy + dashboard pair; releases must
+      # version-tag BOTH (publish-images only covers main-branch pushes).
+      - name: Build and push dashboard image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: ./dashboard
+          file: ./dashboard/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.DASHBOARD_IMAGE_NAME }}:${{ needs.validate.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.DASHBOARD_IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+          cache-from: type=gha,scope=dashboard
+          cache-to: type=gha,mode=max,scope=dashboard
 
   # ---------------------------------------------------------------------------
   # Job 4: Publish crates to crates.io (in dependency order)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- E2E adversarial test framework (#91, L1–L10): 50-scenario YAML corpus across 8 attack families, pytest harness with per-scenario `/metrics` delta + judge-verdict polling, expectation DSL, regex upstream-fell-for-it judge with six rule classes, PR-gate workflow on every PR, nightly cron with auto-PR'd deterministic markdown report.
-- Judge reliability patterns (#66): binary-first prompt, cross-family startup warning, per-id golden-set fixtures with a shared loader/replay module, integration test with per-category alignment floors, `GET /debug/judge/golden_set/replay` debug endpoint, two new gauges (`llmtrace_judge_golden_set_alignment`, `llmtrace_judge_golden_set_false_positive_rate`), three new PrometheusRule alerts with operator runbook at `docs/runbooks/judge-golden-set-drift.md`.
-- New attack-detection coverage in `RegexSecurityAnalyzer`: rot13 and leetspeak encoding evasion now emit `encoding_attack` findings (previously only base64 was covered).
-- `X-LLMTrace-Trace-Id` request header is honored by the proxy and echoed back on every response (`L1a` of #91).
+### Security fixes
 
-### Changed
-- E2E nightly workflow's auto-PR step is `continue-on-error: true` so a missing `Allow GitHub Actions to create and approve pull requests` repo setting surfaces as a workflow-summary warning rather than a red run while the corpus replay still passes.
-- Bumped GitHub Actions: `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7, `peter-evans/create-pull-request` v7→v8 (Node 24 ahead of the 2026-06-02 forced cutover).
-- `pytest.ini` sets `pythonpath = .` so e2e tests run without a manual `PYTHONPATH` export from the repo root.
-- Dashboard ships `"overrides": { "postcss": "^8.5.10" }` so npm audit catches Next.js's nested transitive postcss copy (GHSA-qx2v-qp2m-jg93).
+### Bug fixes
 
-### Documentation
-- New guide: `docs/guides/e2e-testing.md` (in mkdocs nav under Guides) — quick start, comparator reference, CI workflow contract, scenario authoring.
-- New runbook: `docs/runbooks/judge-golden-set-drift.md` (under Operations) — per-alert diagnose + mitigate steps for the three new PrometheusRule alerts.
-- New section in `docs/guides/llm-judge.md`: "Golden-set calibration loop (#66)" — operator workflow for the replay endpoint, the new gauges, and how to add a fixture.
-- New baseline reports: `docs/research/results/e2e_2026-04-23_baseline.md`, `e2e_2026-04-23.md`, `e2e_2026-04-24.md`.
+### Features
+
+### Operational notes
+
+## [0.3.0] - 2026-06-12
+
+Upgrade urgency: recommended — includes dependency security fixes and
+multi-tenant security hardening; no breaking API changes for proxy clients.
+
+### Security fixes
+- pyo3 0.24.2 -> 0.29.0: RUSTSEC-2026-0176 (out-of-bounds read in
+  PyList/PyTuple iterators) and RUSTSEC-2026-0177 (missing Sync bound on
+  new_closure) (#388).
+- `/v1/*` forwarding now requires an Operator-role credential (#269), and the
+  proxy substitutes the upstream provider key on forward so client-presented
+  keys never reach the provider (#274).
+- Tenant default API keys are minted Operator, not Admin — closes a
+  cross-tenant read via scope=all.
+- Dashboard `/metrics` removed from the public allow-list (#280); datamarking
+  strips zero-width formatting characters (#215); transitive postcss override
+  for GHSA-qx2v-qp2m-jg93.
+
+### Features
+- Multi-tenant runtime: per-tenant upstream routing with keys encrypted at
+  rest, admin tenant scoping, idempotent bootstrap, catch-all tenant
+  self-provisioning (no hardcoded ids), per-tenant rate-limit plumbing and a
+  request-body cap.
+- Tenant admin API: tenant CRUD, per-tenant traffic-token reveal/reset,
+  scoped operator-key minting; audit API `GET /api/v1/audit` with a dashboard
+  page (#246).
+- Dashboard: admin-key login (#250), one-click SSO for portal handoff
+  (#367, #368, #369), `/playground` chat panel with per-message LLMTrace
+  metadata (#284, #287), dark mode by default, dedicated API-docs page (#281).
+- Security analysis: zone detector + zone-aware ensemble and datamarking
+  transform (IS-060), three-tier judge cascade (DeBERTa fast-judge, vLLM
+  backend, runtime toggle), SafetyJudge placeholder + design spec,
+  rot13/leetspeak encoding-attack detection, advisory headers + LLM-facing
+  system advisory, response envelope with deduplicated findings (#83).
+- E2E adversarial framework: 50-scenario corpus across 8 attack families,
+  PR gate + nightly full-corpus runs with auto-PR'd reports, LLM-backed
+  upstream-fell-for-it judge (#97, #98, #99, #100, #123).
+- Proxy: redundant `/v1` prefix de-duplication in upstream URLs (#374),
+  `X-LLMTrace-Trace-Id` honored and echoed (#91), cost tracking enabled by
+  default with per-span aggregation into storage stats.
+
+### Bug fixes
+- Analysis pipeline: full analysis runs pre-forward so the advisory and
+  envelope share findings; silent analyzer skips are forbidden and dropped
+  traces tagged; log mode still runs analyzers (#298, #300, #311).
+- Dashboard: tenant isolation end-to-end, stale tenant-selection
+  reconciliation, `x-llmtrace-*` response-header forwarding, confidence
+  display flooring.
+- Deployment: ML-preload startup-timeout floor (#243), idempotent tenant
+  bootstrap when the catch-all already exists, `sqlite` accepted as a storage
+  profile alias (#249).
+
+### Operational notes
+- Releases now publish BOTH images version-tagged:
+  `ghcr.io/techlab-innov/llmtrace-proxy` and
+  `ghcr.io/techlab-innov/llmtrace-dashboard` as `:0.3.0` and `:latest`.
+- No proxy schema or config migrations are required. Deployments pinned to
+  older images are unaffected until upgraded.
 
 ## [0.2.0] - 2026-04-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llmtrace"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-benchmarks"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-python"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "llmtrace-core",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-security"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-storage"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrace-wasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["Evangelos Pappas <epappas@evalonlabs.com>"]
@@ -22,9 +22,9 @@ repository = "https://github.com/epappas/llmtrace"
 homepage = "https://llmtrace.io"
 
 [workspace.dependencies]
-llmtrace-core = { path = "crates/llmtrace-core", version = "0.2.0" }
-llmtrace-storage = { path = "crates/llmtrace-storage", version = "0.2.0" }
-llmtrace-security = { path = "crates/llmtrace-security", version = "0.2.0" }
+llmtrace-core = { path = "crates/llmtrace-core", version = "0.3.0" }
+llmtrace-storage = { path = "crates/llmtrace-storage", version = "0.3.0" }
+llmtrace-security = { path = "crates/llmtrace-security", version = "0.3.0" }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What

First release under the process agreed in docs/design/release-strategy.md (#383, decision D1 approved): everything shipped since v0.2.0 (2026-04-17, 228 commits) gets a real version.

- Workspace version 0.2.1 → **0.3.0**; internal workspace dependency reqs bumped to match (the 0.2.0 caret reqs stopped matching at a minor bump — found by `cargo update`).
- **CHANGELOG**: curated 0.3.0 entry in the new template — Security fixes / Bug fixes / Features / Operational notes, with a machine-readable `Upgrade urgency: recommended` line (the portal's future update banner consumes this). Existing Unreleased content folded in; fresh Unreleased stub with the template headers as the going-forward convention.
- **release.yml**: the tag-triggered release now also builds and version-tags `ghcr.io/techlab-innov/llmtrace-dashboard` (`:X.Y.Z` + `:latest`). The fleet runs the proxy+dashboard pair, but only the proxy was version-tagged on release; publish-images covers only main-branch pushes. Cache scope mirrors publish-images' dashboard job.

## Evidence

- `cargo update --workspace` clean (internal crates → 0.3.0, no external changes)
- `cargo fmt --all --check` clean
- `cargo check -p llmtrace` (proxy) clean at 0.3.0

## After merge (separate, gated step)

Push the `v0.3.0` tag → release.yml validates, tests, Trivy-scans, publishes both images, crates, PyPI, binaries, and the GitHub Release. The proposal's `:X.Y` minor alias is deliberately NOT added yet — keeping the existing version+latest scheme until there's a consumer for it.