### PR TITLE
docs: point docs domain at docs.llmtrace.setloop.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 license = "MIT"
 authors = ["Evangelos Pappas <epappas@evalonlabs.com>"]
 repository = "https://github.com/techlab-innov/llmtrace"
-homepage = "https://llmtrace.io"
+homepage = "https://llmtrace.setloop.io"
 
 [workspace.dependencies]
 llmtrace-core = { path = "crates/llmtrace-core", version = "0.3.0" }

--- a/deployments/helm/llmtrace/templates/prometheusrule.yaml
+++ b/deployments/helm/llmtrace/templates/prometheusrule.yaml
@@ -68,7 +68,7 @@ spec:
               the curated golden set has been below the 0.85 floor for
               15 minutes. The fast detection tier is drifting; new
               regex / ML weights or a corpus drift may be the cause.
-            runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/
+            runbook_url: https://docs.llmtrace.setloop.io/runbooks/judge-golden-set-drift/
         - alert: LLMTraceJudgeGoldenSetFprDrift
           expr: llmtrace_judge_golden_set_false_positive_rate > 0.25
           for: 15m
@@ -81,7 +81,7 @@ spec:
               0.25 ceiling for 15 minutes. The detector is over-flagging;
               recent regex tightening or a new ML model is the likely
               culprit.
-            runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/
+            runbook_url: https://docs.llmtrace.setloop.io/runbooks/judge-golden-set-drift/
         - alert: LLMTraceJudgeGoldenSetReplayStale
           expr: |
             time()
@@ -100,5 +100,5 @@ spec:
               the nightly CronJob is failing, the LLMTRACE_GOLDEN_SET_PATH
               env var is unset on the running proxy, or
               server.debug_endpoints is OFF in production.
-            runbook_url: https://docs.llmtrace.io/runbooks/judge-golden-set-drift/
+            runbook_url: https://docs.llmtrace.setloop.io/runbooks/judge-golden-set-drift/
 {{- end }}

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docs.llmtrace.io
+docs.llmtrace.setloop.io

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LLMTrace
-site_url: https://docs.llmtrace.io
+site_url: https://docs.llmtrace.setloop.io
 site_description: Zero-code LLM observability and security for production. Transparent proxy that captures, analyses, and secures LLM interactions in real-time.
 site_author: LLMTrace contributors
 repo_url: https://github.com/epappas/llmtrace


### PR DESCRIPTION
## Summary
- Repoints the docs site at `docs.llmtrace.setloop.io`: `docs/CNAME`, `mkdocs.yml` `site_url`, `Cargo.toml` `homepage`, and the 3 `runbook_url` refs in the Helm `prometheusrule.yaml`.
- Part of the llmtrace.io -> llmtrace.setloop.io migration, cutover runbook step 5 (Portal repo, `docs/design/cutover-runbook.md`).

## Do NOT merge yet
GitHub Pages serves exactly one custom domain. Merging this before the `setloop.io` zone has a `docs` CNAME to GitHub Pages will make Pages re-point away from `docs.llmtrace.io` with nothing yet resolving at `docs.llmtrace.setloop.io` — the docs site goes fully unreachable on both hosts.

Sequence required before merge (owner-gated, needs Cloudflare dashboard access — the scoped API token available to this session got 403 on both the llmtrace.io redirect-ruleset endpoint and all setloop.io zone DNS endpoints):
1. Add `docs` CNAME on the `setloop.io` zone -> GitHub Pages, grey-cloud.
2. Merge this PR (Pages re-points).
3. Apply the `docs.llmtrace.io` -> `docs.llmtrace.setloop.io` 301 (paired with the main `llmtrace.io` -> `llmtrace.setloop.io` redirect, cutover runbook step 3B) so old links keep resolving.

## Test plan
- [ ] `setloop.io` zone: `docs` CNAME -> GitHub Pages exists and resolves
- [ ] Merge, confirm Pages rebuild picks up the new CNAME
- [ ] `docs.llmtrace.setloop.io` serves the docs site
- [ ] `docs.llmtrace.io` 301s to `docs.llmtrace.setloop.io` (not a dead 404)